### PR TITLE
fix(file): stringify file-read MCP result

### DIFF
--- a/anvil-file.el
+++ b/anvil-file.el
@@ -1072,7 +1072,7 @@ MCP Parameters:
           (lim (if (and limit (not (string-empty-p limit)))
                    (string-to-number limit)
                  nil)))
-      (anvil-file-read path off lim))))
+      (format "%S" (anvil-file-read path off lim)))))
 
 (defun anvil-file--tool-append (path content)
   "Append CONTENT to end of file at PATH.


### PR DESCRIPTION
## Summary

This fixes `file-read` so its MCP handler returns a string instead of a raw plist.

## Problem

`anvil-file--tool-read` calls `anvil-file-read`, which returns a plist.

However, `anvil-server--handle-tools-call` requires tool handlers to return
either a string or `nil`, so `file-read` currently fails with:

`Tool handler must return string or nil, got: cons`

## Fix

Wrap the `anvil-file-read` result with `format "%S"` in
`anvil-file--tool-read`.

This matches the existing pattern already used by the other `file-*` MCP
wrappers that return plist data.

## Notes

This is a minimal fix only. It does not change the underlying `file-read`
payload shape; it only makes the MCP return type valid.