### PR TITLE
feat(org-index): full-depth JSON outline fast-path (Phase 4c)

### DIFF
--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -856,6 +856,54 @@ re-parsing with org-element for large files that rarely change."
                  :line  (nth 4 row))))
        rows))))
 
+(defun anvil-org-index--outline-build-tree (flat)
+  "Build a hierarchical alist tree from FLAT outline list.
+FLAT is the list returned by `anvil-org-index-read-outline', each
+element a plist with :level and :title.  Returns a vector of alists
+with keys title, level, children (full depth, populated)."
+  (let* ((root (list (cons :level 0) (cons :children nil)))
+         (stack (list root)))
+    (dolist (node flat)
+      (let* ((lv (plist-get node :level))
+             (entry (list (cons :level lv)
+                          (cons :title (plist-get node :title))
+                          (cons :children nil))))
+        ;; Pop deeper/equal-level frames so the top is a strict parent.
+        (while (and (cdr stack)
+                    (>= (alist-get :level (car stack)) lv))
+          (pop stack))
+        (let ((children-cell (assq :children (car stack))))
+          (setcdr children-cell
+                  (append (cdr children-cell) (list entry))))
+        (push entry stack)))
+    (anvil-org-index--outline-nodes-to-json
+     (alist-get :children root))))
+
+(defun anvil-org-index--outline-nodes-to-json (nodes)
+  "Convert internal NODES list to a JSON-ready vector of alists.
+Uses symbol keys (title, level, children) compatible with
+`anvil-org--generate-outline' output."
+  (vconcat
+   (mapcar
+    (lambda (node)
+      `((title    . ,(alist-get :title node))
+        (level    . ,(alist-get :level node))
+        (children . ,(anvil-org-index--outline-nodes-to-json
+                      (alist-get :children node)))))
+    nodes)))
+
+;;;###autoload
+(defun anvil-org-index-read-outline-json (file)
+  "Return a hierarchical outline of FILE as a JSON string.
+Shape matches `anvil-org--generate-outline':
+  {\"headings\": [{\"title\":..,\"level\":..,\"children\":[..]}..]}
+but populates children at full depth instead of only two levels.
+Cheap fast-path for large files already in the index."
+  (require 'json)
+  (let* ((flat (anvil-org-index-read-outline file))
+         (tree (anvil-org-index--outline-build-tree flat)))
+    (json-encode `((headings . ,tree)))))
+
 ;;;###autoload
 (defun anvil-org-index-status ()
   "Show a summary of the current index state."

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1226,10 +1226,12 @@ FILE is the absolute path to an Org file.
 
 MCP Parameters:
   file - Absolute path to an Org file"
-  (anvil-org--handle-outline-resource `(("filename" . ,file))))
+  (or (anvil-org--try-index-read-outline file)
+      (anvil-org--handle-outline-resource `(("filename" . ,file)))))
 
-(declare-function anvil-org-index-read-by-id    "anvil-org-index" (org-id))
-(declare-function anvil-org-index-read-headline  "anvil-org-index" (file path))
+(declare-function anvil-org-index-read-by-id       "anvil-org-index" (org-id))
+(declare-function anvil-org-index-read-headline    "anvil-org-index" (file path))
+(declare-function anvil-org-index-read-outline-json "anvil-org-index" (file))
 
 (defun anvil-org--index-available-p ()
   "Return non-nil when the `anvil-org-index' fast-path can be tried.
@@ -1253,6 +1255,13 @@ A nil return means fall back to the org-element handler."
   (when (anvil-org--index-available-p)
     (condition-case _err
         (anvil-org-index-read-headline file headline-path)
+      (error nil))))
+
+(defun anvil-org--try-index-read-outline (file)
+  "Try `anvil-org-index-read-outline-json'; return JSON string or nil."
+  (when (anvil-org--index-available-p)
+    (condition-case _err
+        (anvil-org-index-read-outline-json file)
       (error nil))))
 
 (defun anvil-org--tool-read-headline (file headline_path)

--- a/tests/anvil-org-index-test.el
+++ b/tests/anvil-org-index-test.el
@@ -9,6 +9,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'json)
 (require 'anvil-org-index)
 
 ;;;; Scanner unit tests
@@ -525,5 +526,72 @@ Gamma body line
     (should-error
      (anvil-org-index-read-outline
       (expand-file-name "never-indexed.org" temporary-file-directory)))))
+
+;;;; Phase 4c: outline -> JSON tree builder
+
+(defun anvil-org-index-test--flat (&rest entries)
+  "Build a flat plist list from ENTRIES of (LEVEL TITLE)."
+  (mapcar (lambda (e) (list :level (nth 0 e) :title (nth 1 e))) entries))
+
+(ert-deftest anvil-org-index-test-outline-tree-empty ()
+  "An empty flat list produces an empty children vector."
+  (let ((tree (anvil-org-index--outline-build-tree nil)))
+    (should (vectorp tree))
+    (should (= 0 (length tree)))))
+
+(ert-deftest anvil-org-index-test-outline-tree-siblings ()
+  "Same-level siblings land under the same parent."
+  (let* ((flat (anvil-org-index-test--flat '(1 "A") '(1 "B") '(1 "C")))
+         (tree (anvil-org-index--outline-build-tree flat)))
+    (should (= 3 (length tree)))
+    (should (equal "A" (alist-get 'title (aref tree 0))))
+    (should (equal "C" (alist-get 'title (aref tree 2))))
+    (should (= 0 (length (alist-get 'children (aref tree 1)))))))
+
+(ert-deftest anvil-org-index-test-outline-tree-full-depth ()
+  "Nesting is populated at full depth, not clipped to two levels."
+  (let* ((flat (anvil-org-index-test--flat
+                '(1 "A") '(2 "A1") '(3 "A1a") '(3 "A1b") '(2 "A2")))
+         (tree (anvil-org-index--outline-build-tree flat))
+         (a  (aref tree 0))
+         (a1 (aref (alist-get 'children a) 0))
+         (a2 (aref (alist-get 'children a) 1)))
+    (should (equal "A"  (alist-get 'title a)))
+    (should (equal "A1" (alist-get 'title a1)))
+    (should (equal "A2" (alist-get 'title a2)))
+    (should (= 2 (length (alist-get 'children a1))))
+    (should (equal "A1a"
+                   (alist-get 'title
+                              (aref (alist-get 'children a1) 0))))))
+
+(ert-deftest anvil-org-index-test-outline-tree-skip-levels ()
+  "Jumping from level 1 to level 3 still nests under level 1."
+  (let* ((flat (anvil-org-index-test--flat '(1 "A") '(3 "deep") '(1 "B")))
+         (tree (anvil-org-index--outline-build-tree flat))
+         (a (aref tree 0)))
+    (should (= 2 (length tree)))
+    (should (= 1 (length (alist-get 'children a))))
+    (should (equal "deep"
+                   (alist-get 'title
+                              (aref (alist-get 'children a) 0))))))
+
+(ert-deftest anvil-org-index-test-read-outline-json-shape ()
+  "read-outline-json returns a JSON object with a headings vector."
+  (skip-unless (anvil-org-index-test--have-sqlite))
+  (anvil-org-index-test--with-seeded f
+    (let* ((json-object-type 'alist)
+           (json-array-type  'vector)
+           (obj  (json-read-from-string
+                  (anvil-org-index-read-outline-json f)))
+           (hds  (alist-get 'headings obj))
+           (alpha (aref hds 0))
+           (gamma (aref hds 1)))
+      (should (= 2 (length hds)))
+      (should (equal "Alpha" (alist-get 'title alpha)))
+      (should (equal "Gamma" (alist-get 'title gamma)))
+      (should (= 2 (length (alist-get 'children alpha))))
+      (should (equal "Beta"
+                     (alist-get 'title
+                                (aref (alist-get 'children alpha) 0)))))))
 
 ;;; anvil-org-index-test.el ends here


### PR DESCRIPTION
## Summary

- Add `anvil-org-index-read-outline-json`, a fast-path renderer that emits the hierarchical outline JSON the `org-read-outline` MCP tool has always advertised.
- Wire `anvil-org--tool-read-outline` through the established `(or (try-index) (fallback))` pattern so indexed files skip the `org-mode` load + full-buffer parse.
- The fast-path emits **full-depth** children; the previous org-element code clipped the tree at level 2. JSON shape is identical (`{headings: [{title, level, children}...]}`).

## Benchmarks (main daemon, reloaded at HEAD)

| file                  | headlines | index | fallback | speedup |
|-----------------------|-----------|-------|----------|---------|
| journals-2025.org     |   2,382   | 0.14s | 0.49s    | **3.6x** |
| newDTW.org            |   4,582   | 0.21s | 1.60s    | **7.7x** |
| raindrop_index.org    |   5,857   | 0.37s | 2.45s    | **6.6x** |

Fallback measured against `with-temp-buffer + org-mode + anvil-org--extract-headings` (i.e. the non-URI-validated core of the original handler).

## Test plan

- [x] `ert-run-tests-batch-and-exit` on `tests/anvil-org-index-test.el` — 31/31 passing (26 prior + 5 new).
- [x] `ert-run-tests-batch-and-exit` on `tests/anvil-new-tools-test.el` — 10/10 passing (no regressions).
- [x] Manual reload in main daemon, benchmarks above.
- [x] `anvil-org-index-watch` enabled on `~/Cowork/Notes/` (25 watchers + periodic timer) for real-world soak alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)