### PR TITLE
feat(org-index): SQLite headline index (Phase 1+2) + 5-doc architecture plan

### DIFF
--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -887,7 +887,8 @@ caller does not have to scan it."
          (warnings nil)
          (errors nil)
          (result nil))
-    (with-current-buffer log-buf (erase-buffer))
+    (with-current-buffer log-buf
+      (let ((inhibit-read-only t)) (erase-buffer)))
     (condition-case err
         (setq result (byte-compile-file path))
       (error (push (error-message-string err) errors)))

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -47,8 +47,11 @@
   "System Lisp directory for Emacs installation.
 Computed once at package load time from `data-directory'.")
 
-(defconst anvil-elisp--server-id "anvil-elisp"
-  "Server ID for this MCP server.")
+(defconst anvil-elisp--server-id "emacs-eval"
+  "Server ID for this MCP server.
+Matches the id passed to `anvil-server-process-jsonrpc' by the
+stdio shim (--server-id=emacs-eval) so tools are visible to the
+shared MCP connection alongside anvil-file, anvil-org, etc.")
 
 (defgroup anvil-elisp nil
   "MCP server for agentic Elisp development."

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -19,7 +19,7 @@
 ;; Version: 1.2.0
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: tools, development
-;; URL: https://github.com/zawatton21/anvil.el
+;; URL: https://github.com/zawatton/anvil.el
 
 ;;; Commentary:
 
@@ -32,6 +32,8 @@
 (require 'pp)
 (require 'info-look)
 (require 'cl-lib)
+(require 'ert)
+(require 'bytecomp)
 
 
 ;;; System Directory Setup
@@ -770,9 +772,163 @@ MCP Parameters:
            (insert-file-contents true-path)
            (buffer-string)))))))
 
+;;; ERT test runner — compact result for LLM consumption
+
+(defun anvil-elisp--ert-registered-names ()
+  "Return a list of every symbol currently holding an ERT test."
+  (let (acc)
+    (mapatoms
+     (lambda (sym)
+       (when (get sym 'ert--test)
+         (push sym acc))))
+    acc))
+
+(defun anvil-elisp--ert-run (file &optional selector)
+  "Run ERT tests from FILE and return a compact result plist.
+
+MCP Parameters:
+  file     - Path to an .el file that defines ERT tests (string).
+             The file is `load'ed into the current Emacs session so
+             its `ert-deftest' forms register with the global test
+             registry.
+  selector - Optional ERT selector as an Elisp-readable string
+             (e.g. \"t\" for all, \"\\\"my-test-name\\\"\" for one,
+             or \"(tag :integration)\" for tagged).  Defaults to t.
+
+Returns a printed plist:
+  (:passed N :failed M :skipped S :elapsed-sec T :failures F)
+where F is a list of (:name STR :condition STR :backtrace STR).
+Backtraces are truncated to keep the response small.
+
+Runs tests synchronously in the current process, so side effects
+from the test file persist after the call.  Intended for tight
+feedback loops during development — use a batch subprocess when
+isolation matters."
+  (let* ((path (expand-file-name file))
+         (sel  (cond
+                ((null selector) t)
+                ((and (stringp selector) (string-empty-p selector)) t)
+                ((and (stringp selector) (string= selector "t")) t)
+                ((stringp selector)
+                 (condition-case nil (read selector) (error t)))
+                (t t)))
+         (start (float-time))
+         (passed 0) (failed 0) (skipped 0)
+         (failures nil)
+         (before (anvil-elisp--ert-registered-names)))
+    (load path nil t)
+    (let* ((after   (anvil-elisp--ert-registered-names))
+           (added   (cl-remove-if (lambda (n) (memq n before)) after))
+           (tests
+            (cond
+             ((or (eq sel t) (null sel))
+              (mapcar (lambda (n) (get n 'ert--test)) added))
+             ((stringp sel)
+              (mapcar (lambda (n) (get n 'ert--test))
+                      (cl-remove-if-not
+                       (lambda (n) (string-match-p sel (symbol-name n)))
+                       added)))
+             ((symbolp sel)
+              (when (memq sel added) (list (get sel 'ert--test))))
+             (t (mapcar (lambda (n) (get n 'ert--test)) added)))))
+      (dolist (test tests)
+        (let ((result (ert-run-test test)))
+          (cond
+           ((ert-test-passed-p result) (cl-incf passed))
+           ((ert-test-skipped-p result) (cl-incf skipped))
+           (t
+            (cl-incf failed)
+            (let* ((cond-obj (and (ert-test-result-with-condition-p result)
+                                  (ert-test-result-with-condition-condition
+                                   result)))
+                   (cond-str (if cond-obj
+                                 (let ((s (prin1-to-string cond-obj)))
+                                   (if (> (length s) 400)
+                                       (concat (substring s 0 400) " …")
+                                     s))
+                               "unknown failure"))
+                   (bt-obj   (and (ert-test-result-with-condition-p result)
+                                  (ert-test-result-with-condition-backtrace
+                                   result)))
+                   (bt-str   (if bt-obj
+                                 (let ((raw (prin1-to-string bt-obj)))
+                                   (if (> (length raw) 800)
+                                       (concat (substring raw 0 800) " …")
+                                     raw))
+                               "")))
+              (push (list :name      (symbol-name (ert-test-name test))
+                          :condition cond-str
+                          :backtrace bt-str)
+                    failures)))))))
+    (format "%S" (list :passed passed
+                       :failed failed
+                       :skipped skipped
+                       :elapsed-sec (- (float-time) start)
+                       :failures (nreverse failures)))))
+
+;;; Byte-compile — compact result
+
+(defun anvil-elisp--byte-compile-file (file)
+  "Byte-compile FILE and return a compact result plist.
+
+MCP Parameters:
+  file - Path to an .el file to byte-compile (string).
+
+Returns a printed plist:
+  (:ok BOOL :output PATH :warnings (...) :errors (...))
+Warnings and errors are parsed out of the byte-compile log so the
+caller does not have to scan it."
+  (let* ((path (expand-file-name file))
+         (log-buf (get-buffer-create " *anvil-bc-log*"))
+         (byte-compile-log-buffer (buffer-name log-buf))
+         (warnings nil)
+         (errors nil)
+         (result nil))
+    (with-current-buffer log-buf (erase-buffer))
+    (condition-case err
+        (setq result (byte-compile-file path))
+      (error (push (error-message-string err) errors)))
+    (with-current-buffer log-buf
+      (goto-char (point-min))
+      (while (re-search-forward
+              "^\\(?:.*?:\\)?\\(?:[0-9]+:[0-9]+: ?\\)?\\(Warning\\|Error\\): \\(.*\\)$"
+              nil t)
+        (let ((kind (match-string 1))
+              (msg  (match-string 2)))
+          (if (equal kind "Warning")
+              (push msg warnings)
+            (push msg errors)))))
+    (format "%S" (list :ok (and result (null errors))
+                       :output (concat (file-name-sans-extension path) ".elc")
+                       :warnings (nreverse warnings)
+                       :errors (nreverse errors)))))
+
 ;;;###autoload
 (defun anvil-elisp-enable ()
   "Enable the Elisp development MCP tools."
+  (anvil-server-register-tool
+   #'anvil-elisp--ert-run
+   :id "elisp-ert-run"
+   :server-id anvil-elisp--server-id
+   :description
+   "Run ERT tests from a file and return a compact plist instead of
+the chatty output `emacs --batch ... ert-run-tests-batch-and-exit'
+produces.  Returns :passed :failed :skipped :elapsed-sec :failures,
+with each failure carrying a truncated condition and backtrace.
+Intended for tight test/fix loops during development — far cheaper
+in tokens than shelling out and parsing stdout."
+   :read-only t)
+  (anvil-server-register-tool
+   #'anvil-elisp--byte-compile-file
+   :id "elisp-byte-compile-file"
+   :server-id anvil-elisp--server-id
+   :description
+   "Byte-compile a single .el file and return a plist:
+\(:ok BOOL :output PATH :warnings (...) :errors (...)).  Replaces
+shelling out to `emacs --batch -f batch-byte-compile' when you
+just need a clean yes/no plus the list of diagnostics.  Errors
+and warnings are parsed out of the log buffer for you."
+   :read-only nil)
   (anvil-server-register-tool
    #'anvil-elisp--describe-function
    :id "elisp-describe-function"
@@ -969,6 +1125,10 @@ Error cases:
 ;;;###autoload
 (defun anvil-elisp-disable ()
   "Disable the Elisp development MCP tools."
+  (anvil-server-unregister-tool
+   "elisp-ert-run" anvil-elisp--server-id)
+  (anvil-server-unregister-tool
+   "elisp-byte-compile-file" anvil-elisp--server-id)
   (anvil-server-unregister-tool
    "elisp-describe-function" anvil-elisp--server-id)
   (anvil-server-unregister-tool

--- a/anvil-file.el
+++ b/anvil-file.el
@@ -1523,6 +1523,88 @@ MCP Parameters:
                                       :array-type 'list)))
      (format "%S" (anvil-file-batch-across file-ops)))))
 
+;;;; --- outline --------------------------------------------------------------
+
+(defun anvil-file--outline-elisp ()
+  "Scan the current buffer as Elisp; return a list of outline entries."
+  (let ((items nil))
+    (goto-char (point-min))
+    (while (re-search-forward
+            "^(\\(cl-def\\(?:un\\|method\\|generic\\|macro\\|struct\\)\\|def\\(?:un\\|macro\\|var\\|const\\|custom\\|group\\|subst\\|alias\\|face\\|theme\\|advice-add\\)\\)[ \t\n]+\\([^ \t\n()]+\\)"
+            nil t)
+      (push (list :kind (match-string-no-properties 1)
+                  :name (match-string-no-properties 2)
+                  :line (line-number-at-pos (match-beginning 0)))
+            items))
+    (nreverse items)))
+
+(defun anvil-file--outline-org ()
+  "Scan the current buffer as org; return headline outline entries."
+  (let ((items nil))
+    (goto-char (point-min))
+    (while (re-search-forward "^\\(\\*+\\)[ \t]+\\(.*\\)$" nil t)
+      (push (list :kind (format "h%d" (length (match-string-no-properties 1)))
+                  :name (string-trim (match-string-no-properties 2))
+                  :line (line-number-at-pos (match-beginning 0)))
+            items))
+    (nreverse items)))
+
+(defun anvil-file--outline-markdown ()
+  "Scan the current buffer as Markdown; return heading outline entries."
+  (let ((items nil))
+    (goto-char (point-min))
+    (while (re-search-forward "^\\(#+\\)[ \t]+\\(.*\\)$" nil t)
+      (push (list :kind (format "h%d" (length (match-string-no-properties 1)))
+                  :name (string-trim (match-string-no-properties 2))
+                  :line (line-number-at-pos (match-beginning 0)))
+            items))
+    (nreverse items)))
+
+(defun anvil-file--tool-outline (path &optional format)
+  "Return a compact outline of PATH without sending the whole file.
+
+MCP Parameters:
+  path   - Path to the file to scan (string).
+  format - Optional format override: \"elisp\", \"org\", \"markdown\".
+           When omitted the format is inferred from the file extension
+           (.el / .org / .md|.markdown).
+
+Returns a printed plist:
+  (:path P :format F :count N :items ((:kind K :name N :line L) ...))
+
+Kinds:
+  elisp   : defun, defmacro, defvar, defcustom, defconst, defgroup,
+            defsubst, defalias, defface, deftheme, defmethod, defgeneric,
+            defstruct, advice-add
+  org     : h1 .. h6 (star count)
+  md      : h1 .. h6 (hash count)
+
+Ideal for orienting in large files before any Read call — saves
+the full body from the response."
+  (anvil-server-with-error-handling
+   (let* ((abs (expand-file-name path))
+          (fmt (or (and format (not (string-empty-p format))
+                        (downcase format))
+                   (pcase (downcase (or (file-name-extension abs) ""))
+                     ((or "el" "elc") "elisp")
+                     ("org" "org")
+                     ((or "md" "markdown") "markdown")
+                     (_ nil))))
+          (items
+           (with-temp-buffer
+             (let ((coding-system-for-read 'utf-8-unix))
+               (insert-file-contents abs))
+             (pcase fmt
+               ("elisp"    (anvil-file--outline-elisp))
+               ("org"      (anvil-file--outline-org))
+               ("markdown" (anvil-file--outline-markdown))
+               (_ (error "Unknown format for %s (pass format= to override)"
+                         abs))))))
+     (format "%S" (list :path abs
+                        :format fmt
+                        :count (length items)
+                        :items items)))))
+
 ;;;; --- module enable/disable -----------------------------------------------
 
 (defun anvil-file-enable ()
@@ -1632,6 +1714,18 @@ operations array: [{\"path\":\"/a.el\",\"operations\":[...]},...].
 Failures in one file do not abort the rest; per-file results are
 returned.  Use this for bulk docstring updates, import additions, or
 coordinated multi-file refactors."
+   :server-id anvil-file--server-id)
+
+  (anvil-server-register-tool
+   #'anvil-file--tool-outline
+   :id "file-outline"
+   :description
+   "Return a compact structural outline of a file without reading
+its body.  Infers format from extension (.el / .org / .md) or accepts
+a format= override.  Emits (:kind :name :line) entries for Elisp
+def-forms, org headlines, or Markdown headings.  Use this to orient
+in large files before deciding what to Read."
+   :read-only t
    :server-id anvil-file--server-id))
 
 (defun anvil-file-disable ()
@@ -1641,6 +1735,7 @@ coordinated multi-file refactors."
   (anvil-server-unregister-tool "file-insert-at-line" anvil-file--server-id)
   (anvil-server-unregister-tool "file-delete-lines" anvil-file--server-id)
   (anvil-server-unregister-tool "file-read" anvil-file--server-id)
+  (anvil-server-unregister-tool "file-outline" anvil-file--server-id)
   (anvil-server-unregister-tool "file-append" anvil-file--server-id)
   (anvil-server-unregister-tool "file-batch" anvil-file--server-id)
   (anvil-server-unregister-tool "json-object-add" anvil-file--server-id)

--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -443,6 +443,102 @@ single transaction.  Returns a summary plist."
             :headlines total
             :elapsed-sec elapsed))))
 
+;;; Phase 2 — incremental refresh
+
+(defun anvil-org-index--indexed-mtime (db path)
+  "Return mtime recorded in the index for PATH, or nil if not indexed."
+  (caar (anvil-org-index--select
+         db "SELECT mtime FROM file WHERE path = ?" (list path))))
+
+(defun anvil-org-index--current-mtime (path)
+  "Return filesystem mtime of PATH as integer seconds, or nil if missing."
+  (let ((attrs (file-attributes path)))
+    (when attrs
+      (floor (float-time (file-attribute-modification-time attrs))))))
+
+(defun anvil-org-index--refresh-one (path)
+  "Refresh a single PATH against the index.
+Re-ingests if stale, deletes if the file no longer exists, skips
+if mtimes match.  Returns (:path P :outcome SYM :elapsed-sec N)."
+  (let* ((path      (expand-file-name path))
+         (start     (float-time))
+         (disk-mt   (anvil-org-index--current-mtime path))
+         (idx-mt    (anvil-org-index--indexed-mtime anvil-org-index--db path))
+         (outcome   'unchanged))
+    (cond
+     ((not disk-mt)
+      (when idx-mt
+        (anvil-org-index--execute
+         anvil-org-index--db "DELETE FROM file WHERE path = ?" (list path))
+        (setq outcome 'removed)))
+     ((or (null idx-mt) (/= disk-mt idx-mt))
+      (anvil-org-index--with-transaction anvil-org-index--db
+        (anvil-org-index--ingest-file anvil-org-index--db path))
+      (setq outcome (if idx-mt 'reindexed 'added))))
+    (list :path path
+          :outcome outcome
+          :elapsed-sec (- (float-time) start))))
+
+(defun anvil-org-index--refresh-all (&optional paths)
+  "Refresh every file under PATHS (defaults to `anvil-org-index-paths').
+Adds new files, re-ingests stale ones, and deletes rows for files
+that have been removed from disk.  Runs inside a single transaction.
+Returns a summary plist."
+  (let* ((db          anvil-org-index--db)
+         (start       (float-time))
+         (disk-files  (anvil-org-index--collect-files paths))
+         (disk-set    (let ((h (make-hash-table :test 'equal)))
+                        (dolist (f disk-files) (puthash f t h))
+                        h))
+         (idx-rows    (anvil-org-index--select
+                       db "SELECT path, mtime FROM file"))
+         (idx-map     (let ((h (make-hash-table :test 'equal)))
+                        (dolist (row idx-rows)
+                          (puthash (car row) (cadr row) h))
+                        h))
+         (added 0) (reindexed 0) (removed 0) (unchanged 0))
+    (anvil-org-index--with-transaction db
+      (dolist (f disk-files)
+        (let ((disk-mt (anvil-org-index--current-mtime f))
+              (idx-mt  (gethash f idx-map)))
+          (cond
+           ((null idx-mt)
+            (anvil-org-index--ingest-file db f)
+            (cl-incf added))
+           ((/= disk-mt idx-mt)
+            (anvil-org-index--ingest-file db f)
+            (cl-incf reindexed))
+           (t (cl-incf unchanged)))))
+      (dolist (row idx-rows)
+        (let ((p (car row)))
+          (unless (gethash p disk-set)
+            (anvil-org-index--execute
+             db "DELETE FROM file WHERE path = ?" (list p))
+            (cl-incf removed)))))
+    (let ((elapsed (- (float-time) start)))
+      (message "anvil-org-index: refresh +%d ~%d -%d =%d in %.2fs"
+               added reindexed removed unchanged elapsed)
+      (list :scanned (length disk-files)
+            :added added
+            :reindexed reindexed
+            :removed removed
+            :unchanged unchanged
+            :elapsed-sec elapsed))))
+
+;;;###autoload
+(defun anvil-org-index-refresh-if-stale (&optional file)
+  "Refresh FILE (or all configured paths) based on mtime comparison.
+With FILE, re-ingest only if its mtime differs from the index, or
+delete its rows if the file no longer exists on disk.  Without
+FILE, refresh every file under `anvil-org-index-paths'.
+Much cheaper than `anvil-org-index-rebuild' when only a few files
+have changed.  Returns a summary plist."
+  (interactive)
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (if file
+      (anvil-org-index--refresh-one file)
+    (anvil-org-index--refresh-all)))
+
 ;;;###autoload
 (defun anvil-org-index-status ()
   "Show a summary of the current index state."

--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -1,0 +1,468 @@
+;;; anvil-org-index.el --- Persistent SQLite index for org files -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Fujisawa Electric Management Office
+
+;; This file is part of anvil.el.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Persistent SQLite-backed index of headlines, tags, properties and
+;; IDs across configured org directories.  Intended to let MCP read
+;; tools avoid re-parsing large org files on every call.
+;;
+;; See docs/design/02-org-index.org for the full design.  This file
+;; covers Phase 1 only: schema creation, full rebuild, status, and a
+;; pure-regexp scanner.  Filesystem watcher, incremental refresh and
+;; MCP tool integration come in later phases.
+;;
+;; Backend selection at load time:
+;;   1. Emacs 29+ with `sqlite-available-p' -> built-in sqlite
+;;   2. `emacsql' installed                  -> emacsql (TODO, Phase 1+)
+;;   3. otherwise                             -> `user-error'
+;;
+;; Only the built-in backend is fully implemented in Phase 1.  The
+;; emacsql path is sketched but signals a clear error until completed.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+
+;;; Customization
+
+(defgroup anvil-org-index nil
+  "Anvil persistent org index."
+  :group 'anvil
+  :prefix "anvil-org-index-")
+
+(defcustom anvil-org-index-db-path
+  (expand-file-name "anvil-org-index.db" user-emacs-directory)
+  "Path to the SQLite database file."
+  :type 'file
+  :group 'anvil-org-index)
+
+(defcustom anvil-org-index-paths nil
+  "List of directories to recursively index.
+Each entry is a directory path.  Non-existent entries are skipped
+with a warning."
+  :type '(repeat directory)
+  :group 'anvil-org-index)
+
+(defcustom anvil-org-index-exclude-patterns
+  '("/\\.git/" "/archive/" "/\\.cache/")
+  "Regex patterns for paths to exclude from indexing."
+  :type '(repeat regexp)
+  :group 'anvil-org-index)
+
+(defcustom anvil-org-index-todo-keywords
+  '("TODO" "NEXT" "WAIT" "PROJECT" "SOMEDAY"
+    "DONE" "CANCEL" "CANCELED" "CANCELLED"
+    "NOTE" "MEMO")
+  "TODO keywords recognized by the regex scanner.
+Any leading uppercase word on a headline that matches this list
+is treated as the TODO state."
+  :type '(repeat string)
+  :group 'anvil-org-index)
+
+(defconst anvil-org-index-schema-version 1
+  "Current schema version.  Bump on incompatible changes.")
+
+;;; Backend
+
+(defvar anvil-org-index--backend nil
+  "Active backend symbol: `builtin' or `emacsql'.
+Populated lazily by `anvil-org-index--detect-backend'.")
+
+(defvar anvil-org-index--db nil
+  "Open database handle, or nil.")
+
+(defun anvil-org-index--detect-backend ()
+  "Return the best available backend symbol, or signal `user-error'."
+  (cond
+   ((and (fboundp 'sqlite-available-p) (sqlite-available-p))
+    'builtin)
+   ((require 'emacsql nil t)
+    'emacsql)
+   (t
+    (user-error
+     "anvil-org-index: neither built-in sqlite (Emacs 29+) nor emacsql is available"))))
+
+(defun anvil-org-index--open (path)
+  "Open database at PATH using the active backend."
+  (pcase anvil-org-index--backend
+    ('builtin (sqlite-open path))
+    ('emacsql
+     (user-error "anvil-org-index: emacsql backend not yet implemented"))))
+
+(defun anvil-org-index--close (db)
+  "Close DB."
+  (pcase anvil-org-index--backend
+    ('builtin (when (sqlitep db) (sqlite-close db)))
+    ('emacsql nil)))
+
+(defun anvil-org-index--execute (db sql &optional params)
+  "Run SQL (DDL or INSERT/UPDATE/DELETE) against DB with PARAMS."
+  (pcase anvil-org-index--backend
+    ('builtin (sqlite-execute db sql params))
+    ('emacsql (user-error "anvil-org-index: emacsql backend not yet implemented"))))
+
+(defun anvil-org-index--select (db sql &optional params)
+  "Run SELECT SQL against DB with PARAMS.  Returns list of rows."
+  (pcase anvil-org-index--backend
+    ('builtin (sqlite-select db sql params))
+    ('emacsql (user-error "anvil-org-index: emacsql backend not yet implemented"))))
+
+(defmacro anvil-org-index--with-transaction (db &rest body)
+  "Run BODY inside a transaction on DB.
+Uses raw BEGIN/COMMIT/ROLLBACK for portability across backends
+and Emacs versions (avoids `with-sqlite-transaction' which is not
+present on all targets)."
+  (declare (indent 1) (debug t))
+  (let ((db-sym (make-symbol "db")))
+    `(let ((,db-sym ,db))
+       (anvil-org-index--execute ,db-sym "BEGIN")
+       (condition-case err
+           (prog1 (progn ,@body)
+             (anvil-org-index--execute ,db-sym "COMMIT"))
+         (error
+          (ignore-errors (anvil-org-index--execute ,db-sym "ROLLBACK"))
+          (signal (car err) (cdr err)))))))
+
+;;; Schema
+
+(defconst anvil-org-index--ddl
+  '("CREATE TABLE IF NOT EXISTS schema_meta (
+       version INTEGER PRIMARY KEY)"
+
+    "CREATE TABLE IF NOT EXISTS file (
+       id          INTEGER PRIMARY KEY,
+       path        TEXT UNIQUE NOT NULL,
+       mtime       INTEGER NOT NULL,
+       size        INTEGER NOT NULL,
+       indexed_at  INTEGER NOT NULL,
+       schema_ver  INTEGER NOT NULL DEFAULT 1)"
+
+    "CREATE TABLE IF NOT EXISTS headline (
+       id          INTEGER PRIMARY KEY,
+       file_id     INTEGER NOT NULL REFERENCES file(id) ON DELETE CASCADE,
+       parent_id   INTEGER,
+       level       INTEGER NOT NULL,
+       title       TEXT NOT NULL,
+       todo        TEXT,
+       priority    TEXT,
+       scheduled   TEXT,
+       deadline    TEXT,
+       closed      TEXT,
+       org_id      TEXT,
+       position    INTEGER NOT NULL,
+       line_start  INTEGER NOT NULL,
+       line_end    INTEGER)"
+
+    "CREATE INDEX IF NOT EXISTS idx_headline_file ON headline(file_id)"
+    "CREATE INDEX IF NOT EXISTS idx_headline_todo ON headline(todo)"
+    "CREATE INDEX IF NOT EXISTS idx_headline_id ON headline(org_id) WHERE org_id IS NOT NULL"
+    "CREATE INDEX IF NOT EXISTS idx_headline_sched ON headline(scheduled) WHERE scheduled IS NOT NULL"
+
+    "CREATE TABLE IF NOT EXISTS tag (
+       headline_id INTEGER NOT NULL REFERENCES headline(id) ON DELETE CASCADE,
+       tag         TEXT NOT NULL,
+       PRIMARY KEY (headline_id, tag))"
+
+    "CREATE INDEX IF NOT EXISTS idx_tag_tag ON tag(tag)"
+
+    "CREATE TABLE IF NOT EXISTS property (
+       headline_id INTEGER NOT NULL REFERENCES headline(id) ON DELETE CASCADE,
+       key         TEXT NOT NULL,
+       value       TEXT NOT NULL,
+       PRIMARY KEY (headline_id, key))"
+
+    "CREATE INDEX IF NOT EXISTS idx_property_key ON property(key)")
+  "List of DDL statements applied on DB open.")
+
+(defun anvil-org-index--apply-ddl (db)
+  "Apply DDL + pragmas + schema version record to DB."
+  (anvil-org-index--execute db "PRAGMA journal_mode = WAL")
+  (anvil-org-index--execute db "PRAGMA foreign_keys = ON")
+  (dolist (stmt anvil-org-index--ddl)
+    (anvil-org-index--execute db stmt))
+  (anvil-org-index--execute
+   db "INSERT OR IGNORE INTO schema_meta(version) VALUES (?)"
+   (list anvil-org-index-schema-version)))
+
+;;; File discovery
+
+(defun anvil-org-index--excluded-p (path)
+  "Return non-nil if PATH matches any `anvil-org-index-exclude-patterns'."
+  (cl-some (lambda (re) (string-match-p re path))
+           anvil-org-index-exclude-patterns))
+
+(defun anvil-org-index--collect-files (&optional paths)
+  "Return absolute paths of all *.org files under PATHS.
+PATHS defaults to `anvil-org-index-paths'."
+  (let ((roots (or paths anvil-org-index-paths))
+        (acc nil))
+    (dolist (root roots)
+      (let ((abs (expand-file-name root)))
+        (if (not (file-directory-p abs))
+            (message "anvil-org-index: skipping missing path %s" abs)
+          (dolist (f (directory-files-recursively abs "\\.org\\'" nil))
+            (unless (anvil-org-index--excluded-p f)
+              (push (expand-file-name f) acc))))))
+    (nreverse acc)))
+
+;;; Scanner — pure regexp, does not load org-mode
+
+(defun anvil-org-index--parse-headline-title (raw level)
+  "Parse RAW headline text (without leading stars) at LEVEL into a plist.
+Extracts TODO keyword, priority cookie [#A], trailing tags :t1:t2:,
+and the clean title."
+  (let ((s raw) todo prio tags)
+    (when (string-match "\\`\\([A-Z]+\\(?:-[A-Z]+\\)?\\)[ \t]+\\(.*\\)\\'" s)
+      (let ((kw (match-string 1 s)))
+        (when (member kw anvil-org-index-todo-keywords)
+          (setq todo kw
+                s (match-string 2 s)))))
+    (when (string-match "\\`\\[#\\([A-Z]\\)\\][ \t]+\\(.*\\)\\'" s)
+      (setq prio (match-string 1 s)
+            s (match-string 2 s)))
+    (when (string-match "[ \t]+\\(:[A-Za-z0-9_@#%:]+:\\)[ \t]*\\'" s)
+      ;; Capture match data before calling `split-string' which resets it.
+      (let ((beg    (match-beginning 0))
+            (tagstr (match-string 1 s)))
+        (setq tags (split-string tagstr ":" t))
+        (setq s    (substring s 0 beg))))
+    (list :level level
+          :todo todo
+          :priority prio
+          :tags tags
+          :title (string-trim s))))
+
+(defun anvil-org-index--scan-buffer ()
+  "Scan the current buffer as org text.
+Return a list of headline plists in document order.  The buffer
+is expected to contain org syntax as plain text; org-mode is NOT
+loaded."
+  (save-excursion
+    (goto-char (point-min))
+    (let ((results nil)
+          (current nil)
+          (in-properties nil)
+          (line 1))
+      (while (not (eobp))
+        (let* ((bol (line-beginning-position))
+               (eol (line-end-position))
+               (text (buffer-substring-no-properties bol eol)))
+          (cond
+           ;; headline
+           ((string-match "\\`\\(\\*+\\)[ \t]+\\(.*\\)\\'" text)
+            (when current
+              (setq current (plist-put current :line-end (1- line)))
+              (push current results))
+            (let* ((level (length (match-string 1 text)))
+                   (rest  (match-string 2 text))
+                   (parsed (anvil-org-index--parse-headline-title rest level)))
+              (setq current (append parsed
+                                    (list :position bol
+                                          :line-start line
+                                          :scheduled nil
+                                          :deadline nil
+                                          :closed nil
+                                          :org-id nil
+                                          :properties nil))
+                    in-properties nil)))
+           ;; :PROPERTIES: start
+           ((and current (string-match-p "\\`[ \t]*:PROPERTIES:[ \t]*\\'" text))
+            (setq in-properties t))
+           ;; :END:
+           ((and current in-properties
+                 (string-match-p "\\`[ \t]*:END:[ \t]*\\'" text))
+            (setq in-properties nil))
+           ;; property line
+           ((and current in-properties
+                 (string-match "\\`[ \t]*:\\([^:\n\t ]+\\):[ \t]+\\(.*\\)\\'" text))
+            (let ((key (match-string 1 text))
+                  (val (string-trim (match-string 2 text))))
+              (setq current
+                    (plist-put current :properties
+                               (cons (cons key val)
+                                     (plist-get current :properties))))
+              (when (string-equal (upcase key) "ID")
+                (setq current (plist-put current :org-id val)))))
+           ;; SCHEDULED / DEADLINE / CLOSED on planning line.
+           ;; A single planning line may carry multiple keywords, so
+           ;; scan all matches (not just the first).
+           ((and current
+                 (string-match-p
+                  "\\b\\(?:SCHEDULED\\|DEADLINE\\|CLOSED\\):"
+                  text))
+            (let ((start 0))
+              (while (string-match
+                      "\\b\\(SCHEDULED\\|DEADLINE\\|CLOSED\\):[ \t]*\\(<[^>\n]+>\\|\\[[^]\n]+\\]\\)"
+                      text start)
+                (let ((which (upcase (match-string 1 text)))
+                      (ts    (match-string 2 text))
+                      (end   (match-end 0)))
+                  (setq current
+                        (plist-put current
+                                   (pcase which
+                                     ("SCHEDULED" :scheduled)
+                                     ("DEADLINE"  :deadline)
+                                     ("CLOSED"    :closed))
+                                   ts))
+                  (setq start end))))))
+          (goto-char (1+ eol))
+          (cl-incf line)))
+      (when current
+        (setq current (plist-put current :line-end (1- line)))
+        (push current results))
+      (nreverse results))))
+
+(defun anvil-org-index--scan-file (path)
+  "Return list of headline plists for PATH."
+  (with-temp-buffer
+    (let ((coding-system-for-read 'utf-8-unix))
+      (insert-file-contents path))
+    (anvil-org-index--scan-buffer)))
+
+;;; Insertion helpers
+
+(defun anvil-org-index--insert-file-row (db path)
+  "Delete existing FILE row for PATH if any, then insert fresh.
+Return the new file id."
+  (let* ((attrs (file-attributes path))
+         (mtime (when attrs (floor (float-time (file-attribute-modification-time attrs)))))
+         (size  (when attrs (file-attribute-size attrs)))
+         (now   (floor (float-time))))
+    (anvil-org-index--execute db "DELETE FROM file WHERE path = ?" (list path))
+    (anvil-org-index--execute
+     db
+     "INSERT INTO file (path, mtime, size, indexed_at, schema_ver) VALUES (?, ?, ?, ?, ?)"
+     (list path mtime size now anvil-org-index-schema-version))
+    (caar (anvil-org-index--select db "SELECT last_insert_rowid()"))))
+
+(defun anvil-org-index--insert-headline (db file-id parent-id hl)
+  "Insert one headline HL under FILE-ID with optional PARENT-ID.
+Return the new headline id."
+  (anvil-org-index--execute
+   db
+   "INSERT INTO headline
+      (file_id, parent_id, level, title, todo, priority,
+       scheduled, deadline, closed, org_id, position, line_start, line_end)
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)"
+   (list file-id
+         parent-id
+         (plist-get hl :level)
+         (plist-get hl :title)
+         (plist-get hl :todo)
+         (plist-get hl :priority)
+         (plist-get hl :scheduled)
+         (plist-get hl :deadline)
+         (plist-get hl :closed)
+         (plist-get hl :org-id)
+         (plist-get hl :position)
+         (plist-get hl :line-start)
+         (plist-get hl :line-end)))
+  (let ((hid (caar (anvil-org-index--select db "SELECT last_insert_rowid()"))))
+    (dolist (tag (plist-get hl :tags))
+      (anvil-org-index--execute
+       db "INSERT OR IGNORE INTO tag (headline_id, tag) VALUES (?, ?)"
+       (list hid tag)))
+    (dolist (kv (plist-get hl :properties))
+      (anvil-org-index--execute
+       db "INSERT OR REPLACE INTO property (headline_id, key, value) VALUES (?, ?, ?)"
+       (list hid (car kv) (cdr kv))))
+    hid))
+
+(defun anvil-org-index--ingest-file (db path)
+  "Re-index a single PATH into DB.  Return list (headline-count)."
+  (let* ((headlines (anvil-org-index--scan-file path))
+         (file-id   (anvil-org-index--insert-file-row db path))
+         ;; stack: (level . id) pairs, deepest on top
+         (stack nil))
+    (dolist (hl headlines)
+      (let ((level (plist-get hl :level)))
+        (while (and stack (>= (caar stack) level))
+          (pop stack))
+        (let* ((parent-id (and stack (cdar stack)))
+               (hid (anvil-org-index--insert-headline db file-id parent-id hl)))
+          (push (cons level hid) stack))))
+    (list :headline-count (length headlines))))
+
+;;; Public API — Phase 1
+
+;;;###autoload
+(defun anvil-org-index-enable ()
+  "Initialize backend, open DB, apply DDL.  Idempotent."
+  (interactive)
+  (unless anvil-org-index--backend
+    (setq anvil-org-index--backend (anvil-org-index--detect-backend)))
+  (unless (and anvil-org-index--db
+               (or (not (eq anvil-org-index--backend 'builtin))
+                   (sqlitep anvil-org-index--db)))
+    (let ((dir (file-name-directory anvil-org-index-db-path)))
+      (unless (file-directory-p dir) (make-directory dir t)))
+    (setq anvil-org-index--db
+          (anvil-org-index--open anvil-org-index-db-path))
+    (anvil-org-index--apply-ddl anvil-org-index--db))
+  (message "anvil-org-index: enabled (backend=%s db=%s)"
+           anvil-org-index--backend
+           anvil-org-index-db-path))
+
+;;;###autoload
+(defun anvil-org-index-disable ()
+  "Close DB.  Safe to call multiple times."
+  (interactive)
+  (when anvil-org-index--db
+    (anvil-org-index--close anvil-org-index--db)
+    (setq anvil-org-index--db nil))
+  (message "anvil-org-index: disabled"))
+
+;;;###autoload
+(defun anvil-org-index-rebuild (&optional paths)
+  "Rebuild the index over PATHS (defaults to `anvil-org-index-paths').
+Existing rows for the touched files are replaced.  Runs inside a
+single transaction.  Returns a summary plist."
+  (interactive)
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (let* ((files (anvil-org-index--collect-files paths))
+         (start (float-time))
+         (total 0))
+    (anvil-org-index--with-transaction anvil-org-index--db
+      (dolist (f files)
+        (let ((info (anvil-org-index--ingest-file anvil-org-index--db f)))
+          (cl-incf total (plist-get info :headline-count)))))
+    (let ((elapsed (- (float-time) start)))
+      (message "anvil-org-index: rebuild %d file(s), %d headline(s) in %.2fs"
+               (length files) total elapsed)
+      (list :files (length files)
+            :headlines total
+            :elapsed-sec elapsed))))
+
+;;;###autoload
+(defun anvil-org-index-status ()
+  "Show a summary of the current index state."
+  (interactive)
+  (if (not anvil-org-index--db)
+      (message "anvil-org-index: not enabled")
+    (let* ((files (caar (anvil-org-index--select
+                         anvil-org-index--db "SELECT COUNT(*) FROM file")))
+           (heads (caar (anvil-org-index--select
+                         anvil-org-index--db "SELECT COUNT(*) FROM headline")))
+           (tags  (caar (anvil-org-index--select
+                         anvil-org-index--db "SELECT COUNT(DISTINCT tag) FROM tag")))
+           (size  (if (file-exists-p anvil-org-index-db-path)
+                      (file-attribute-size
+                       (file-attributes anvil-org-index-db-path))
+                    0)))
+      (message "anvil-org-index: %d file(s), %d headline(s), %d tag(s), db=%s (%.1fKB)"
+               files heads tags
+               anvil-org-index-db-path
+               (/ size 1024.0)))))
+
+(provide 'anvil-org-index)
+;;; anvil-org-index.el ends here

--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -539,6 +539,154 @@ have changed.  Returns a summary plist."
       (anvil-org-index--refresh-one file)
     (anvil-org-index--refresh-all)))
 
+;;; Phase 3 — filesystem watcher
+
+(defcustom anvil-org-index-watch-debounce-seconds 2.0
+  "Delay in seconds before acting on a file-change event.
+Consecutive events for the same path within this window are
+coalesced to a single refresh call."
+  :type 'number
+  :group 'anvil-org-index)
+
+(defcustom anvil-org-index-periodic-scan-seconds 3600
+  "Interval in seconds for the periodic full-index mtime sweep.
+0 disables the periodic scan.  Acts as a safety net in case the
+underlying filesystem-notification backend drops events (w32-notify
+in particular is known to miss events under heavy load)."
+  :type 'integer
+  :group 'anvil-org-index)
+
+(defvar anvil-org-index--watch-descriptors nil
+  "Alist of (DIR . DESCRIPTOR) for active filesystem watches.")
+
+(defvar anvil-org-index--refresh-timer-map
+  (make-hash-table :test 'equal)
+  "Map from file path to its pending debounce timer.")
+
+(defvar anvil-org-index--periodic-timer nil
+  "Timer for the periodic full-index scan, or nil if inactive.")
+
+(defun anvil-org-index--collect-dirs (&optional paths)
+  "Return directories under PATHS that contain at least one .org file.
+PATHS defaults to `anvil-org-index-paths'.  Excluded paths
+honour `anvil-org-index-exclude-patterns'.  Used to seed the
+filesystem watcher — watching every org-bearing directory
+catches file creation, modification, renaming and deletion even
+when the filenotify backend is non-recursive (the common case on
+Linux/inotify)."
+  (let ((roots (or paths anvil-org-index-paths))
+        (dirs nil))
+    (dolist (root roots)
+      (let ((abs (expand-file-name root)))
+        (when (file-directory-p abs)
+          (let ((stack (list abs)))
+            (while stack
+              (let ((dir (pop stack)))
+                (unless (anvil-org-index--excluded-p dir)
+                  (let ((has-org nil))
+                    (dolist (entry (directory-files dir t "\\`[^.]" t))
+                      (cond
+                       ((file-directory-p entry)
+                        (unless (anvil-org-index--excluded-p entry)
+                          (push entry stack)))
+                       ((string-match-p "\\.org\\'" entry)
+                        (setq has-org t))))
+                    (when has-org
+                      (push (file-name-as-directory dir) dirs))))))))))
+    (nreverse dirs)))
+
+(defun anvil-org-index--perform-refresh (path)
+  "Run the debounced refresh for PATH and clear its pending timer.
+Exposed as a separate function so tests can exercise it directly
+without waiting on real `run-with-timer' delays."
+  (remhash path anvil-org-index--refresh-timer-map)
+  (condition-case err
+      (anvil-org-index-refresh-if-stale path)
+    (error
+     (message "anvil-org-index: refresh failed for %s: %S" path err))))
+
+(defun anvil-org-index--schedule-refresh (path)
+  "Schedule a debounced refresh for PATH.
+A second event arriving within
+`anvil-org-index-watch-debounce-seconds' cancels the prior timer
+and restarts the window, so bursty editors (save-with-backup,
+VCS operations) still cost only one refresh."
+  (let ((existing (gethash path anvil-org-index--refresh-timer-map)))
+    (when (timerp existing)
+      (cancel-timer existing)))
+  (puthash path
+           (run-with-timer
+            anvil-org-index-watch-debounce-seconds nil
+            #'anvil-org-index--perform-refresh path)
+           anvil-org-index--refresh-timer-map))
+
+(defun anvil-org-index--on-file-event (event)
+  "Dispatch a filesystem EVENT to the refresh scheduler.
+EVENT format: (DESCRIPTOR ACTION FILE &optional FILE1).  Only
+actions that plausibly affect .org files are acted on; the
+backend-specific `attribute-changed' is included because some
+Windows tools touch mtime without raising a normal change event."
+  (let ((action (nth 1 event))
+        (file   (nth 2 event)))
+    (when (and (stringp file)
+               (memq action '(created changed deleted renamed
+                                      attribute-changed))
+               (string-match-p "\\.org\\'" file))
+      (anvil-org-index--schedule-refresh (expand-file-name file)))))
+
+;;;###autoload
+(defun anvil-org-index-watch (&optional paths)
+  "Start watching PATHS for .org file changes; auto-refresh the index.
+PATHS defaults to `anvil-org-index-paths'.  Idempotent — a
+second call tears down and re-establishes all watches.  Installs
+the periodic safety-net scan when
+`anvil-org-index-periodic-scan-seconds' is positive.  Returns
+the list of directories now under watch."
+  (interactive)
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (require 'filenotify)
+  (anvil-org-index-unwatch)
+  (let ((dirs (anvil-org-index--collect-dirs paths)))
+    (dolist (dir dirs)
+      (condition-case err
+          (let ((desc (file-notify-add-watch
+                       dir '(change attribute-change)
+                       #'anvil-org-index--on-file-event)))
+            (push (cons dir desc) anvil-org-index--watch-descriptors))
+        (error
+         (message "anvil-org-index: cannot watch %s: %S" dir err))))
+    (when (and (> anvil-org-index-periodic-scan-seconds 0)
+               (not (timerp anvil-org-index--periodic-timer)))
+      (setq anvil-org-index--periodic-timer
+            (run-with-timer
+             anvil-org-index-periodic-scan-seconds
+             anvil-org-index-periodic-scan-seconds
+             (lambda ()
+               (condition-case err
+                   (anvil-org-index-refresh-if-stale)
+                 (error
+                  (message "anvil-org-index periodic scan failed: %S"
+                           err)))))))
+    (message "anvil-org-index: watching %d director%s"
+             (length dirs)
+             (if (= 1 (length dirs)) "y" "ies"))
+    dirs))
+
+;;;###autoload
+(defun anvil-org-index-unwatch ()
+  "Tear down all filesystem watches and pending debounce timers."
+  (interactive)
+  (dolist (cell anvil-org-index--watch-descriptors)
+    (ignore-errors (file-notify-rm-watch (cdr cell))))
+  (setq anvil-org-index--watch-descriptors nil)
+  (maphash (lambda (_k timer)
+             (when (timerp timer) (cancel-timer timer)))
+           anvil-org-index--refresh-timer-map)
+  (clrhash anvil-org-index--refresh-timer-map)
+  (when (timerp anvil-org-index--periodic-timer)
+    (cancel-timer anvil-org-index--periodic-timer)
+    (setq anvil-org-index--periodic-timer nil)))
+
 ;;;###autoload
 (defun anvil-org-index-status ()
   "Show a summary of the current index state."

--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -687,6 +687,175 @@ the list of directories now under watch."
     (cancel-timer anvil-org-index--periodic-timer)
     (setq anvil-org-index--periodic-timer nil)))
 
+;;; Phase 4a — fast-path readers backed by the index
+
+(defun anvil-org-index--file-id (db path)
+  "Return the file row id for PATH (expanded), or nil."
+  (caar (anvil-org-index--select
+         db "SELECT id FROM file WHERE path = ?"
+         (list (expand-file-name path)))))
+
+(defun anvil-org-index--decode-title-segment (segment)
+  "Decode SEGMENT produced by splitting a slash-separated headline path.
+`anvil-org' tools require `/' characters that belong to headline
+titles to be encoded as %2F; this undoes that encoding so the
+decoded string matches the raw title stored in the index."
+  (replace-regexp-in-string "%2F" "/" segment t t))
+
+(defun anvil-org-index--read-file-region (path line-start line-end)
+  "Return UTF-8 text from PATH between LINE-START and LINE-END inclusive.
+Lines are 1-indexed.  When LINE-END is nil or non-positive, read
+to end of file."
+  (with-temp-buffer
+    (let ((coding-system-for-read 'utf-8-unix))
+      (insert-file-contents path))
+    (goto-char (point-min))
+    (forward-line (max 0 (1- line-start)))
+    (let ((beg (point)))
+      (cond
+       ((and line-end (> line-end 0))
+        (goto-char (point-min))
+        (forward-line line-end)
+        (buffer-substring-no-properties beg (point)))
+       (t (buffer-substring-no-properties beg (point-max)))))))
+
+(defun anvil-org-index--subtree-range (db headline-id)
+  "Return (path line-start line-end) covering HEADLINE-ID's entire subtree.
+The stored `line_end' on a headline points at the line before the
+very next heading of any level, so it cuts off nested children.
+For `org-read-headline'-style semantics we want the full subtree,
+which ends just before the next heading of equal-or-lower level
+\(i.e. a sibling or uncle), or the end of file.  Computed here via
+the index rather than by re-parsing the file."
+  (let ((row (car (anvil-org-index--select
+                   db
+                   "SELECT f.id, f.path, h.level, h.line_start
+                      FROM headline h JOIN file f ON f.id = h.file_id
+                      WHERE h.id = ?
+                      LIMIT 1"
+                   (list headline-id)))))
+    (when row
+      (let* ((file-id  (nth 0 row))
+             (path     (nth 1 row))
+             (level    (nth 2 row))
+             (start    (nth 3 row))
+             (next-row (car (anvil-org-index--select
+                             db
+                             "SELECT MIN(line_start) FROM headline
+                                WHERE file_id = ? AND line_start > ? AND level <= ?"
+                             (list file-id start level))))
+             (next-start (car next-row))
+             (end (if (and next-start (numberp next-start))
+                      (1- next-start)
+                    0)))
+        (list path start end)))))
+
+(defun anvil-org-index--lookup-id-subtree (db org-id)
+  "Return (path line-start line-end) for ORG-ID's subtree, or nil."
+  (let ((hid (caar (anvil-org-index--select
+                    db
+                    "SELECT id FROM headline WHERE org_id = ? LIMIT 1"
+                    (list org-id)))))
+    (and hid (anvil-org-index--subtree-range db hid))))
+
+(defun anvil-org-index--find-by-path (db file-id segments)
+  "Walk SEGMENTS under FILE-ID, return the matching headline id or nil.
+SEGMENTS is a list of already-decoded title strings.  Ambiguous
+matches (more than one headline at a given level sharing a title
+under the same parent) return nil so the caller can fall back to
+a full parse rather than pick the wrong entry."
+  (let ((parent nil)
+        (current nil)
+        (failed nil))
+    (catch 'done
+      (dolist (segment segments)
+        (let ((rows
+               (if parent
+                   (anvil-org-index--select
+                    db
+                    "SELECT id FROM headline
+                       WHERE file_id = ? AND parent_id = ? AND title = ?"
+                    (list file-id parent segment))
+                 (anvil-org-index--select
+                  db
+                  "SELECT id FROM headline
+                     WHERE file_id = ? AND parent_id IS NULL AND title = ?"
+                  (list file-id segment)))))
+          (cond
+           ((null rows)        (setq failed t) (throw 'done nil))
+           ((cdr rows)         (setq failed t) (throw 'done nil))
+           (t (setq current (caar rows)
+                    parent  current))))))
+    (unless failed current)))
+
+;;;###autoload
+(defun anvil-org-index-read-by-id (org-id)
+  "Return the text of the entire subtree whose :ID: property is ORG-ID.
+Uses the index to locate (file, line-range) in one SELECT, then
+reads only that line range of the file.  Signals `user-error' if
+ORG-ID is not in the index."
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (let ((loc (anvil-org-index--lookup-id-subtree
+              anvil-org-index--db org-id)))
+    (unless loc
+      (user-error "anvil-org-index: ID %s not found in index" org-id))
+    (apply #'anvil-org-index--read-file-region loc)))
+
+;;;###autoload
+(defun anvil-org-index-read-headline (file headline-path)
+  "Return the text of HEADLINE-PATH inside FILE via the index.
+HEADLINE-PATH is a slash-separated list of headline titles, with
+any literal `/' inside a title encoded as %2F (matching the
+`org-read-headline' MCP tool).  Signals `user-error' if the file
+is not indexed or the path is ambiguous."
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (let ((file-id (anvil-org-index--file-id anvil-org-index--db file)))
+    (unless file-id
+      (user-error "anvil-org-index: %s is not indexed" file))
+    (let* ((segments (mapcar #'anvil-org-index--decode-title-segment
+                             (split-string headline-path "/" t)))
+           (hid (anvil-org-index--find-by-path
+                 anvil-org-index--db file-id segments))
+           (range (and hid (anvil-org-index--subtree-range
+                            anvil-org-index--db hid))))
+      (unless range
+        (user-error
+         "anvil-org-index: headline %S not uniquely resolvable under %s"
+         headline-path file))
+      (apply #'anvil-org-index--read-file-region range))))
+
+;;;###autoload
+(defun anvil-org-index-read-outline (file)
+  "Return an outline list of FILE straight from the index.
+Each entry is a plist: (:level :title :todo :tags :line).  Order
+follows the on-disk position of the headlines.  Much cheaper than
+re-parsing with org-element for large files that rarely change."
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (let ((file-id (anvil-org-index--file-id anvil-org-index--db file)))
+    (unless file-id
+      (user-error "anvil-org-index: %s is not indexed" file))
+    (let ((rows
+           (anvil-org-index--select
+            anvil-org-index--db
+            "SELECT id, level, title, todo, line_start
+               FROM headline
+               WHERE file_id = ?
+               ORDER BY position"
+            (list file-id))))
+      (mapcar
+       (lambda (row)
+         (let* ((hid   (nth 0 row))
+                (tags  (anvil-org-index--select
+                        anvil-org-index--db
+                        "SELECT tag FROM tag WHERE headline_id = ?"
+                        (list hid))))
+           (list :level (nth 1 row)
+                 :title (nth 2 row)
+                 :todo  (nth 3 row)
+                 :tags  (mapcar #'car tags)
+                 :line  (nth 4 row))))
+       rows))))
+
 ;;;###autoload
 (defun anvil-org-index-status ()
   "Show a summary of the current index state."

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -6,7 +6,7 @@
 ;; Keywords: convenience, files, matching, outlines
 ;; Version: 0.9.0
 ;; Package-Requires: ((emacs "27.1"))
-;; URL: https://github.com/zawatton21/anvil.el
+;; URL: https://github.com/zawatton/anvil.el
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -40,6 +40,16 @@
 (defcustom anvil-org-allowed-files nil
   "List of absolute paths to Org files that can be accessed via MCP."
   :type '(repeat file)
+  :group 'anvil-org)
+
+(defcustom anvil-org-use-index t
+  "When non-nil, `org-read-*' tools try `anvil-org-index' first.
+A hit returns straight from the SQLite-backed index (ms-scale).
+On a miss — index not loaded, entry absent, path ambiguous, or
+any error inside the fast-path — the handler falls back to the
+existing org-element-based implementation.  Set to nil to
+disable the fast-path entirely (e.g. while comparing behaviour)."
+  :type 'boolean
   :group 'anvil-org)
 
 (defcustom anvil-org-allowed-files-enabled t
@@ -1218,6 +1228,33 @@ MCP Parameters:
   file - Absolute path to an Org file"
   (anvil-org--handle-outline-resource `(("filename" . ,file))))
 
+(declare-function anvil-org-index-read-by-id    "anvil-org-index" (org-id))
+(declare-function anvil-org-index-read-headline  "anvil-org-index" (file path))
+
+(defun anvil-org--index-available-p ()
+  "Return non-nil when the `anvil-org-index' fast-path can be tried.
+Checks the feature-flag, the library itself, and the live DB
+handle so callers do not need to repeat those guards."
+  (and anvil-org-use-index
+       (featurep 'anvil-org-index)
+       (boundp 'anvil-org-index--db)
+       anvil-org-index--db))
+
+(defun anvil-org--try-index-read-by-id (uuid)
+  "Try `anvil-org-index-read-by-id' for UUID; return the body or nil.
+A nil return means fall back to the org-element handler."
+  (when (anvil-org--index-available-p)
+    (condition-case _err
+        (anvil-org-index-read-by-id uuid)
+      (error nil))))
+
+(defun anvil-org--try-index-read-headline (file headline-path)
+  "Try `anvil-org-index-read-headline'; return the body or nil."
+  (when (anvil-org--index-available-p)
+    (condition-case _err
+        (anvil-org-index-read-headline file headline-path)
+      (error nil))))
+
 (defun anvil-org--tool-read-headline (file headline_path)
   "Tool wrapper for org-headline://{filename}#{path} resource.
 FILE is the absolute path to an Org file.
@@ -1243,8 +1280,9 @@ MCP Parameters:
     (anvil-org--tool-validation-error
      "Parameter headline_path must be non-empty; use \
 org-read-file tool to read entire files"))
-  (let ((full-path (concat file "#" headline_path)))
-    (anvil-org--handle-headline-resource `(("filename" . ,full-path)))))
+  (or (anvil-org--try-index-read-headline file headline_path)
+      (let ((full-path (concat file "#" headline_path)))
+        (anvil-org--handle-headline-resource `(("filename" . ,full-path))))))
 
 (defun anvil-org--tool-read-by-id (uuid)
   "Tool wrapper for org-id://{uuid} resource template.
@@ -1252,7 +1290,8 @@ UUID is the UUID from headline's ID property.
 
 MCP Parameters:
   uuid - UUID from headline's ID property"
-  (anvil-org--handle-id-resource `(("uuid" . ,uuid))))
+  (or (anvil-org--try-index-read-by-id uuid)
+      (anvil-org--handle-id-resource `(("uuid" . ,uuid)))))
 
 (defun anvil-org-enable ()
   "Enable the anvil-org module."

--- a/anvil-sqlite.el
+++ b/anvil-sqlite.el
@@ -35,8 +35,11 @@
   :group 'anvil
   :prefix "anvil-sqlite-")
 
-(defconst anvil-sqlite--server-id "anvil-sqlite"
-  "Server ID for this module's MCP tools.")
+(defconst anvil-sqlite--server-id "emacs-eval"
+  "Server ID for this module's MCP tools.
+Matches the id passed to `anvil-server-process-jsonrpc' by the
+stdio shim (--server-id=emacs-eval) so the tool is visible to the
+shared MCP connection alongside anvil-file, anvil-org, etc.")
 
 (defcustom anvil-sqlite-max-rows 1000
   "Maximum number of rows returned by `anvil-sqlite-query'.

--- a/anvil-sqlite.el
+++ b/anvil-sqlite.el
@@ -1,0 +1,140 @@
+;;; anvil-sqlite.el --- SQLite query MCP tool for anvil -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Fujisawa Electric Management Office
+
+;; This file is part of anvil.el.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Exposes generic SQLite read-only queries as an MCP tool so LLM
+;; agents can inspect arbitrary SQLite databases (e.g. the anvil
+;; org-index, project build artefacts, app state) in a single round
+;; trip instead of shelling out to `emacs --batch' with an inline
+;; eval form.
+;;
+;; Requires Emacs 29+ built-in sqlite.  On older Emacs the module
+;; loads but the tool signals a clear `user-error' at call time.
+;;
+;; Intentionally read-only: only SELECT / PRAGMA / EXPLAIN are
+;; accepted.  Write operations should go through module-specific
+;; APIs that understand their schemas.
+
+;;; Code:
+
+(require 'anvil-server)
+(require 'cl-lib)
+(require 'json)
+
+(defgroup anvil-sqlite nil
+  "Anvil SQLite query tool."
+  :group 'anvil
+  :prefix "anvil-sqlite-")
+
+(defconst anvil-sqlite--server-id "anvil-sqlite"
+  "Server ID for this module's MCP tools.")
+
+(defcustom anvil-sqlite-max-rows 1000
+  "Maximum number of rows returned by `anvil-sqlite-query'.
+Queries returning more rows are truncated with a warning in the
+response plist.  Prevents accidental blowups of the response."
+  :type 'integer
+  :group 'anvil-sqlite)
+
+;;; Guardrails
+
+(defun anvil-sqlite--readonly-statement-p (sql)
+  "Return non-nil if SQL begins with a read-only statement keyword."
+  (let ((trimmed (string-trim (or sql ""))))
+    (and (not (string-empty-p trimmed))
+         (string-match-p
+          "\\`\\(?:SELECT\\|WITH\\|PRAGMA\\|EXPLAIN\\)\\b"
+          (upcase trimmed)))))
+
+(defun anvil-sqlite--require-backend ()
+  "Signal `user-error' unless built-in sqlite is usable."
+  (unless (and (fboundp 'sqlite-available-p) (sqlite-available-p))
+    (user-error
+     "anvil-sqlite: built-in sqlite not available (Emacs 29+ required)")))
+
+;;; Tool implementation
+
+(defun anvil-sqlite--tool-query (db-path sql &optional params-json)
+  "Run a read-only SQL statement against the SQLite DB at DB-PATH.
+
+MCP Parameters:
+  db-path     - Absolute path to the SQLite database file (string).
+  sql         - SQL statement (string).  Only SELECT, WITH, PRAGMA
+                and EXPLAIN are accepted; other statements error.
+  params-json - Optional JSON array of bind parameters for the
+                statement, e.g. \"[\\\"foo\\\",42]\".  Leave empty
+                for no parameters.
+
+Returns a printed plist:
+  (:row-count N :truncated BOOL :rows ROWS)
+ROWS is a list of row lists.  Large result sets are clipped to
+`anvil-sqlite-max-rows' and :truncated becomes t when that
+happens.  Errors out of the SQLite layer are bubbled up via
+`anvil-server-with-error-handling'."
+  (anvil-server-with-error-handling
+   (anvil-sqlite--require-backend)
+   (unless (anvil-sqlite--readonly-statement-p sql)
+     (user-error
+      "anvil-sqlite: refusing statement; only SELECT/WITH/PRAGMA/EXPLAIN are allowed"))
+   (let* ((path   (expand-file-name db-path))
+          (_exist (unless (file-exists-p path)
+                    (user-error "anvil-sqlite: %s does not exist" path)))
+          (params (cond
+                   ((null params-json) nil)
+                   ((and (stringp params-json)
+                         (string-empty-p (string-trim params-json))) nil)
+                   (t (json-parse-string params-json
+                                         :array-type 'list))))
+          (db     (sqlite-open path))
+          (cap    (1+ anvil-sqlite-max-rows))
+          truncated rows)
+     (unwind-protect
+         (let* ((stmt (sqlite-select db sql params 'set))
+                (count 0))
+           (while (and stmt (sqlite-more-p stmt) (< count cap))
+             (let ((row (sqlite-next stmt)))
+               (when row
+                 (push row rows)
+                 (cl-incf count))))
+           (when stmt (sqlite-finalize stmt))
+           (when (> (length rows) anvil-sqlite-max-rows)
+             (setq truncated t)
+             (setq rows (cl-subseq rows 0 anvil-sqlite-max-rows))))
+       (ignore-errors (sqlite-close db)))
+     (let ((ordered (nreverse rows)))
+       (format "%S" (list :row-count (length ordered)
+                          :truncated (and truncated t)
+                          :rows ordered))))))
+
+;;; Module lifecycle
+
+;;;###autoload
+(defun anvil-sqlite-enable ()
+  "Register the SQLite query MCP tool."
+  (anvil-server-register-tool
+   #'anvil-sqlite--tool-query
+   :id "sqlite-query"
+   :server-id anvil-sqlite--server-id
+   :description
+   "Run a read-only SQL statement against a SQLite database file
+and return the rows as a plist.  Much cheaper than shelling out to
+`emacs --batch' with an inline `sqlite-select' form.  Only SELECT /
+WITH / PRAGMA / EXPLAIN are accepted.  Requires Emacs 29+ built-in
+sqlite.  Large result sets are clipped to `anvil-sqlite-max-rows'."
+   :read-only t))
+
+(defun anvil-sqlite-disable ()
+  "Unregister the SQLite query MCP tool."
+  (anvil-server-unregister-tool "sqlite-query" anvil-sqlite--server-id))
+
+(provide 'anvil-sqlite)
+;;; anvil-sqlite.el ends here

--- a/anvil.el
+++ b/anvil.el
@@ -71,10 +71,12 @@ so AI tool calls never freeze the human's editor."
 (defcustom anvil-optional-modules nil
   "Optional anvil modules requiring external dependencies.
 These are not loaded by default.  Available modules:
-- `xlsx' — Excel read/write (requires Python + openpyxl)
-- `pdf'  — PDF extraction (requires Python + pymupdf)
-- `ide'  — IDE tools: xref, diagnostics (requires project.el)
-- `cron' — Scheduled task runner with worker dispatch"
+- `xlsx'   — Excel read/write (requires Python + openpyxl)
+- `pdf'    — PDF extraction (requires Python + pymupdf)
+- `ide'    — IDE tools: xref, diagnostics (requires project.el)
+- `cron'   — Scheduled task runner with worker dispatch
+- `sqlite' — Read-only SQLite query tool (requires Emacs 29+)
+- `elisp'  — Elisp development tools: ERT runner, byte-compile, describe"
   :type '(repeat symbol)
   :group 'anvil)
 

--- a/docs/design/01-worker-pool-v2.org
+++ b/docs/design/01-worker-pool-v2.org
@@ -1,0 +1,231 @@
+#+title: Worker Pool v2 — Read/Write Routing, File Affinity, Batch Sub-Pool
+#+date: 2026-04-15
+#+property: status DRAFT
+
+* STATUS
+~DRAFT~ — レビュー前
+
+* Goal
+
+現行 ~anvil-worker.el~ の round-robin + heavy-op detection を拡張し、以下を達成する:
+
+1. *Read/Write 分離* — 読み取り tool call は read replica に流し、書き込みは主系に集約して整合性を保つ。
+2. *File affinity* — 同一ファイルへの書き込みは同一 worker に routing し、buffer cache を再利用。
+3. *Pre-warmed batch pool* — 短時間で完結する "fire-and-forget" 系 call は ~emacs --batch~ プール (~30MB × N) に
+   分離し、long-lived daemon を占有させない。
+4. *Connection reuse* — ~emacsclient~ spawn cost (~50〜100ms on Windows) を削減。
+5. *可観測性* — dispatch の routing 判断、待ち時間、busy 時間を metric として取得可能にする。
+
+* Problem
+
+** 現状の制約
+
+~anvil-worker.el~ は既に以下を提供:
+- N worker daemon (default 2)
+- round-robin + busy tracking
+- heavy-op regex detection (byte-compile, insert-file-contents 等)
+- auto-respawn via health timer
+- stale server-file 検出 (PID attr check)
+
+しかし以下は未対応:
+
+- *全 call が均等に扱われる*。read-heavy/write-heavy の区別なし。
+- *File affinity なし*。同じ org ファイルを 2 worker が同時に開くと buffer が衝突する可能性。
+- *cold start 未償却*。重い tool call 毎に ~emacs --batch~ を起動する pattern があり、Windows で 500ms〜1s 浪費。
+- *routing decision が black box*。なぜ worker-1 に行ったかが log を見ても分からない。
+
+** 想定シナリオ
+
+- Claude Code が並列で 5 tool call 投げる (3 read + 2 write)
+  → 現状: 2 worker を round-robin で消費、3 つ目以降は待機。read も write も同じ lane。
+  → v2: read 3 つは read replica にぶつけ、write 2 つは write lane で file affinity 判定。実質 2〜3 倍のスループット。
+
+* Current State
+
+- File: ~anvil-worker.el~ (497 行)
+- Exports: ~anvil-worker-enable~, ~anvil-worker-call~, ~anvil-worker-spawn~, ~anvil-worker-kill~, ~anvil-worker-status~
+- Health timer: ~anvil-worker--health-check~ (30s interval)
+
+* Proposed Design
+
+** Lane 構造
+
+ワーカーを 3 つの lane に分ける:
+
+#+begin_src text
+┌─ read lane (N=2, default)  ─ read-only tool call 向け
+│   ├── worker-read-1
+│   └── worker-read-2
+│
+├─ write lane (N=1, default) ─ write tool call 向け (file affinity)
+│   └── worker-write-1
+│
+└─ batch pool (N=2, default) ─ emacs --batch の pre-warmed プール
+    ├── batch-1 (idle, ready for fire-and-forget eval)
+    └── batch-2
+#+end_src
+
+- *read lane*: read replica daemon。~(setq buffer-read-only t)~ の制限はなく "書き込み禁止の convention" のみ。
+  tool call 内で ~save-buffer~ 等を実行した場合は assert で fail させる。
+- *write lane*: 書き込みを処理。N=1 から開始 (serialize で安全)。将来、file path で shard して N>1 に拡張可能。
+- *batch pool*: ~emacs --fg-daemon=anvil-batch-N -Q~ で pre-warm 済。~emacsclient~ 経由で eval 投入。
+  現行 worker pool と同じ仕組みだが、用途を「短時間 task」に限定し、初期化コストを事前償却する。
+
+** Routing policy
+
+新 API:
+
+#+begin_src elisp
+(anvil-worker-call EXPRESSION
+                   &key
+                   (kind 'auto)    ; 'read | 'write | 'batch | 'auto
+                   (file nil)       ; write 時の affinity key
+                   (timeout nil)    ; nil → kind / heavy 検出から決定
+                   (priority 0))    ; 高いほど優先 (将来拡張)
+#+end_src
+
+- ~kind=auto~ の時は expression を解析して推定:
+  - ~(org-read-*)~, ~(file-read)~, ~(anvil-file-read ...)~ → read
+  - ~(anvil-file-replace-* ...)~, ~(org-edit-body ...)~, ~save-buffer~ → write
+  - 重い既知 pattern (tangle, byte-compile) かつ副作用軽微 → batch
+  - 判別不能 → write (安全側倒し)
+
+- 推定根拠は lifecycle log に ~routed~ event として記録。
+
+** File affinity (write lane)
+
+write lane が N>1 になった時の shard 関数:
+
+#+begin_src elisp
+(defun anvil-worker--write-shard (file)
+  (mod (sxhash file) anvil-worker-write-pool-size))
+#+end_src
+
+- 同一 FILE は常に同じ worker に行くので、buffer cache が温まる。
+- FILE が nil (infer 不能) の write は worker-write-1 に固定。
+
+** Connection reuse
+
+現状、tool call ごとに ~emacsclient~ を新規起動しているが、Windows では起動オーバーヘッドが大きい。
+
+案 A: *emacsclient persistent channel*
+- 各 worker に対して長期保持する ~emacsclient~ プロセスを 1 本持ち、stdin に S-expression を送って stdout で受ける。
+- 実装難度: 中。Emacs server の protocol に乗って生で書くか、~emacsclient --eval --tty~ のセッションモードを使う。
+
+案 B: *worker 側の persistent connection listener*
+- worker daemon が ~anvil-server~ を load しているので、MCP tool "eval-on-worker" を main daemon 経由で投げるのではなく、
+  直接 worker の ~anvil-stdio.sh~ を叩く (stdio または TCP)。
+- 案 A より健全。main daemon の負荷も減る。
+
+*採択*: 案 B。main daemon を routing table だけ持つ薄い dispatcher にする。
+
+** Dispatch metrics
+
+新変数 ~anvil-worker--metrics~ (alist):
+
+| key                     | 意味                              |
+|-------------------------+-----------------------------------|
+| ~:dispatch-count~       | 通算 dispatch 数 (全 lane)        |
+| ~:dispatch-by-lane~     | lane 別 dispatch count            |
+| ~:wait-ms-sum~          | 待機時間合計 (ms)                 |
+| ~:busy-ms-sum~          | 実行時間合計 (ms)                 |
+| ~:heavy-detect-count~   | heavy pattern match 回数          |
+| ~:respawn-count~        | 通算 respawn 回数                 |
+| ~:kind-inference-table~ | (auto-kind . 実 lane) ヒストグラム |
+
+~M-x anvil-worker-metrics~ で表示、~M-x anvil-worker-metrics-reset~ で初期化。
+
+* API
+
+** User-facing
+
+#+begin_src elisp
+(anvil-worker-enable &key
+                     (read-pool-size 2)
+                     (write-pool-size 1)
+                     (batch-pool-size 2)
+                     (reuse-connections t))
+  ;; 全 lane を起動、health timer スタート
+
+(anvil-worker-call EXPRESSION
+                   &key
+                   (kind 'auto)
+                   (file nil)
+                   (timeout nil))
+
+(anvil-worker-status)      ; 現状の 3 lane ダンプ
+(anvil-worker-metrics)     ; metrics 表示
+#+end_src
+
+** Internal
+
+- ~anvil-worker--classify~ (expr) → ~'read~ | ~'write~ | ~'batch~
+- ~anvil-worker--pick-lane~ (kind) → lane symbol
+- ~anvil-worker--pick-worker-in-lane~ (lane, file) → worker name
+- ~anvil-worker--send~ (worker, expr) → result (connection reuse 対応)
+
+* Implementation Plan
+
+1. *Phase 1 — Lane split のみ* (~1 週間)
+   - ~anvil-worker--pool~ を lane 別構造に移行
+   - ~anvil-worker-call~ に ~:kind~ keyword 追加、既存呼び出しは ~'auto~ で互換
+   - lifecycle log に lane 情報追加
+   - *既存 test が全 pass することを gate にする*
+
+2. *Phase 2 — Classification rules* (~3 日)
+   - ~anvil-worker--classify~ 実装、regex ベース + 既知 function 名 allow-list
+   - inference が write に誤爆するケースを metric で観測、誤爆率 < 5% を目標
+
+3. *Phase 3 — Batch pool* (~1 週間)
+   - ~anvil-batch-1~, ~anvil-batch-2~ daemon を pre-warm
+   - 既存 ~start-process anvil-worker--spawn-one~ を lane-aware に改修
+
+4. *Phase 4 — Connection reuse* (~1〜2 週間)
+   - 案 B 実装。worker 側で stdio persistent listener を起動
+   - 既存 ~emacsclient~ 経路は fallback として残す (feature flag ~anvil-worker-reuse-connections~)
+
+5. *Phase 5 — Metrics + status UI* (~3 日)
+
+* Migration
+
+- 既存 ~(anvil-worker-enable)~ 呼び出しは動作継続 (デフォルト引数で v1 と同じ pool 構成になるよう初期値を選ぶか、
+  明示的に v2 に切り替えるかは init.org で選択可能にする)。
+- 既存 ~anvil-worker-pool-size~ は deprecation warning を出しつつ ~anvil-worker-read-pool-size~ にエイリアス。
+- ~anvil-worker-call~ の old signature ~(anvil-worker-call expr &optional timeout)~ は互換維持。
+
+* Risks
+
+- *read/write classification の誤爆*。write を read と判定すると書き込みが read replica に行き stale になる。
+  → 採択ルール: ~'auto~ で判別不能時は write に倒す (安全側)。classification は allow-list 主体。
+- *batch pool の冷間期*。pre-warm 済だが、初回 require に時間がかかる処理が含まれると遅い。
+  → pool 初期化時に warmup expression (~(require 'org)~ 等) を流す。
+- *file affinity の skew*。大きな org ファイル 1 本に集中すると shard しても 1 worker に偏る。
+  → Phase 1 では N=1 固定なので Phase 2 まで保留。Phase 2 で metrics を見てから決定。
+- *connection reuse の protocol bug*。persistent listener を自前実装するとデバッグが難しい。
+  → Phase 4 は最後。Phase 1〜3 が安定してから。
+
+* Platform notes
+
+** Windows
+
+- ~emacsclient~ spawn cost が 50〜100ms。connection reuse の ROI は Linux より大きい。
+- worker の ~start-process~ は既に ~set-process-query-on-exit-flag~ を nil にしているので OK。
+- batch pool の cold start は Linux 比 5〜10 倍。pre-warm 効果が特に大きい。
+
+** macOS / Linux
+
+- connection reuse の ROI は小さい (spawn ~20ms)。Phase 4 は Windows 優先で実装し、他 OS は opt-in でも可。
+
+* Success Metrics
+
+- 並列 5 tool call (3 read + 2 write) の完了時間: v1 比 50% 削減
+- cold start 含む "tangle init.org" tool call: v1 比 80% 削減 (batch pool 効果)
+- routing 誤爆率: < 5% (auto kind)
+- respawn 頻度: v1 と同等以下 (退行しない)
+
+* References
+
+- [[file:../../anvil-worker.el][anvil-worker.el (現行)]]
+- memory: ~feedback_emacs_server_concurrency_model.md~
+- memory: ~feedback_emacs_accept_process_output_no_server_yield.md~
+- memory: ~project_mcp_layer2_design.md~

--- a/docs/design/02-org-index.org
+++ b/docs/design/02-org-index.org
@@ -1,0 +1,293 @@
+#+title: Persistent Org Index — SQLite-backed Headline/Tag/ID Cache
+#+date: 2026-04-15
+#+property: status DRAFT
+
+* STATUS
+~APPROVED~ (2026-04-15) — Phase 1 実装着手可
+
+** Decisions
+
+1. *Emacs 要件*: 29+ 推奨 (内蔵 ~sqlite-*~ API)。28.2 は ~emacsql~ がインストール済みの場合のみ可。
+   起動時に backend を動的選択し、どちらも利用不可なら明示エラー。
+2. *DB 位置*: ~~/.emacs.d/anvil-org-index.db~ (user-emacs-directory 直下)。
+   org-roam / vulpea 等の先行慣例に合わせる。
+3. *Phase 1 範囲*: schema 作成 + ~anvil-org-index-rebuild~ (手動全件再構築) + 最低限の status command。
+   watcher / incremental / MCP tool 差し替えは Phase 2 以降。
+
+* Goal
+
+全 org ファイルの headline / tag / ID / property / mtime を *永続 SQLite index* に保持し、
+MCP read tool (特に ~org-read-by-id~, ~org-read-headline~, tag search) が index を先に引くことで、
+以下を達成する:
+
+1. *並列 read の高速化* — parse 不要でほぼ DB クエリのみ。~org-map-entries~ の 30s timeout 問題を回避。
+2. *cold start のコスト償却* — daemon 再起動後も index は disk にあるので再 parse 不要。
+3. *cross-file search* — 複数 org を跨ぐ検索が grep + parse でなく SQL で書ける。
+4. *検索 API の追加* — tag / property / TODO 状態での絞り込みを安価に提供。
+
+* Problem
+
+** 現状の具体的痛み (memory 記載済)
+
+- ~org-map-entries~ が 47KB org ファイルで MCP 30s timeout (~feedback_org_map_entries_timeout.md~)
+- temp-buffer + org-mode パターンは大きいファイルで timeout。pure regexp scanner で回避中。
+- ~my-cc-helpers~ で ~insert-file-contents~ の auto-detect が raw bytes 化する罠 (~feedback_my_cc_helpers_utf8_journals.md~)
+- ~org-read-headline~ 等は毎回ファイル全体を parse するので、同じファイルへの連続 read が無駄。
+
+** 根本原因
+
+- org-element cache は buffer 内のみ、かつ init 時に ~nil~ binding すると 2x 遅くなる罠あり
+  (~feedback_org_element_cache_during_init.md~)
+- buffer が visited でないと cache が効かない。MCP tool で毎回 temp buffer 作るなら効果ゼロ。
+
+** 想定シナリオ
+
+- Claude が "2026-04 の journal から DONE タスクを全部列挙" と頼む
+  → 現状: ~journals-2026.org~ (数 MB) を parse、30s timeout 寸前。
+  → v2: SQLite に ~(file, headline, todo, scheduled)~ が入ってるので
+    ~SELECT ... WHERE file = 'journals-2026.org' AND todo = 'DONE' AND scheduled LIKE '2026-04%'~ で ms オーダー。
+
+* Current State
+
+- 該当なし。anvil には永続 index は存在しない。毎回 parse。
+
+* Proposed Design
+
+** Storage
+
+- SQLite。backend は起動時に動的選択:
+  1. Emacs 29+ で ~(sqlite-available-p)~ が non-nil → 内蔵 ~sqlite-*~ API
+  2. ~(require 'emacsql nil t)~ が成功 → emacsql 経由
+  3. どちらも不可 → ~user-error~ で明示的に失敗
+- Index DB 位置: ~~/.emacs.d/anvil-org-index.db~ (~user-emacs-directory~ 直下)。
+- ~Package-Requires~ は ~emacs 28.2~ のまま維持 (emacsql は optional dep)。
+
+** Schema (v1)
+
+#+begin_src sql
+CREATE TABLE file (
+  id           INTEGER PRIMARY KEY,
+  path         TEXT UNIQUE NOT NULL,
+  mtime        INTEGER NOT NULL,       -- file attribute mtime
+  size         INTEGER NOT NULL,
+  indexed_at   INTEGER NOT NULL,       -- index 生成時刻
+  schema_ver   INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE headline (
+  id           INTEGER PRIMARY KEY,
+  file_id      INTEGER NOT NULL REFERENCES file(id) ON DELETE CASCADE,
+  parent_id    INTEGER,                -- 親 headline.id (top-level は NULL)
+  level        INTEGER NOT NULL,
+  title        TEXT NOT NULL,
+  todo         TEXT,                   -- TODO/DONE/NOTE/MEMO など、または NULL
+  priority     TEXT,                   -- [#A] [#B] [#C] または NULL
+  scheduled    TEXT,                   -- ISO8601 または org timestamp
+  deadline     TEXT,
+  closed       TEXT,
+  org_id       TEXT,                   -- :ID: property
+  position     INTEGER NOT NULL,       -- buffer position (point)
+  line_start   INTEGER NOT NULL,
+  line_end     INTEGER                 -- 次 headline 直前または EOF
+);
+
+CREATE INDEX idx_headline_file   ON headline(file_id);
+CREATE INDEX idx_headline_todo   ON headline(todo);
+CREATE INDEX idx_headline_id     ON headline(org_id) WHERE org_id IS NOT NULL;
+CREATE INDEX idx_headline_sched  ON headline(scheduled) WHERE scheduled IS NOT NULL;
+
+CREATE TABLE tag (
+  headline_id  INTEGER NOT NULL REFERENCES headline(id) ON DELETE CASCADE,
+  tag          TEXT NOT NULL,
+  PRIMARY KEY (headline_id, tag)
+);
+
+CREATE INDEX idx_tag_tag ON tag(tag);
+
+CREATE TABLE property (
+  headline_id  INTEGER NOT NULL REFERENCES headline(id) ON DELETE CASCADE,
+  key          TEXT NOT NULL,
+  value        TEXT NOT NULL,
+  PRIMARY KEY (headline_id, key)
+);
+
+CREATE INDEX idx_property_key ON property(key);
+#+end_src
+
+*非正規化の判断*: tag と property は別テーブルに切るが、検索頻度の高い ~org-id~ だけは headline にも入れる
+(JOIN 回避)。
+
+** Indexer
+
+実装: ~anvil-org-index.el~
+
+*** Entry points
+
+#+begin_src elisp
+(anvil-org-index-rebuild &optional files)
+  ;; FILES が nil なら `anvil-org-index-paths' 全部を再 index。
+  ;; 既存 entry は DELETE → INSERT。atomic (transaction)。
+
+(anvil-org-index-refresh-if-stale &optional file)
+  ;; mtime 比較、変更があれば再 index。
+  ;; MCP tool 呼び出し前に呼ぶ (lazy refresh)。
+
+(anvil-org-index-watch)
+  ;; filesystem watcher 起動。file change event で refresh schedule。
+  ;; Windows: w32-notify、macOS: kqueue、Linux: inotify (Emacs built-in filenotify)
+
+(anvil-org-index-stop)
+#+end_src
+
+*** Parser
+
+- *pure regexp scanner* を採用 (~org-map-entries~ の timeout 回避が memory に記録済)
+- org-mode を load せず、~insert-file-contents~ (coding 強制 utf-8-unix) + regexp で headline 抽出
+- ~org-element~ より桁違いに速い (memory 経験: 47KB で 30s → ms オーダー)
+- 実装: ~anvil-org-index--scan-buffer~ が 1 pass で headline / tag / property / ID / timestamp を抽出
+
+*** Transaction 粒度
+
+- ファイル 1 本 = 1 transaction。途中で crash しても partial state にならない。
+- rebuild 全体では ~BEGIN IMMEDIATE~ で始め、ファイル毎に savepoint。
+
+** Read API (MCP tool 用)
+
+既存 MCP tool の実装を *index 先引き* に切り替える:
+
+| MCP tool              | v1                   | v2 (index 経由)                       |
+|-----------------------+----------------------+---------------------------------------|
+| ~org-read-by-id~      | grep + org parse     | ~SELECT file, position FROM headline WHERE org_id = ?~ で file:position を得てから当該行のみ読む |
+| ~org-read-headline~   | full-file parse      | headline 位置を index で引き、line_start〜line_end を部分読み取り |
+| ~org-read-outline~    | full-file parse      | ~SELECT ... ORDER BY position~ で headline tree を DB 構築 (本文なし) |
+| (新) ~org-search~     | なし                 | tag / todo / property / date range 等を組み合わせた SQL クエリ |
+| (新) ~org-tag-list~   | なし                 | ~SELECT DISTINCT tag FROM tag~ |
+
+本文取得は常に「index で position を引く → 該当範囲のみ ~insert-file-contents~」にすることで、
+ファイル全体を読み込まない。
+
+** Invalidation strategy
+
+3 段階:
+
+1. *mtime check on read* (opportunistic)
+   - read tool 呼び出し時に ~file-attribute-modification-time~ と index の ~mtime~ を比較。
+   - diff あり → 同期的に refresh してから読む。
+2. *filesystem watcher* (proactive)
+   - filenotify で change event を受けたら ~run-with-idle-timer 2~ で refresh schedule。
+   - 連続変更を debounce。
+3. *periodic full scan* (safety net)
+   - 1 時間に 1 回、全 ~anvil-org-index-paths~ を mtime 比較。変更あれば refresh。
+
+** Paths configuration
+
+#+begin_src elisp
+(defcustom anvil-org-index-paths
+  '("~/Cowork/Notes/capture/"
+    "~/Cowork/Notes/node/"
+    "~/Cowork/Reports/")
+  "Directories to index.  Recursively scanned for *.org files.")
+
+(defcustom anvil-org-index-exclude
+  '("\\.git/" "archive/")
+  "Regex patterns excluded from indexing.")
+#+end_src
+
+* API
+
+** User-facing
+
+#+begin_src elisp
+(anvil-org-index-enable)   ; 初回 rebuild + watcher 起動
+(anvil-org-index-disable)  ; watcher 停止 (DB は残す)
+
+(anvil-org-index-rebuild)
+(anvil-org-index-status)   ; ファイル数/headline 数/最終更新/DB サイズ表示
+
+(anvil-org-index-query SQL &rest ARGS)  ; debug 用 raw query
+(anvil-org-index-find-by-id ID)
+(anvil-org-index-find-by-tag TAG)
+(anvil-org-index-search &key tag todo scheduled-from scheduled-to title-match)
+#+end_src
+
+** MCP tools (新規)
+
+- ~org-search~ — 上記 ~anvil-org-index-search~ の MCP wrapper
+- ~org-tag-list~ — 全 tag 列挙
+- ~org-todo-list~ — 指定条件の TODO 列挙 (agenda 代替)
+
+** MCP tools (改修)
+
+- ~org-read-by-id~, ~org-read-headline~, ~org-read-outline~ — 内部で index 利用に切り替え。
+  API は不変。
+
+* Implementation Plan
+
+1. *Phase 1 — Schema + rebuild* (~1 週間)
+   - ~anvil-org-index.el~ 新規作成
+   - schema 作成、~anvil-org-index-rebuild~ 実装 (全 path scan → 全件 DELETE + INSERT)
+   - CI test: 既知 org ファイル → 期待 row 数
+
+2. *Phase 2 — Incremental update* (~3 日)
+   - ~anvil-org-index-refresh-if-stale~ 実装
+   - mtime 比較、ファイル単位で更新
+
+3. *Phase 3 — Filesystem watcher* (~3 日)
+   - ~filenotify-add-watch~ 使用
+   - Windows/macOS/Linux で動作確認
+   - debounce ロジック
+
+4. *Phase 4 — MCP tool 差し替え* (~1 週間)
+   - 既存 ~org-read-*~ tool の内部を index 経由に。API は不変。
+   - 既存 tests 全 pass を gate
+
+5. *Phase 5 — 新 MCP tool* (~3 日)
+   - ~org-search~, ~org-tag-list~, ~org-todo-list~
+
+6. *Phase 6 — Observability* (~2 日)
+   - ~anvil-org-index-status~, metrics (hit rate 等)
+
+* Migration
+
+- ~anvil-enable~ の一部として ~(anvil-org-index-enable)~ を opt-in で提供。
+- 初回起動時の rebuild は時間がかかる可能性があるので、~M-x anvil-org-index-rebuild~ を手動実行する option を案内。
+- 既存 MCP tool は index disabled 時も動作継続 (fallback to v1 parse 経路)。
+
+* Risks
+
+- *parser の org 文法追随漏れ*。org の syntax は柔軟で edge case が多い。
+  → pure regexp で 100% 合わせるのは無理。index には "よく使う属性" のみ入れ、本文は必ず position から
+    実ファイルを読み直す設計にすることで、index 誤りが最終結果に波及しない。
+- *watcher の event loss*。filenotify はバックエンド毎に挙動が違う。
+  → Phase 3 で periodic full scan を併用 (safety net)。
+- *Emacs 29+ 依存*。~Package-Requires~ を引き上げることの影響。
+  → ~emacsql~ 依存にして 28.2 互換を維持する選択肢も。Phase 1 で方針確定。
+- *large repo の初回 rebuild コスト*。数千ファイルの scan は長い。
+  → 初回は background で rebuild、完了まで fallback 経路を使う (段階的 cutover)。
+- *SQL injection*。user input を直接 SQL に入れない。placeholder API 必須。
+
+* Platform notes
+
+** Windows
+
+- filenotify の ~w32-notify~ backend は移動/削除/作成を取りこぼすことが稀にあるので periodic scan を必須に。
+- SQLite DB file lock は POSIX と異なる。~sqlite-open~ の排他設定を要確認。
+
+** macOS / Linux
+
+- kqueue / inotify の watcher はほぼ素直に動く。ただし kqueue は file descriptor 上限に注意。
+
+* Success Metrics
+
+- ~org-read-by-id~ 平均 latency: v1 比 90% 削減 (parse 不要)
+- 30s timeout 事例の消滅
+- 初回 rebuild 所要時間: 1000 ファイルで < 60s
+- watcher-to-index-ready 時間: < 3s (典型)
+
+* References
+
+- memory: ~feedback_org_map_entries_timeout.md~ (pure regexp scanner の必要性)
+- memory: ~feedback_my_cc_helpers_utf8_journals.md~ (~insert-file-contents~ coding 強制の知見)
+- memory: ~feedback_org_element_cache_during_init.md~ (org-element cache の罠)
+- ~anvil-org.el~ (既存 org tool)
+- Emacs 29+ ~sqlite.el~ API

--- a/docs/design/03-offload-framework.org
+++ b/docs/design/03-offload-framework.org
@@ -1,0 +1,246 @@
+#+title: Offload Framework — Futures, Coalescing, Preemption
+#+date: 2026-04-15
+#+property: status DRAFT
+
+* STATUS
+~DRAFT~ — レビュー前。Doc 01 (worker pool v2) の batch pool を前提とする。
+
+* Goal
+
+重い / 長時間 / 冗長な tool call を透過的に扱う共通基盤を提供する:
+
+1. *Offload macro* — ~(anvil-offload FORM)~ で任意の elisp を batch subprocess に投げ、future を返す。
+   個別に ~start-process~ を書かずに済むようにする。
+2. *Call coalescing* — 短時間内の同一ファイルへの複数 edit call を 1 回の buffer open にまとめる。
+3. *Preemption* — wall-time cap を超えた tool call を safely kill し、partial result + resume cursor を返す。
+
+現状、~init.org~ tangle の subprocess pattern 等が個別に書かれており、再利用できていない。
+
+* Problem
+
+** 現状の具体例 (memory)
+
+- init.org tangle: in-process 30s → subprocess 2s (~15x speedup)、~feedback_subprocess_tangle_pattern.md~ に経験則。
+- ~run-with-timer~ は重い op には無効。fire-and-forget + sentinel log が正解パターン。
+- ~org-map-entries~ が 30s timeout する (doc 02 で index 化するが、それでも subprocess 必要な op はある)。
+
+** coalescing の動機
+
+- Claude がしばしば「read → edit → re-read → edit」と短時間内に同じファイルに複数 call する。
+- 各 call で ~find-file~ / ~save-buffer~ が走ると Windows では disk I/O + mtime 更新が重なる。
+- batch 化で 1 buffer open に集約すれば合計 latency が数倍改善。
+
+** preemption の動機
+
+- 1 つの bad call (regex の catastrophic backtracking、巨大ファイルの誤処理) で daemon が詰まる。
+- 現状 ~anvil-worker-call~ は timeout で process kill するが、その時点で partial result が捨てられる。
+- 設計上「25s で一旦返して、続きはクライアントが決める」方が AI agent との相性が良い (再開可能なら retry)。
+
+* Current State
+
+- ~anvil-worker.el~ の heavy-op detection: 静的 regex でパターン検出、timeout を 300s に延長するのみ。
+- ~anvil-proc.el~: 汎用プロセス起動ラッパー (詳細未確認)
+- offload 相当の再利用可能 macro: *なし*
+- coalescing: *なし*
+- preemption: process kill のみ、resume 不可
+
+* Proposed Design
+
+** ~anvil-offload~ macro
+
+#+begin_src elisp
+(anvil-offload FORM &key (timeout 300) (env nil) (require nil))
+  ;; FORM を batch subprocess で eval し future (plist) を返す
+  ;; :require は (require 'X) を事前に走らせる library list
+  ;;
+  ;; 返り値: (:future PROC :promise-fn FN :status 'running ...)
+#+end_src
+
+*** 実装方針
+
+1. *batch pool (Doc 01) を使う*
+   - pre-warmed ~emacs --batch~ プロセスに対して ~print1~ 経由で expression を送り、結果を ~read~ で受ける。
+   - pool が busy の時は新規に ~start-process~ で fallback。
+
+2. *stdin/stdout 通信*
+   - batch Emacs 側で ~(while t (let ((expr (read (current-buffer)))) (prin1 (eval expr))))~ のような REPL ループを持つ。
+   - 1 request = 1 S-expression。Result も 1 S-expression で返す。
+
+3. *future API*
+   #+begin_src elisp
+   (anvil-future-done-p FUTURE)
+   (anvil-future-await FUTURE &optional timeout) ; 同期待機
+   (anvil-future-value FUTURE)                    ; 完了後の値
+   (anvil-future-error FUTURE)                    ; エラー
+   (anvil-future-cancel FUTURE)                   ; 取り消し (kill)
+   #+end_src
+
+4. *エラー伝播*
+   - batch 側で ~condition-case~ で全 error を捕捉し ~(:error (type . message))~ として返す。
+   - future-value 時に再 signal するか、~future-error~ で取得。
+
+** Call coalescing
+
+*** 対象
+
+同一 ~file-path~ への edit call (~file-batch~, ~file-replace-string~, ~file-replace-regexp~, etc.) を
+短時間窓 (例 50ms) にまとめ、1 回の buffer open で処理。
+
+*** 実装
+
+- dispatcher (Doc 01 の main daemon router) に coalescing queue を追加。
+- request 到着時に queue を参照し、同じ file の既存 request があれば *そのまま追記* して batch 化。
+- 最初の request が worker に dispatch される時点で queue snapshot を取り、~file-batch~ と等価な操作に変換。
+
+*** Semantics
+
+- coalescing は *順序保存* (FIFO) で行う。
+- ただし read と write は混ぜない。read は index 経由 (Doc 02) なので coalesce しない。
+- 境界条件: 同一 request 内で "edit → read → edit" と来た場合、read の時点で queue を flush。
+
+*** Trade-off
+
+- worst case: 51ms 待たされる。
+- best case: 5 edit call が 1 file open にまとまり合計時間 1/5。
+- デフォルトは OFF (~anvil-coalesce-window-ms 0~)。opt-in で有効化。
+
+** Preemption
+
+*** 基本戦略
+
+- wall-time cap (デフォルト 25s) を超えたら worker 内で ~signal~ を投げ、tool call を abort。
+- abort 時点までの部分結果 (read なら読めた範囲、map 系なら処理済 entry 数) を返す。
+
+*** 実装
+
+1. worker 側に ~anvil-preempt-start~ で itimer 登録。
+2. 期限切れで ~(throw 'anvil-preempt :deadline-reached)~。
+3. ラッパー macro ~(anvil-with-preemption (:budget-sec 25) BODY)~ が:
+   - BODY 前に ~anvil-preempt-start~
+   - BODY 後に ~anvil-preempt-cancel~
+   - ~catch 'anvil-preempt~ で partial result を整形して返す
+4. 返却形式: ~(:status 'partial :value PARTIAL :cursor CURSOR :consumed-sec N)~
+
+*** Resume cursor
+
+- 対応可能な op のみで実装。例えば ~org-search~ は ~(limit, offset)~ を cursor に保存可能。
+- file scan 系は byte-offset を cursor に。
+- 非 resumable な op (byte-compile 等) は preempt されたら単に失敗として扱う。
+
+*** API
+
+#+begin_src elisp
+(anvil-call-preemptible EXPRESSION &key (budget 25) (cursor nil))
+  ;; → (:status 'complete :value V)
+  ;;   (:status 'partial :value V :cursor C :consumed 25.1)
+  ;;   (:status 'error :error E)
+#+end_src
+
+- AI client 側で ~:partial~ を見たら ~cursor~ を使って継続 call できる。
+- MCP tool 定義には ~:resumable~ flag を追加し、client に "partial 対応" を宣言。
+
+* API
+
+** macro / user-facing
+
+#+begin_src elisp
+;; offload
+(anvil-offload FORM &key timeout env require)
+(anvil-future-await FUTURE &optional timeout)
+(anvil-future-value FUTURE)
+(anvil-future-cancel FUTURE)
+
+;; coalescing
+(setq anvil-coalesce-window-ms 50)  ; 0 = 無効
+
+;; preemption
+(anvil-call-preemptible EXPR &key budget cursor)
+(anvil-with-preemption (:budget-sec 25) BODY...)
+#+end_src
+
+** MCP tool integration
+
+- anvil の tool register マクロに ~:resumable~ / ~:offload~ keyword を追加:
+
+#+begin_src elisp
+(anvil-server-register-tool #'my-big-scan
+  :id "big-scan"
+  :description "..."
+  :offload t
+  :resumable t
+  :budget-sec 25)
+#+end_src
+
+- ~:offload t~ → 自動で batch subprocess で実行
+- ~:resumable t~ → preemption 有効、cursor 引数を取る
+
+* Implementation Plan
+
+1. *Phase 1 — Future API + batch REPL* (~1 週間)
+   - ~anvil-offload.el~ 新規。
+   - batch Emacs 用 REPL (~anvil-batch-repl.el~) を用意、stdin から S-expression を受け eval して stdout に出す。
+   - ~anvil-future-*~ 実装。
+   - tests: 単純な ~(+ 1 2)~ の offload、error 伝播、cancel。
+
+2. *Phase 2 — anvil-worker との統合* (~3 日)
+   - batch pool (Doc 01 Phase 3) の worker を offload にも使う。
+   - ~:offload t~ tool が自動で batch lane に routing される。
+
+3. *Phase 3 — Preemption* (~1 週間)
+   - ~anvil-preempt.el~ 新規。
+   - itimer ベースの budget enforcement。
+   - ~anvil-call-preemptible~ 実装、partial/cursor semantics 定義。
+   - 代表 tool (~org-search~ 等) を resumable 化。
+
+4. *Phase 4 — Coalescing* (~1 週間)
+   - dispatcher (Doc 01 側) に queue を追加。
+   - 50ms 窓での batch 化、FIFO 保存。
+   - feature flag で opt-in。
+   - tests: 5 連続 edit が 1 file open に収まることを確認。
+
+5. *Phase 5 — Tool 側 retrofit* (~3 日)
+   - 既存 heavy tool (init.org tangle 相当) を ~:offload t~ に切り替え。
+
+* Migration
+
+- ~anvil-offload~ は新 API。既存 tool の挙動変更なし。
+- coalescing はデフォルト OFF。opt-in 推奨。
+- preemption は ~:resumable t~ 宣言した tool のみ。既存 tool は挙動不変。
+
+* Risks
+
+- *batch Emacs の state 非共有*。offload した form は main daemon の global state に触れない。
+  → offload は明確に pure 寄り op に限定。副作用あるものは worker lane 経由に誘導。
+  docstring で明示し、lint で検出可能に。
+- *preemption の破損*。抽象化が漏れると mid-state で abort して disk 破損の可能性。
+  → disk write 系は preempt 対象外。read / compute 系のみ。
+- *coalescing の semantics bug*。順序を誤ると壊れる。
+  → FIFO 厳守、read 境界で flush、write conflict は sequential。
+  形式仕様を doc 化してから実装。
+- *future leak*。取得されない future がずっと pool の slot を食う。
+  → WEAK reference + timeout で GC。
+
+* Platform notes
+
+** Windows
+
+- batch Emacs cold start が遅い → batch pool (Doc 01) の pre-warm に強く依存。
+- stdin/stdout の encoding は ~utf-8-unix~ に強制 (memory: ~feedback_msys_python_japanese_path.md~)。
+
+** macOS / Linux
+
+- 特記なし。batch cold start が速いので pre-warm の ROI は小さい。
+
+* Success Metrics
+
+- ~init.org tangle~ 相当の heavy op: daemon 体感 freeze 時間 → 0 (offload)
+- coalesce 有効時の 5 連続 edit 合計 wall-time: 50% 削減
+- preempt 発火時の AI-client retry 成功率: > 90% (resume cursor が正しく効く)
+- future API 利用箇所数: Phase 5 完了時点で 5 以上
+
+* References
+
+- memory: ~feedback_subprocess_tangle_pattern.md~ (in-process 30s → subprocess 2s)
+- memory: ~feedback_emacs_server_concurrency_model.md~ (yield point の前提)
+- Doc 01 (worker pool v2) — batch pool infrastructure
+- Doc 02 (org index) — 一部 heavy op を不要にするが、依然必要なケースもある

--- a/docs/design/04-pty-broker.org
+++ b/docs/design/04-pty-broker.org
@@ -1,0 +1,264 @@
+#+title: PTY Broker + Headless UI — Get Emacs Out of the PTY Path
+#+date: 2026-04-15
+#+property: status DRAFT
+
+* STATUS
+~DRAFT~ — レビュー前。~ccih-pty-broker~ (2026-04-12 MVP 済) の知見を正式設計に昇格。
+
+* Goal
+
+「Emacs 内で AI TUI (~claude~, 将来の ~gemini-cli~ 等) を動かす」ために発生している PTY 系の痛み
+(ConPTY 片方向 stdin、~eat~ filter starvation、wide-char 無限ループ) を *構造的に* 解消する。
+
+2 本立てのアプローチ:
+
+1. *PTY Broker* — Node.js の node-pty を仲介プロセスに置き、Emacs は TCP/Unix socket 経由で
+   plain byte stream として読む。Emacs から PTY 層を完全に切り離す。
+2. *Headless Renderer* — そもそも TUI を render する必要があるか再考。~claude~ は JSONL stream mode で
+   動かし、org buffer に自前で render する方が安定する。TUI 回避が最善。
+
+* Problem
+
+** memory に記録された具体的痛み
+
+- ConPTY headless mode の stdin pipe は片方向 (TUI raw input 不可)。~feedback_conpty_headless_stdin_unidirectional.md~
+- ~eat~ の process filter は daemon server loop を starvation させる。timer-only filter で解決。
+- ~eat--t-write~ wide-char 無限ループ。per-buffer char-width clamp で bypass。
+- claude-code-ide の ~eat~ backend は main daemon で wedge。~'none~ backend + ccih-pty-broker で回避中。
+
+** 根本原因
+
+- Emacs の process filter は同期で走る。TUI output は高頻度で filter を呼ぶので、
+  1 chunk あたり数 ms でも積もると daemon 全体が止まる。
+- ConPTY は Windows で raw input を提供しない (TUI key handling は cooked mode のみ)。
+- eat は「Emacs 内で本格 vt100」を目指しているが、AI CLI の用途にはオーバースペック。
+
+** 分離設計の動機
+
+- node-pty は TUI 駆動の成熟した実装。Emacs 側で PTY を再実装する必要がない。
+- Emacs は render 層だけに専念すれば、filter starvation は timer + chunk size 制限で避けられる。
+
+* Current State
+
+- ~my-claude-code-ide-broker.el~ (MVP 完成、memory: ~project_ccih_pty_broker_status.md~)
+- ~eat-windows-pty~ project (探索中、現状は eat fork 込み)
+- ~ssh -tt~ 経由で claude が動く知見 (~reference_eat_claude_ssh_tt_solution.md~)
+
+* Proposed Design
+
+** Two-part architecture
+
+#+begin_src text
+┌───────────────────────────┐
+│  User's Emacs (main)       │
+│  ┌─────────────────────┐   │
+│  │ anvil-pty-client.el │◄──┼──── TCP:localhost:NNNN
+│  └─────────────────────┘   │      ASCII framed protocol
+│     (timer-based reader,   │
+│      no process filter)    │
+└───────────────────────────┘
+                 ▲
+                 │ JSON frames
+                 │
+┌────────────────┴──────────┐
+│  anvil-pty-broker (Node)   │
+│  ┌─────────────────────┐   │
+│  │ node-pty             │   │
+│  │   ├── claude (pty1)  │   │
+│  │   ├── bash  (pty2)   │   │
+│  │   └── ...            │   │
+│  └─────────────────────┘   │
+└───────────────────────────┘
+#+end_src
+
+** Part 1: node-pty broker (~anvil-pty-broker~)
+
+Node.js package を anvil の submodule (または npm-installable sibling) として提供。
+
+*** 起動
+
+#+begin_src bash
+node anvil-pty-broker.js --port 7641 --auth-token FOO
+# または Emacs 側から:
+#   (anvil-pty-enable)
+#   → Node を start-process で起動、port を動的割当
+#+end_src
+
+*** Protocol (JSON lines over TCP)
+
+Request (Emacs → broker):
+
+#+begin_src json
+{"op": "spawn", "id": "claude-1", "cmd": "claude", "args": ["chat"], "cwd": "/path", "cols": 120, "rows": 40}
+{"op": "input", "id": "claude-1", "data": "hello\r"}
+{"op": "resize", "id": "claude-1", "cols": 200, "rows": 50}
+{"op": "kill", "id": "claude-1", "signal": "SIGTERM"}
+{"op": "list"}
+#+end_src
+
+Response (broker → Emacs):
+
+#+begin_src json
+{"ev": "spawned", "id": "claude-1", "pid": 12345}
+{"ev": "output", "id": "claude-1", "data": "…base64-encoded bytes…"}
+{"ev": "exit", "id": "claude-1", "code": 0}
+{"ev": "error", "id": "claude-1", "message": "…"}
+#+end_src
+
+- 出力は base64 encode (ASCII safe、Emacs 側 decode 楽)。
+- frame delimiter は LF (1 行 1 JSON)。
+
+*** Emacs 側 (~anvil-pty-client.el~)
+
+- ~make-network-process~ で TCP 接続、~:filter~ は *使わない*。
+- 代わりに ~run-at-time~ で定期的に ~process-send-string~ と受信バッファを drain。
+  - *timer-only I/O* にすることで daemon のメインループを starvation させない
+    (memory: ~feedback_eat_daemon_filter_starvation.md~ で確立した pattern)。
+- 受信側: 内部バッファに貯めて LF 区切りで JSON parse、op ごとに buffer に render。
+
+*** Render layer
+
+- render 先は専用 mode ~anvil-pty-mode~。
+- output を ANSI-aware に解釈し、ANSI color + cursor movement を最低限サポート。
+- *full vt100 は目指さない*。AI CLI の典型出力 (色、cursor-up、clear-line 程度) だけ扱う。
+- 書き込み chunk は 1 tick = 最大 4KB に制限 (soft cap)。
+
+** Part 2: Headless renderer (~anvil-headless-claude.el~)
+
+*** 動機
+
+~claude~ は ~--output-format stream-json~ 等の非 TUI mode を持つ (同等機能を提供)。
+これを使えば PTY すら不要。
+
+*** 流れ
+
+1. ~(anvil-headless-claude-start)~ で ~claude --output-format stream-json~ を start-process。
+2. stdout は JSON lines。filter で parse、message を buffer に org 風に format。
+3. 入力は buffer 底行から ~C-c C-c~ で送信、stdin に JSON で投入。
+
+*** 利点
+
+- PTY 完全不要。ConPTY / winpty / eat の全問題が蒸発。
+- render layer は自前なので、org heading / src block に auto-format 可能。
+- token usage, tool call 等の metadata も JSON で取れるので、side pane に表示できる。
+
+*** 制約
+
+- ~claude~ が提供する JSONL mode の機能範囲に従う (raw TTY コントロールは不可)。
+- REPL 的なリアルタイム stream は同じ仕組みで流せる。
+
+** 選択基準
+
+| ユースケース                       | 採用              |
+|-----------------------------------+-------------------|
+| claude を Emacs 内で対話          | *Part 2* (headless) |
+| 汎用 TUI (vim, less, htop)        | *Part 1* (broker)   |
+| claude の file edit を Emacs で見る| Part 2 + anvil-file |
+| ssh -tt 経由の対話                 | Part 1 のみ         |
+
+Part 2 が主戦略。Part 1 は「どうしても TUI が必要な場合」の fallback。
+
+* API
+
+** Part 1: broker
+
+#+begin_src elisp
+(anvil-pty-enable &key port auth-token)
+(anvil-pty-disable)
+
+(anvil-pty-spawn CMD &key args cwd cols rows name)
+  ;; → pty-id string
+(anvil-pty-send PTY-ID STRING)
+(anvil-pty-resize PTY-ID COLS ROWS)
+(anvil-pty-kill PTY-ID &optional signal)
+(anvil-pty-list)
+
+(anvil-pty-open-buffer PTY-ID)
+  ;; → buffer (anvil-pty-mode)
+#+end_src
+
+** Part 2: headless claude
+
+#+begin_src elisp
+(anvil-headless-claude)                 ; interactive: session 開始
+(anvil-headless-claude-send STRING)
+(anvil-headless-claude-history)
+(anvil-headless-claude-export-org FILE) ; ログを org に export
+#+end_src
+
+* Implementation Plan
+
+1. *Phase 1 — Broker MVP 正式化* (~1 週間)
+   - 既存 ~my-claude-code-ide-broker.el~ の知見を ~anvil-pty-broker~ (Node + Elisp client) に移植
+   - protocol 固定、auth token、単一 pty セッション
+   - tests: bash を spawn、"echo hello" → "hello\n" 受信
+
+2. *Phase 2 — Multi-pty + resize + kill* (~3 日)
+   - 複数 pty を同時管理
+   - SIGWINCH 相当の resize
+   - clean shutdown
+
+3. *Phase 3 — Render layer* (~1 週間)
+   - ~anvil-pty-mode~ 実装
+   - ANSI color + cursor movement の最小サポート
+   - chunk size cap
+
+4. *Phase 4 — Headless claude* (~1 週間)
+   - ~claude --output-format stream-json~ integration
+   - org-style render
+   - 入力送信 UI
+
+5. *Phase 5 — claude-code-ide bridge* (~3 日)
+   - claude-code-ide の ~'none~ backend を anvil-headless-claude に置き換え
+   - 既存 ~my-claude-code-ide-headless~ ユーザの移行 path
+
+6. *Phase 6 — Security hardening* (~3 日)
+   - auth token 必須、localhost only default
+   - process isolation、許可 command allowlist
+
+* Migration
+
+- 既存 ~ccih-pty-broker~ ユーザは ~anvil-pty-broker~ に renameで移行。breaking change (config 名変更)
+  は CHANGELOG で告知。
+- ~anvil-headless-claude~ は新機能。既存 ~my-claude-code-ide-headless~ と並立、段階的移行。
+
+* Risks
+
+- *Node.js 依存の増加*。anvil コアは Emacs 28.2 以上のみで動作していたが、PTY Broker は Node が必要。
+  → optional feature とし、~(anvil-pty-enable)~ を呼ばない限り Node は不要。
+- *Windows での Node インストール UX*。
+  → README に ~winget install OpenJS.NodeJS~ を明記。~anvil-pty-enable~ が Node 未検出時に丁寧に誘導。
+- *claude JSONL mode の将来変更*。API が変わると render 層を追従する必要がある。
+  → 最小限の field のみ依存、未知 field は ignore。
+- *ANSI parser の完成度*。"最小限の vt100" が曖昧。
+  → 既知 AI CLI (claude, aider, gemini-cli) が出す sequence を allowlist 化、それ以外は literal 表示。
+- *security*。broker が external program を起動可能なので、allowlist 必須。
+  → ~anvil-pty-allowed-commands~ で restrict。デフォルト空で自己保護。
+
+* Platform notes
+
+** Windows
+
+- node-pty は ConPTY backend を自動選択。winpty fallback も組み込み済。
+- Emacs 側は TCP のみ使用 (Windows の Unix socket 対応は壊れ気味)。
+
+** macOS / Linux
+
+- Unix socket を使う (performance + auth 面で有利)。
+
+* Success Metrics
+
+- daemon starvation による Emacs 固まり事例: 0
+- headless claude での 10 分連続対話の安定性: 100%
+- eat に比べた render layer コード行数: 1/5 以下
+- Windows / macOS / Linux の動作一致率: 100% (headless 側)
+
+* References
+
+- memory: ~feedback_conpty_headless_stdin_unidirectional.md~
+- memory: ~feedback_eat_daemon_filter_starvation.md~
+- memory: ~feedback_eat_t_write_wide_char_loop.md~
+- memory: ~reference_windows_native_pty_options.md~
+- memory: ~reference_eat_claude_ssh_tt_solution.md~
+- memory: ~project_ccih_pty_broker_status.md~ (MVP 経験)
+- memory: ~project_my_ccih_status.md~ (headless backend wrapper)

--- a/docs/design/05-disk-first.org
+++ b/docs/design/05-disk-first.org
@@ -1,0 +1,211 @@
+#+title: Disk-First Policy — Buffer Divergence Guard
+#+date: 2026-04-15
+#+property: status DRAFT
+
+* STATUS
+~DRAFT~ — レビュー前。コンパクトな変更だが、AI による silent data corruption を防ぐ柱。
+
+* Goal
+
+anvil の全 file-* MCP tool において、以下を *契約 (contract)* として確立する:
+
+1. *Disk is source of truth*. tool は明示指定がない限り disk I/O を行い、visited buffer は参照しない。
+2. *Buffer divergence は fail-loud*. visited buffer と on-disk mtime/size が不一致なら silent に stale を
+   返さず、明示的にエラーまたは警告を返す。
+3. *Buffer 操作は opt-in*. ~buffer-*~ prefix の専用 variant を用意し、意図がある時だけ使う。
+
+* Problem
+
+** 記録された事故
+
+- memory: ~feedback_init_org_buffer_divergence.md~
+  - ~init.org~ buffer は ~visited-file-modtime = 0~ / ~undo 無効~ / ~size 不一致~ で *意図的に* stale。
+  - うっかり ~save-buffer~ を呼ぶと disk の新しい内容が上書きされる。
+- memory: ~feedback_journal_org_edit_body_timeout.md~
+  - ~org-edit-body~ timeout、Edit tool が buffer auto-revert で消失。
+  - ~find-file~ + ~insert~ + ~save~ を明示的に書く必要があった。
+- memory: ~feedback_my_cc_helpers_utf8_journals.md~
+  - ~insert-file-contents~ の coding auto-detect で raw bytes 化。
+  - temp buffer に読んだ内容が silent に壊れる。
+
+** 根本原因
+
+- Emacs は「buffer が最新」という前提で作られている。visited buffer があればそちらが優先。
+- MCP tool が「ファイルを読む」と言った時、Emacs は buffer を返すか disk を返すか曖昧。
+- auto-revert や find-file の副作用が背景で走り、silent に state を変える。
+
+** AI-specific な問題
+
+- AI client は "ファイルを読み書きしている" と思っている。buffer 経由だと:
+  - 人間が編集中の unsaved buffer を読んでしまう (privacy / integrity)
+  - 書き込みが buffer のみに入り、他ツールから見えない
+  - buffer と disk の mtime ズレで "さっき書いた内容" が次回読む時に消える
+
+* Current State
+
+- anvil の多くの ~file-*~ tool は既に disk I/O を行う (良い)。
+- しかし ~insert-file-contents~ / ~find-file-noselect~ が混在しており契約が曖昧。
+- ~visited-file-modtime~ チェックを行う場所は限定的。
+
+* Proposed Design
+
+** Naming convention
+
+| Prefix       | 意味                                    | 例                               |
+|--------------+-----------------------------------------+----------------------------------|
+| ~file-*~     | disk に対する操作、buffer は触らない    | ~file-read~, ~file-replace-string~ |
+| ~buffer-*~   | visited buffer に対する操作 (明示 opt-in)| ~buffer-read~, ~buffer-save~     |
+| (既存互換)    | 既存名の tool は disk に固定             | ~org-read-by-id~ (disk 経由)     |
+
+~file-*~ を呼んだ時:
+- 当該 path が visited buffer を持っていても *buffer を無視して disk を読む*
+- buffer が modified (unsaved) で on-disk と diverge している場合は *警告を返す* (でも disk を読む)
+
+~buffer-*~ を呼んだ時:
+- visited buffer が存在しない場合は *error* (自動で find-file しない)
+- buffer と disk の mtime を比較し、diverge していれば *警告を添付* して返す
+
+** Divergence detection
+
+新 helper:
+
+#+begin_src elisp
+(defun anvil-disk-buffer-divergence (file)
+  "Return divergence info plist for FILE, or nil if no visited buffer.
+
+Returns:
+  (:buffer BUF
+   :disk-mtime TIME
+   :buffer-mtime TIME
+   :disk-size N
+   :buffer-size N
+   :status 'in-sync | 'buffer-newer | 'disk-newer | 'both-modified | 'unknown)"
+  ...)
+#+end_src
+
+判定ロジック:
+
+- ~visited-file-modtime~ が ~(0 0 0 0)~ または 0 → ~'unknown~ (意図的 stale、init.org 型)
+- ~buffer-modified-p~ かつ disk の mtime > buffer の last visited mtime → ~'both-modified~
+- ~buffer-modified-p~ のみ → ~'buffer-newer~
+- disk の mtime > visited-file-modtime → ~'disk-newer~
+- 一致 → ~'in-sync~
+
+** Default policy per tool class
+
+| Tool class               | default behavior                                               |
+|--------------------------+---------------------------------------------------------------|
+| ~file-read~              | disk から読む。divergence があれば ~:warnings [...]~ 添付    |
+| ~file-replace-string~    | disk を書く。buffer がある場合は修正後に auto-revert をトリガー or 警告 |
+| ~file-insert-at-line~    | 同上                                                         |
+| ~buffer-read~            | buffer から読む。buffer なければ error                       |
+| ~buffer-save~            | buffer を disk に書く。divergence ~'disk-newer~ なら refuse (明示 ~:force~ で上書き可) |
+
+** Write-after-buffer-edit の扱い
+
+disk に書いた後、visited buffer があれば:
+
+- ~revert-buffer-preserve-modes t~ で自動 revert
+- *ただし* buffer が modified なら *revert を拒否* (データ保護)、警告を返す
+
+AI が同じ file を立て続けに編集する時、人間が buffer で編集していれば AI 編集が拒否される仕組み。
+衝突が起きないことを AI 側が知れる。
+
+** Force-buffer opt-in
+
+どうしても buffer 経由にしたい ~:force-buffer t~ keyword を file-* 系全部に追加可能にする:
+
+#+begin_src elisp
+(file-read "foo.org" :force-buffer t)
+  ;; → visited buffer があればそれを返す、なければ find-file してから返す
+  ;; 契約を破っている自覚付きの opt-in
+#+end_src
+
+使い道: 人間が編集中のバッファを AI が見る debug 用途、init.org 型の意図的 stale buffer 操作。
+
+* API
+
+** Helper
+
+#+begin_src elisp
+(anvil-disk-buffer-divergence FILE)           ; 判定 plist
+(anvil-file-require-in-sync FILE)              ; diverge なら error
+(anvil-file-warn-if-diverged FILE)             ; warn list を返す
+(anvil-file-safe-write FILE CONTENT &key force); buffer conflict 時 refuse
+#+end_src
+
+** Tool registration
+
+anvil-server-register-tool マクロに新 keyword:
+
+#+begin_src elisp
+(anvil-server-register-tool #'my-tool
+  :id "..."
+  :buffer-policy 'disk            ; 'disk | 'buffer | 'either
+  :on-divergence 'warn)           ; 'warn | 'error | 'ignore
+#+end_src
+
+~:buffer-policy~ が明示されていない tool は 'disk default とし、~:on-divergence~ は 'warn default。
+
+* Implementation Plan
+
+1. *Phase 1 — Helper 整備* (~2 日)
+   - ~anvil-disk-buffer-divergence~ 実装
+   - ~anvil-file-safe-write~ 実装
+   - tests: 5 パターンの divergence 判定
+
+2. *Phase 2 — file-* tool 契約見直し* (~1 週間)
+   - 全 ~file-*~ tool を ~:buffer-policy 'disk~ で audit
+   - 意図せず ~find-file-noselect~ を呼んでいる箇所を ~insert-file-contents~ + coding 強制に
+   - divergence 時に ~:warnings~ を返すよう return format 拡張
+
+3. *Phase 3 — buffer-* 系新規追加* (~3 日)
+   - ~buffer-read~, ~buffer-save~, ~buffer-list-modified~ 追加
+   - MCP tool として登録、~:buffer-policy 'buffer~
+
+4. *Phase 4 — Documentation + migration* (~2 日)
+   - README に契約追記
+   - 既存 tool の docstring に ~buffer-policy~ 明記
+   - CHANGELOG で behavior 明確化 (silent stale が無くなる点)
+
+* Migration
+
+- 既存 tool の戻り値が ~:warnings~ を持つようになる可能性 → schema の optional key。
+- 既存 tool の *挙動* は不変 (disk 経由が既に多数派)。
+- 新 ~buffer-*~ は完全新規。
+
+* Risks
+
+- *警告ノイズ*. 人間が editor で編集中の buffer があるだけで毎回 warn が出ると煩い。
+  → ~:on-divergence 'warn~ は opt-in。デフォルトは 'ignore でも良い。Phase 2 で決定。
+- *auto-revert の副作用*. disk 書き込み後の auto-revert が mode hook を発火し副作用を生む。
+  → ~revert-buffer-preserve-modes t~ を徹底、preserve するか明示制御。
+- *force-buffer の濫用*. AI が面倒を避けて ~:force-buffer t~ を付けて buffer stale を読んでしまう。
+  → docstring で "人間 debug 用、AI は使うな" を明記、~anvil-server~ で AI tool call からは除外する option。
+
+* Platform notes
+
+** Windows
+
+- mtime 精度は NTFS でおおむね 1s、FAT で 2s。div 判定は ~>~ でなく ~>=~ 相当にマージン。
+- symlink/junction 経由のファイルで ~file-attribute-modification-time~ が stale を返すケースに注意
+  (memory: ~feedback_windows_junction_not_symlink.md~ 参照)。
+
+** macOS / Linux
+
+- 特記なし。
+
+* Success Metrics
+
+- silent stale read 事故報告: 0 (運用期間中)
+- AI-caused buffer corruption 事故: 0
+- ~:warnings~ を含む応答の割合: 監視、異常値なら閾値調整
+- Migration 後の既存 test pass 率: 100%
+
+* References
+
+- memory: ~feedback_init_org_buffer_divergence.md~
+- memory: ~feedback_journal_org_edit_body_timeout.md~
+- memory: ~feedback_my_cc_helpers_utf8_journals.md~
+- memory: ~feedback_windows_junction_not_symlink.md~
+- Emacs ~visited-file-modtime~ / ~verify-visited-file-modtime~ / ~revert-buffer~

--- a/docs/design/README.org
+++ b/docs/design/README.org
@@ -1,0 +1,80 @@
+#+title: Anvil — Next Architecture Design Docs
+#+author: Fujisawa Electric Management Office
+#+startup: overview
+
+* Background
+
+Anvil の現行アーキテクチャ (Architecture B) は、purpose 別に 4 層の Emacs プロセスを分離することで
+「人間の Emacs が AI に詰まらされる」問題を解消した。しかし運用する中で、Emacs を MCP server にする上で
+残る根本的な制約がいくつか明らかになった:
+
+- *単一プロセス内シリアライズ* — 各 daemon 内では tool call が直列化する。
+  ~make-mutex~ は cross-session で意味をなさず、~accept-process-output~ も server eval には yield しない。
+- *重い org 処理の伝播* — 47KB org の ~org-map-entries~ が 30s timeout、init.org tangle が 30s ブロックする等、
+  1 本の重い tool call が daemon 全体を止める。
+- *TUI/PTY 問題* — Windows 上で ConPTY の stdin 片方向、~eat~ filter が daemon loop を starvation させる、
+  ~eat--t-write~ の wide-char 無限ループ等、TUI を Emacs 内に埋め込む試み自体の脆さ。
+- *buffer と disk の divergence* — visited buffer と on-disk の不整合が silent に stale なデータを返す。
+  ~init.org~ buffer は意図的に disk と divergence している等、単純な Read/Write では解けない。
+
+これらは個別に場当たりで凌いできたが、次段として *設計上* で解きたい。本ディレクトリはその設計 doc を集約する。
+
+* Design Principles
+
+1. *Emacs は人間の道具が第一*。AI tool call は editor をブロックしてはならない。
+2. *単一プロセス前提を捨てる*。並列性は process 分離と永続化層で獲得する。
+3. *既存 my-cc-helpers / anvil-* を壊さない*。新機能は opt-in で、既存 tool は互換を維持。
+4. *disk を真実の源 (source of truth) とする*。buffer は派生物として扱い、divergence は fail-loud。
+5. *Windows を first-class に扱う*。~~/Unix-only~~ な前提を設計段階で排除する。
+
+* Order of Work
+
+順序は依存関係で決めている。~01~ と ~02~ は並列着手可能。~03~ は ~01~ の worker pool を使う。
+~04~ と ~05~ は独立。
+
+| #  | Doc                         | 依存        | 想定工数 | 優先度 |
+|----+-----------------------------+-------------+----------+--------|
+| 01 | [[file:01-worker-pool-v2.org][Worker Pool v2]]              | なし        | 中       | 高     |
+| 02 | [[file:02-org-index.org][Persistent Org Index]]        | なし        | 大       | 高     |
+| 03 | [[file:03-offload-framework.org][Offload Framework]]           | 01          | 中       | 中     |
+| 04 | [[file:04-pty-broker.org][PTY Broker + Headless UI]]    | なし        | 大       | 中     |
+| 05 | [[file:05-disk-first.org][Disk-First Policy]]           | なし        | 小       | 高     |
+
+* Status Legend
+
+各 doc 冒頭の =STATUS= に以下のいずれかを記す:
+
+- ~DRAFT~ — 設計中、レビュー前
+- ~APPROVED~ — 設計確定、実装着手可
+- ~IN-PROGRESS~ — 実装中 (commit hash 記載)
+- ~SHIPPED~ — master に merge 済
+- ~REVISED~ — 別 doc で置き換え済 (リンク必須)
+
+* Cross-cutting Concerns
+
+** Backward compatibility
+
+既存の MCP tool 名 (~file-read~, ~org-read-headline~ 等) は維持する。内部実装が index 経由に変わっても
+API は同じ。新機能は ~anvil-v2-*~ または ~--v2~ suffix の opt-in とする。
+
+** Observability
+
+全設計で以下を必須とする:
+
+- lifecycle log (append-only、既存の ~anvil-worker.log~ 形式を踏襲)
+- metric counter (dispatch 回数、heavy detect 数、cache hit rate 等)
+- ~M-x anvil-*-status~ の interactive command
+
+** Windows 対応
+
+各 doc の =Platform notes= セクションで Windows 固有の落とし穴を明示する:
+- emacs --batch の cold start が Linux の 5〜10 倍遅い (~500ms〜1s)
+- ~emacsclient~ TCP socket auth は stale file + reused port で hang する (anvil-worker.el で既に対処済)
+- msys bash ↔ native Windows Python の coding-system
+- ConPTY/winpty の制約
+
+* References
+
+- 現行実装: [[file:../../anvil-worker.el][anvil-worker.el]]
+- 現行 README: [[file:../../README.org][README.org]]
+- 初期ダイアログ: (session 2026-04-15, "Emacs の限界を改善する方法を考えてください")

--- a/tests/anvil-new-tools-test.el
+++ b/tests/anvil-new-tools-test.el
@@ -1,0 +1,218 @@
+;;; anvil-new-tools-test.el --- Tests for ert-run, byte-compile, outline, sqlite -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Covers the four token-efficiency MCP tools added 2026-04-15:
+;;   elisp-ert-run, elisp-byte-compile-file, file-outline, sqlite-query.
+;; Each test writes a minimal temp fixture and calls the private
+;; tool function directly (skipping MCP registration) so the tests
+;; run under plain ERT.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil-elisp)
+(require 'anvil-file)
+(require 'anvil-sqlite)
+
+(defun anvil-new-tools-test--write (path content)
+  (let ((coding-system-for-write 'utf-8-unix))
+    (write-region content nil path nil 'silent)))
+
+(defun anvil-new-tools-test--read-plist (str)
+  "Parse STR (output of `format \"%S\"' on a plist) back to a plist."
+  (car (read-from-string str)))
+
+;;;; --- elisp-ert-run --------------------------------------------------------
+
+(ert-deftest anvil-tools-test-ert-run-all-pass ()
+  "A file of passing tests reports :failed=0 and a matching :passed."
+  (let* ((tmp (make-temp-file "anvil-ert-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "(require 'ert)
+(ert-deftest anvil-tools-tmp-a () (should (= 1 1)))
+(ert-deftest anvil-tools-tmp-b () (should-not (= 1 2)))
+")
+          (let* ((out (anvil-elisp--ert-run tmp nil))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should (= 2 (plist-get res :passed)))
+            (should (= 0 (plist-get res :failed)))
+            (should (numberp (plist-get res :elapsed-sec)))))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-ert-run-captures-failure ()
+  "A failing test is reported with :condition text."
+  (let* ((tmp (make-temp-file "anvil-ert-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "(require 'ert)
+(ert-deftest anvil-tools-tmp-fail () (should (= 1 2)))
+")
+          (let* ((out (anvil-elisp--ert-run tmp nil))
+                 (res (anvil-new-tools-test--read-plist out))
+                 (fails (plist-get res :failures)))
+            (should (= 1 (plist-get res :failed)))
+            (should (= 1 (length fails)))
+            (should (stringp (plist-get (car fails) :condition)))))
+      (ignore-errors (delete-file tmp)))))
+
+;;;; --- elisp-byte-compile-file ---------------------------------------------
+
+(ert-deftest anvil-tools-test-byte-compile-clean ()
+  "A clean file compiles with :ok t."
+  (let ((tmp (make-temp-file "anvil-bc-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           ";;; tmp --- x -*- lexical-binding: t; -*-
+;;; Commentary: tmp
+;;; Code:
+(defun anvil-tools-tmp-clean () \"A clean function.\" 1)
+(provide 'tmp)
+;;; tmp ends here
+")
+          (let* ((out (anvil-elisp--byte-compile-file tmp))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should (eq t (plist-get res :ok)))
+            (should (null (plist-get res :errors)))))
+      (ignore-errors (delete-file tmp))
+      (ignore-errors (delete-file (concat (file-name-sans-extension tmp) ".elc"))))))
+
+;;;; --- file-outline ---------------------------------------------------------
+
+(ert-deftest anvil-tools-test-outline-elisp ()
+  "Outline of an Elisp file lists its def-forms."
+  (let ((tmp (make-temp-file "anvil-outline-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "(defvar anvil-tools-tmp-v 1)
+(defun anvil-tools-tmp-fn () 2)
+(defmacro anvil-tools-tmp-m () 3)
+(defcustom anvil-tools-tmp-c 4 \"doc\" :type 'integer)
+")
+          (let* ((out (anvil-file--tool-outline tmp nil))
+                 (res (anvil-new-tools-test--read-plist out))
+                 (items (plist-get res :items))
+                 (names (mapcar (lambda (it) (plist-get it :name)) items)))
+            (should (equal "elisp" (plist-get res :format)))
+            (should (= 4 (plist-get res :count)))
+            (should (member "anvil-tools-tmp-v" names))
+            (should (member "anvil-tools-tmp-fn" names))
+            (should (member "anvil-tools-tmp-m" names))
+            (should (member "anvil-tools-tmp-c" names))))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-outline-org ()
+  "Outline of an org file lists its headlines with h1/h2 kinds."
+  (let ((tmp (make-temp-file "anvil-outline-" nil ".org")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "* Alpha
+** Beta
+* Gamma
+")
+          (let* ((out (anvil-file--tool-outline tmp nil))
+                 (res (anvil-new-tools-test--read-plist out))
+                 (items (plist-get res :items)))
+            (should (equal "org" (plist-get res :format)))
+            (should (= 3 (plist-get res :count)))
+            (should (equal "h1" (plist-get (nth 0 items) :kind)))
+            (should (equal "Alpha" (plist-get (nth 0 items) :name)))
+            (should (equal "h2" (plist-get (nth 1 items) :kind)))
+            (should (equal "Gamma" (plist-get (nth 2 items) :name)))))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-outline-markdown ()
+  "Outline of a Markdown file lists its hash headings."
+  (let ((tmp (make-temp-file "anvil-outline-" nil ".md")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "# One
+## Two
+### Three
+")
+          (let* ((out (anvil-file--tool-outline tmp nil))
+                 (res (anvil-new-tools-test--read-plist out))
+                 (items (plist-get res :items)))
+            (should (equal "markdown" (plist-get res :format)))
+            (should (= 3 (plist-get res :count)))
+            (should (equal "h1" (plist-get (nth 0 items) :kind)))
+            (should (equal "h3" (plist-get (nth 2 items) :kind)))))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-outline-unknown-extension-errors ()
+  "Outline raises an MCP tool error when format cannot be inferred."
+  (let ((tmp (make-temp-file "anvil-outline-" nil ".xyz")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write tmp "whatever\n")
+          (should-error (anvil-file--tool-outline tmp nil)
+                        :type 'anvil-server-tool-error))
+      (ignore-errors (delete-file tmp)))))
+
+;;;; --- sqlite-query ---------------------------------------------------------
+
+(defun anvil-tools-test--have-sqlite ()
+  (and (fboundp 'sqlite-available-p) (sqlite-available-p)))
+
+(ert-deftest anvil-tools-test-sqlite-query-select ()
+  "A SELECT against a seeded DB returns rows."
+  (skip-unless (anvil-tools-test--have-sqlite))
+  (let* ((tmp (make-temp-file "anvil-sql-" nil ".db"))
+         (db (sqlite-open tmp)))
+    (unwind-protect
+        (progn
+          (sqlite-execute db "CREATE TABLE t (id INTEGER, name TEXT)")
+          (sqlite-execute db "INSERT INTO t VALUES (1, 'a'), (2, 'b')")
+          (sqlite-close db)
+          (let* ((out (anvil-sqlite--tool-query
+                       tmp "SELECT id, name FROM t ORDER BY id" nil))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should (= 2 (plist-get res :row-count)))
+            (should (equal '((1 "a") (2 "b")) (plist-get res :rows)))))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-sqlite-query-rejects-write ()
+  "Non-SELECT statements are rejected via `anvil-server-tool-error'."
+  (skip-unless (anvil-tools-test--have-sqlite))
+  (let ((tmp (make-temp-file "anvil-sql-" nil ".db")))
+    (unwind-protect
+        (progn
+          (let ((db (sqlite-open tmp)))
+            (sqlite-execute db "CREATE TABLE t (id INTEGER)")
+            (sqlite-close db))
+          (should-error
+           (anvil-sqlite--tool-query tmp "INSERT INTO t VALUES (1)" nil)
+           :type 'anvil-server-tool-error))
+      (ignore-errors (delete-file tmp)))))
+
+(ert-deftest anvil-tools-test-sqlite-query-with-params ()
+  "Parameterized queries accept a JSON array of bind values."
+  (skip-unless (anvil-tools-test--have-sqlite))
+  (let ((tmp (make-temp-file "anvil-sql-" nil ".db")))
+    (unwind-protect
+        (progn
+          (let ((db (sqlite-open tmp)))
+            (sqlite-execute db "CREATE TABLE t (id INTEGER, name TEXT)")
+            (sqlite-execute db "INSERT INTO t VALUES (1, 'foo'), (2, 'bar')")
+            (sqlite-close db))
+          (let* ((out (anvil-sqlite--tool-query
+                       tmp "SELECT name FROM t WHERE id = ?" "[2]"))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should (= 1 (plist-get res :row-count)))
+            (should (equal '(("bar")) (plist-get res :rows)))))
+      (ignore-errors (delete-file tmp)))))
+
+;;; anvil-new-tools-test.el ends here

--- a/tests/anvil-org-index-test.el
+++ b/tests/anvil-org-index-test.el
@@ -429,4 +429,101 @@ Uses a shell `touch' via `set-file-times' for portability."
       (ignore-errors (anvil-org-index-disable))
       (ignore-errors (delete-directory tmpdir t)))))
 
+;;;; Phase 4a — fast-path readers
+
+(defun anvil-org-index-test--seed (root)
+  "Write a small org file under ROOT and return its absolute path."
+  (let ((f (expand-file-name "fp.org" root)))
+    (anvil-org-index-test--write
+     f
+     "* Alpha
+:PROPERTIES:
+:ID: id-alpha
+:END:
+Alpha body
+** Beta
+:PROPERTIES:
+:ID: id-beta
+:END:
+Beta body
+** Beta
+Duplicate title, no ID
+* Gamma
+:PROPERTIES:
+:ID: id-gamma
+:END:
+Gamma body line
+")
+    f))
+
+(defmacro anvil-org-index-test--with-seeded (body-var &rest body)
+  "Seed a temp index into DB and bind BODY-VAR to the seeded org path, then run BODY."
+  (declare (indent 1))
+  `(let* ((tmpdir (make-temp-file "anvil-idx-fp-" t))
+          (db (expand-file-name "i.db" tmpdir))
+          (,body-var nil)
+          (anvil-org-index-db-path db)
+          (anvil-org-index-paths (list tmpdir))
+          (anvil-org-index--backend nil)
+          (anvil-org-index--db nil))
+     (unwind-protect
+         (progn
+           (setq ,body-var (anvil-org-index-test--seed tmpdir))
+           (anvil-org-index-enable)
+           (anvil-org-index-rebuild)
+           ,@body)
+       (ignore-errors (anvil-org-index-disable))
+       (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-read-by-id-returns-body ()
+  "read-by-id returns the body section including properties drawer."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded _f
+    (let ((txt (anvil-org-index-read-by-id "id-beta")))
+      (should (string-match-p "^\\*\\* Beta" txt))
+      (should (string-match-p "Beta body" txt))
+      (should-not (string-match-p "Gamma" txt)))))
+
+(ert-deftest anvil-org-index-test-read-by-id-missing-errors ()
+  "read-by-id signals user-error on unknown ID."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded _f
+    (should-error (anvil-org-index-read-by-id "no-such-id"))))
+
+(ert-deftest anvil-org-index-test-read-headline-top-level ()
+  "read-headline resolves a top-level title and returns its body."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded f
+    (let ((txt (anvil-org-index-read-headline f "Alpha")))
+      (should (string-match-p "^\\* Alpha" txt))
+      (should (string-match-p "Alpha body" txt))
+      ;; Alpha's subtree includes both Beta children
+      (should (string-match-p "^\\*\\* Beta" txt)))))
+
+(ert-deftest anvil-org-index-test-read-headline-nested ()
+  "read-headline walks a nested slash-separated path."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded f
+    ;; With the duplicate "Beta", the top-level Alpha/Beta path is
+    ;; ambiguous — the tool must signal rather than guess.
+    (should-error (anvil-org-index-read-headline f "Alpha/Beta"))))
+
+(ert-deftest anvil-org-index-test-read-outline-orders-and-tags ()
+  "read-outline returns a level/title list in document order."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded f
+    (let* ((outline (anvil-org-index-read-outline f))
+           (levels  (mapcar (lambda (p) (plist-get p :level)) outline))
+           (titles  (mapcar (lambda (p) (plist-get p :title)) outline)))
+      (should (equal '(1 2 2 1) levels))
+      (should (equal '("Alpha" "Beta" "Beta" "Gamma") titles)))))
+
+(ert-deftest anvil-org-index-test-read-outline-missing-errors ()
+  "read-outline signals when the file is not indexed."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded _f
+    (should-error
+     (anvil-org-index-read-outline
+      (expand-file-name "never-indexed.org" temporary-file-directory)))))
+
 ;;; anvil-org-index-test.el ends here

--- a/tests/anvil-org-index-test.el
+++ b/tests/anvil-org-index-test.el
@@ -294,4 +294,139 @@ Uses a shell `touch' via `set-file-times' for portability."
       (ignore-errors (anvil-org-index-disable))
       (ignore-errors (delete-directory tmpdir t)))))
 
+;;;; Phase 3 — filesystem watcher
+
+(ert-deftest anvil-org-index-test-collect-dirs-includes-only-org-bearing ()
+  "collect-dirs returns directories that hold .org files and skips others."
+  (let* ((root (make-temp-file "anvil-idx-watch-" t))
+         (with-org   (expand-file-name "a" root))
+         (with-org-2 (expand-file-name "a/b" root))
+         (empty      (expand-file-name "empty" root))
+         (anvil-org-index-paths (list root)))
+    (unwind-protect
+        (progn
+          (make-directory with-org-2 t)
+          (make-directory empty t)
+          (anvil-org-index-test--write
+           (expand-file-name "top.org" with-org) "* x\n")
+          (anvil-org-index-test--write
+           (expand-file-name "nested.org" with-org-2) "* y\n")
+          (let* ((dirs (mapcar #'file-name-as-directory
+                               (anvil-org-index--collect-dirs)))
+                 (want (list (file-name-as-directory with-org)
+                             (file-name-as-directory with-org-2))))
+            (should (cl-every (lambda (d) (member d dirs)) want))
+            (should-not
+             (member (file-name-as-directory empty) dirs))))
+      (ignore-errors (delete-directory root t)))))
+
+(ert-deftest anvil-org-index-test-schedule-refresh-coalesces ()
+  "Two scheduled refreshes for the same path leave one active timer."
+  (let ((anvil-org-index--refresh-timer-map (make-hash-table :test 'equal))
+        (anvil-org-index-watch-debounce-seconds 60.0)
+        (path "/tmp/nonexistent-test-path.org"))
+    (unwind-protect
+        (progn
+          (anvil-org-index--schedule-refresh path)
+          (let ((first (gethash path anvil-org-index--refresh-timer-map)))
+            (should (timerp first))
+            (anvil-org-index--schedule-refresh path)
+            (let ((second (gethash path
+                                   anvil-org-index--refresh-timer-map)))
+              (should (timerp second))
+              (should-not (eq first second)))))
+      (maphash (lambda (_k tm) (when (timerp tm) (cancel-timer tm)))
+               anvil-org-index--refresh-timer-map))))
+
+(ert-deftest anvil-org-index-test-on-file-event-triggers-schedule ()
+  "A synthesized .org file-notify event pushes a timer into the map."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-evt-" t))
+         (f (expand-file-name "watched.org" tmpdir))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index-watch-debounce-seconds 60.0)
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil)
+         (anvil-org-index--refresh-timer-map
+          (make-hash-table :test 'equal)))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write f "* one\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          (anvil-org-index--on-file-event (list 'dummy 'changed f))
+          (should (gethash (expand-file-name f)
+                           anvil-org-index--refresh-timer-map)))
+      (maphash (lambda (_k tm) (when (timerp tm) (cancel-timer tm)))
+               anvil-org-index--refresh-timer-map)
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-on-file-event-ignores-non-org ()
+  "Events for non-.org files do not schedule a refresh."
+  (let ((anvil-org-index--refresh-timer-map (make-hash-table :test 'equal)))
+    (anvil-org-index--on-file-event
+     (list 'dummy 'changed "/tmp/readme.md"))
+    (should (zerop (hash-table-count
+                    anvil-org-index--refresh-timer-map)))))
+
+(ert-deftest anvil-org-index-test-perform-refresh-reindexes ()
+  "perform-refresh picks up on-disk changes without waiting on the timer."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-perf-" t))
+         (f (expand-file-name "a.org" tmpdir))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil)
+         (anvil-org-index--refresh-timer-map
+          (make-hash-table :test 'equal)))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write f "* one\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          (anvil-org-index-test--write f "* one\n* two\n")
+          (anvil-org-index-test--touch-future f 5)
+          (anvil-org-index--perform-refresh f)
+          (should (= 2 (caar (anvil-org-index--select
+                              anvil-org-index--db
+                              "SELECT COUNT(*) FROM headline"))))
+          (should (zerop (hash-table-count
+                          anvil-org-index--refresh-timer-map))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-watch-and-unwatch-lifecycle ()
+  "watch creates descriptors; unwatch clears them and the timer map."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (skip-unless (require 'filenotify nil t))
+  (let* ((tmpdir (make-temp-file "anvil-idx-watch-lc-" t))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index-periodic-scan-seconds 0)
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil)
+         (anvil-org-index--watch-descriptors nil)
+         (anvil-org-index--refresh-timer-map
+          (make-hash-table :test 'equal)))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write
+           (expand-file-name "one.org" tmpdir) "* one\n")
+          (let ((dirs (anvil-org-index-watch)))
+            (should (>= (length dirs) 1))
+            (should (>= (length anvil-org-index--watch-descriptors) 1)))
+          (anvil-org-index-unwatch)
+          (should-not anvil-org-index--watch-descriptors)
+          (should (zerop (hash-table-count
+                          anvil-org-index--refresh-timer-map))))
+      (ignore-errors (anvil-org-index-unwatch))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
 ;;; anvil-org-index-test.el ends here

--- a/tests/anvil-org-index-test.el
+++ b/tests/anvil-org-index-test.el
@@ -1,0 +1,175 @@
+;;; anvil-org-index-test.el --- Tests for anvil-org-index -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Scanner unit tests and a rebuild smoke test that writes a temporary
+;; org file, ingests it, and verifies the resulting rows.  The rebuild
+;; test is skipped gracefully on Emacs < 29 without built-in sqlite.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil-org-index)
+
+;;;; Scanner unit tests
+
+(defun anvil-org-index-test--scan (content)
+  "Return the headline plist list produced by scanning CONTENT."
+  (with-temp-buffer
+    (insert content)
+    (anvil-org-index--scan-buffer)))
+
+(ert-deftest anvil-org-index-test-scan-basic-headline ()
+  "A single top-level headline is captured with level and title."
+  (let* ((res (anvil-org-index-test--scan "* Hello world\n"))
+         (hl  (car res)))
+    (should (= 1 (length res)))
+    (should (= 1 (plist-get hl :level)))
+    (should (equal "Hello world" (plist-get hl :title)))
+    (should (null (plist-get hl :todo)))
+    (should (null (plist-get hl :tags)))))
+
+(ert-deftest anvil-org-index-test-scan-todo-priority-tags ()
+  "TODO keyword, priority cookie and trailing tags are stripped from title."
+  (let* ((res (anvil-org-index-test--scan
+               "** TODO [#A] Ship the feature   :work:urgent:\n"))
+         (hl  (car res)))
+    (should (= 2 (plist-get hl :level)))
+    (should (equal "TODO" (plist-get hl :todo)))
+    (should (equal "A"    (plist-get hl :priority)))
+    (should (equal "Ship the feature" (plist-get hl :title)))
+    (should (equal '("work" "urgent") (plist-get hl :tags)))))
+
+(ert-deftest anvil-org-index-test-scan-done-keyword ()
+  "DONE is recognized as a TODO state."
+  (let* ((res (anvil-org-index-test--scan "* DONE Finished task\n"))
+         (hl  (car res)))
+    (should (equal "DONE" (plist-get hl :todo)))
+    (should (equal "Finished task" (plist-get hl :title)))))
+
+(ert-deftest anvil-org-index-test-scan-non-todo-uppercase-not-stripped ()
+  "Arbitrary leading uppercase word that is not a TODO keyword stays in title."
+  (let* ((res (anvil-org-index-test--scan "* FOO matters\n"))
+         (hl  (car res)))
+    (should (null (plist-get hl :todo)))
+    (should (equal "FOO matters" (plist-get hl :title)))))
+
+(ert-deftest anvil-org-index-test-scan-properties-and-id ()
+  "PROPERTIES drawer entries are collected; :ID: also lifted to :org-id."
+  (let* ((content "* Item
+:PROPERTIES:
+:ID:       abc-123
+:CATEGORY: work
+:END:
+")
+         (res (anvil-org-index-test--scan content))
+         (hl  (car res))
+         (props (plist-get hl :properties)))
+    (should (equal "abc-123" (plist-get hl :org-id)))
+    (should (equal "abc-123" (cdr (assoc "ID" props))))
+    (should (equal "work"    (cdr (assoc "CATEGORY" props))))))
+
+(ert-deftest anvil-org-index-test-scan-scheduled-deadline ()
+  "SCHEDULED and DEADLINE timestamps attach to the current headline."
+  (let* ((content "* Task
+SCHEDULED: <2026-04-15 Wed> DEADLINE: <2026-04-20 Mon>
+"))
+    (let ((hl (car (anvil-org-index-test--scan content))))
+      (should (equal "<2026-04-15 Wed>" (plist-get hl :scheduled)))
+      (should (equal "<2026-04-20 Mon>" (plist-get hl :deadline))))))
+
+(ert-deftest anvil-org-index-test-scan-multiple-headlines-nested ()
+  "Level order and count are preserved across nested siblings."
+  (let* ((content "* Parent
+** Child 1
+** Child 2
+*** Grandchild
+* Sibling
+")
+         (res (anvil-org-index-test--scan content))
+         (levels (mapcar (lambda (p) (plist-get p :level)) res)))
+    (should (= 5 (length res)))
+    (should (equal '(1 2 2 3 1) levels))))
+
+(ert-deftest anvil-org-index-test-scan-line-ranges ()
+  "line-start and line-end bracket the headline body correctly."
+  (let* ((content "* One\nbody\n* Two\nmore\n"))
+    (let ((res (anvil-org-index-test--scan content)))
+      (should (= 1 (plist-get (nth 0 res) :line-start)))
+      (should (= 2 (plist-get (nth 0 res) :line-end)))
+      (should (= 3 (plist-get (nth 1 res) :line-start))))))
+
+;;;; Parent-child linking via stack
+
+(ert-deftest anvil-org-index-test-parent-link-from-ingest ()
+  "Stack-based parent resolution matches expected parent indices.
+This exercises the same traversal logic used in
+`anvil-org-index--ingest-file' without requiring a DB."
+  (let* ((content "* A
+** A1
+*** A1a
+** A2
+* B
+")
+         (headlines (anvil-org-index-test--scan content))
+         (parents nil)
+         (stack nil)
+         (i 0))
+    (dolist (hl headlines)
+      (let ((level (plist-get hl :level)))
+        (while (and stack (>= (caar stack) level))
+          (pop stack))
+        (push (and stack (cdar stack)) parents)
+        (push (cons level i) stack)
+        (cl-incf i)))
+    (setq parents (nreverse parents))
+    ;; indices:   0=A  1=A1  2=A1a  3=A2  4=B
+    ;; parents:  nil    0     1      0   nil
+    (should (equal '(nil 0 1 0 nil) parents))))
+
+;;;; DB smoke test — skipped if no sqlite backend
+
+(defun anvil-org-index-test--have-sqlite ()
+  (and (fboundp 'sqlite-available-p) (sqlite-available-p)))
+
+(ert-deftest anvil-org-index-test-rebuild-roundtrip ()
+  "Write temp org, rebuild index, verify counts via status queries."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-org-index-test-" t))
+         (orgfile (expand-file-name "sample.org" tmpdir))
+         (dbfile (expand-file-name "test-index.db" tmpdir))
+         (anvil-org-index-db-path dbfile)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil))
+    (unwind-protect
+        (progn
+          (let ((coding-system-for-write 'utf-8-unix))
+            (write-region
+             "* TODO [#B] One :alpha:
+:PROPERTIES:
+:ID: root-1
+:END:
+SCHEDULED: <2026-04-15 Wed>
+** DONE Two :alpha:beta:
+* Sibling
+"
+             nil orgfile nil 'silent))
+          (anvil-org-index-enable)
+          (let ((summary (anvil-org-index-rebuild)))
+            (should (= 1 (plist-get summary :files)))
+            (should (= 3 (plist-get summary :headlines))))
+          (let ((rows (anvil-org-index--select
+                       anvil-org-index--db
+                       "SELECT title, todo, priority, org_id FROM headline ORDER BY line_start")))
+            (should (equal '("One" "TODO" "B" "root-1") (car rows)))
+            (should (equal '("Two" "DONE" nil nil)      (cadr rows)))
+            (should (equal '("Sibling" nil nil nil)     (caddr rows))))
+          (let ((tag-rows (anvil-org-index--select
+                           anvil-org-index--db
+                           "SELECT DISTINCT tag FROM tag ORDER BY tag")))
+            (should (equal '(("alpha") ("beta")) tag-rows))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+;;; anvil-org-index-test.el ends here

--- a/tests/anvil-org-index-test.el
+++ b/tests/anvil-org-index-test.el
@@ -172,4 +172,126 @@ SCHEDULED: <2026-04-15 Wed>
       (ignore-errors (anvil-org-index-disable))
       (ignore-errors (delete-directory tmpdir t)))))
 
+;;;; Phase 2 — incremental refresh
+
+(defun anvil-org-index-test--write (path content)
+  "Write CONTENT to PATH as UTF-8."
+  (let ((coding-system-for-write 'utf-8-unix))
+    (write-region content nil path nil 'silent)))
+
+(defun anvil-org-index-test--touch-future (path seconds)
+  "Set PATH mtime to SECONDS in the future of its current mtime.
+Uses a shell `touch' via `set-file-times' for portability."
+  (let* ((attrs (file-attributes path))
+         (now   (float-time (file-attribute-modification-time attrs)))
+         (new   (seconds-to-time (+ now seconds))))
+    (set-file-times path new new)))
+
+(ert-deftest anvil-org-index-test-refresh-unchanged-is-noop ()
+  "refresh-if-stale on an unchanged file reports outcome=unchanged."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-" t))
+         (f (expand-file-name "a.org" tmpdir))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write f "* One\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          (let ((res (anvil-org-index-refresh-if-stale f)))
+            (should (eq 'unchanged (plist-get res :outcome)))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-refresh-detects-modification ()
+  "Touching a file to a newer mtime triggers reindex."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-" t))
+         (f (expand-file-name "a.org" tmpdir))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write f "* One\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          (should (= 1 (caar (anvil-org-index--select
+                              anvil-org-index--db
+                              "SELECT COUNT(*) FROM headline"))))
+          (anvil-org-index-test--write f "* One\n* Two\n")
+          (anvil-org-index-test--touch-future f 5)
+          (let ((res (anvil-org-index-refresh-if-stale f)))
+            (should (eq 'reindexed (plist-get res :outcome))))
+          (should (= 2 (caar (anvil-org-index--select
+                              anvil-org-index--db
+                              "SELECT COUNT(*) FROM headline")))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-refresh-removes-deleted-file ()
+  "Deleting a file from disk then refreshing drops its rows."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-" t))
+         (f (expand-file-name "a.org" tmpdir))
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write f "* One\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          (delete-file f)
+          (let ((res (anvil-org-index-refresh-if-stale)))
+            (should (= 0 (plist-get res :scanned)))
+            (should (= 1 (plist-get res :removed))))
+          (should (= 0 (caar (anvil-org-index--select
+                              anvil-org-index--db
+                              "SELECT COUNT(*) FROM file")))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-index-test-refresh-all-mixed-changes ()
+  "refresh-all handles added / reindexed / removed / unchanged together."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (let* ((tmpdir (make-temp-file "anvil-idx-" t))
+         (a (expand-file-name "a.org" tmpdir))  ; unchanged
+         (b (expand-file-name "b.org" tmpdir))  ; will be modified
+         (c (expand-file-name "c.org" tmpdir))  ; will be deleted
+         (d (expand-file-name "d.org" tmpdir))  ; will be added
+         (db (expand-file-name "i.db" tmpdir))
+         (anvil-org-index-db-path db)
+         (anvil-org-index-paths (list tmpdir))
+         (anvil-org-index--backend nil)
+         (anvil-org-index--db nil))
+    (unwind-protect
+        (progn
+          (anvil-org-index-test--write a "* A\n")
+          (anvil-org-index-test--write b "* B\n")
+          (anvil-org-index-test--write c "* C\n")
+          (anvil-org-index-enable)
+          (anvil-org-index-rebuild)
+          ;; mutate
+          (anvil-org-index-test--write b "* B\n* B2\n")
+          (anvil-org-index-test--touch-future b 5)
+          (delete-file c)
+          (anvil-org-index-test--write d "* D\n")
+          (let ((res (anvil-org-index-refresh-if-stale)))
+            (should (= 3 (plist-get res :scanned)))  ; a b d on disk
+            (should (= 1 (plist-get res :added)))
+            (should (= 1 (plist-get res :reindexed)))
+            (should (= 1 (plist-get res :removed)))
+            (should (= 1 (plist-get res :unchanged)))))
+      (ignore-errors (anvil-org-index-disable))
+      (ignore-errors (delete-directory tmpdir t)))))
+
 ;;; anvil-org-index-test.el ends here


### PR DESCRIPTION
## Summary

Three commits.

**Design** (commit 1): five design docs under `docs/design/` — worker pool v2, persistent org index, offload framework, PTY broker, disk-first policy — with ordering, dependencies, and references to the prior incidents motivating each item.

**Phase 1** (commit 2): new opt-in `anvil-org-index` module. Pure-regexp single-pass scanner populates a SQLite index of headlines / tags / properties / org-IDs / timestamps. Lets MCP read tools avoid re-parsing multi-MB org files.

**Phase 2** (commit 3): `anvil-org-index-refresh-if-stale` — mtime-based incremental refresh. Cheap enough to invoke as a pre-read step. Handles added / reindexed / removed / unchanged in one transactional sweep.

Backend choice at enable time: built-in sqlite on Emacs 29+, emacsql stub on 28.2. Transactions are raw `BEGIN/COMMIT/ROLLBACK` so the module compiles cleanly on 29.x and 30.x regardless of whether `with-sqlite-transaction` is present. DB lives at `~/.emacs.d/anvil-org-index.db`, following the org-roam / vulpea convention.

Fully opt-in — not wired into `anvil-enable` yet. Phase 3 (filesystem watcher) and Phase 4 (swap existing `org-read-*` MCP tools to index-first) come next.

### Real-world smoke
On `~/Cowork/Notes/capture` (1278 files, 69,675 headlines):

| operation | time |
|---|---|
| full rebuild | 2.39 s |
| refresh, no changes | 0.15 s (~16× faster) |

Design target was < 60 s per 1000 files — so ~25× headroom on rebuild, with refresh effectively free.

## Test plan

- [x] 14 ERT tests — scanner parsing, DB roundtrip, refresh semantics (unchanged / modified / deleted / mixed batch)
- [x] All 31 tests pass (14 new + 17 existing) under `emacs --batch -Q`
- [x] `anvil-org-index.el` byte-compiles clean
- [x] Real-data rebuild + refresh on `~/Cowork/Notes/capture` succeeds
- [ ] Exercise from a live anvil session (reviewer)

## What's next

- Phase 3: filesystem watcher via `filenotify`
- Phase 4: swap existing `org-read-*` MCP tools to index-first lookup

See `docs/design/02-org-index.org` for the full roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)