### PR TITLE
feat(http): Doc 09 Phase 1a — anvil-http MVP (GET/HEAD + ETag/TTL cache)

### DIFF
--- a/README.ja.org
+++ b/README.ja.org
@@ -479,6 +479,7 @@ Anvil を使うと:
 | =elisp=      | エージェント向け Elisp 開発ツール（オプション）| —                |
 | =browser=    | agent-browser 経由の Web fetch / interact / capture / screenshot（オプション） | agent-browser CLI |
 | =state=      | モジュール共通の永続 SQLite KV ストア（ns / TTL、オプション） | Emacs 29+        |
+| =http=       | =url-retrieve= 経由の GET/HEAD、ETag/TTL cache（オプション） | Emacs 29+（state 依存） |
 
 * クイックスタート
 

--- a/README.org
+++ b/README.org
@@ -500,6 +500,7 @@ budget goes to reasoning about your code, not re-reading it.
 | =elisp=      | Agentic Elisp development tools (optional)     | —                |
 | =browser=    | Web fetch / interact / capture / screenshot via agent-browser (opt.) | agent-browser CLI |
 | =state=      | Persistent SQLite-backed KV store (ns / TTL, opt.) | Emacs 29+        |
+| =http=       | GET/HEAD with ETag/TTL cache via `url-retrieve' (opt.) | Emacs 29+ (state) |
 
 * Quick Start
 

--- a/anvil-http.el
+++ b/anvil-http.el
@@ -1,0 +1,620 @@
+;;; anvil-http.el --- HTTP client for anvil -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 zawatton
+
+;; This file is part of anvil.el.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Lightweight wrapper around Emacs' built-in `url-retrieve-synchronously'
+;; exposing three MCP tools — `http-fetch' (GET), `http-head' (HEAD) and
+;; `http-cache-clear' — for LLM clients that need to fetch static HTTP
+;; resources without paying for a full browser session.
+;;
+;; Design doc: docs/design/09-http.org.
+;;
+;; Name-collision note: `anvil-net' is unrelated — it inspects listening
+;; sockets (netstat / ss / lsof wrapper).  HTTP client concerns live here.
+;;
+;; Phase 1a scope (this file):
+;;   * `anvil-http-get' / `anvil-http-head' / `anvil-http-cache-clear'
+;;     Elisp API + matching MCP tools
+;;   * SQLite-backed cache via `anvil-state' (ns = "http")
+;;   * Conditional GET: If-None-Match / If-Modified-Since on revalidate,
+;;     304 serves body from cache and refreshes fetched-at
+;;   * TTL fast path (`anvil-http-cache-ttl-sec'): within-window fetches
+;;     never touch the network
+;;   * Retry on 5xx / 408 / 429 with exponential backoff
+;;     (`Retry-After' honoured for 429)
+;;   * `url-max-redirections' clamped to 5, http/https-only
+;;
+;; Phase 1b+ (not in this sub-phase): selector / json-path extract,
+;; body-overflow to disk, header-filter, batch fetch, robots.txt.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+(require 'url)
+(require 'url-http)
+(require 'url-util)
+(require 'anvil-server)
+(require 'anvil-state)
+
+;; `anvil-version' is defined in anvil.el; we only read it in the
+;; User-Agent default so soft-require it to avoid a load-order dep.
+(defvar anvil-version)
+
+;;;; --- configuration ------------------------------------------------------
+
+(defgroup anvil-http nil
+  "HTTP client MCP tools for anvil."
+  :group 'anvil
+  :prefix "anvil-http-")
+
+(defconst anvil-http--server-id "emacs-eval"
+  "MCP server id that anvil-http tools register under.
+Shared with anvil-file / anvil-org / anvil-browser / anvil-sqlite so
+the client sees one unified tool list.")
+
+(defconst anvil-http--state-ns "http"
+  "Namespace used when storing cached responses in `anvil-state'.")
+
+(defcustom anvil-http-user-agent
+  (format "anvil.el/%s (+https://github.com/zawatton/anvil.el)"
+          (if (boundp 'anvil-version) anvil-version "dev"))
+  "Default value of the User-Agent request header."
+  :type 'string
+  :group 'anvil-http)
+
+(defcustom anvil-http-cache-ttl-sec 300
+  "Default freshness TTL (seconds) for `anvil-http-get' responses.
+Within this window the cached entry is served without any network
+round-trip.  0 disables the fresh-serve path but the cache still
+stores validators for conditional revalidation."
+  :type 'integer
+  :group 'anvil-http)
+
+(defcustom anvil-http-timeout-sec 30
+  "Per-call transport timeout in seconds."
+  :type 'integer
+  :group 'anvil-http)
+
+(defcustom anvil-http-retry-max 3
+  "Maximum retry attempts for 5xx / 408 / 429 responses."
+  :type 'integer
+  :group 'anvil-http)
+
+(defcustom anvil-http-retry-base-ms 200
+  "Base backoff milliseconds for retry attempts.
+Actual wait is `base * 2^attempt' unless the server sent a
+`Retry-After' header (429 only)."
+  :type 'integer
+  :group 'anvil-http)
+
+(defcustom anvil-http-max-redirections 5
+  "Cap on url.el's redirect chain.  Lower than the Emacs default (30)."
+  :type 'integer
+  :group 'anvil-http)
+
+(defcustom anvil-http-allowed-schemes '("http" "https")
+  "Schemes accepted by `anvil-http-get' / `-head'.
+Non-listed schemes are refused with a user-error to block SSRF to
+file:// / javascript:// etc."
+  :type '(repeat string)
+  :group 'anvil-http)
+
+(defvar anvil-http--metrics
+  (list :requests 0 :cache-fresh 0 :cache-revalidated 0
+        :network-200 0 :errors 0 :log nil)
+  "Rolling counters and recent-request log.
+:log entries are (:url URL :elapsed-ms N :status N :cache SYM :at T).")
+
+(defcustom anvil-http-metrics-log-size 20
+  "Number of recent request entries kept in `anvil-http--metrics'."
+  :type 'integer
+  :group 'anvil-http)
+
+;;;; --- URL validation / normalization -------------------------------------
+
+(defun anvil-http--check-url (url)
+  "Validate URL and its scheme.  Signal `user-error' on failure."
+  (unless (and (stringp url) (not (string-empty-p url)))
+    (user-error "anvil-http: URL must be a non-empty string, got %S" url))
+  (let* ((parsed (url-generic-parse-url url))
+         (scheme (and (url-type parsed) (downcase (url-type parsed)))))
+    (unless (member scheme anvil-http-allowed-schemes)
+      (user-error "anvil-http: scheme %S not in `anvil-http-allowed-schemes'" scheme))))
+
+(defun anvil-http--normalize-url (url)
+  "Return a canonical form of URL suitable as a cache key.
+Lowercases scheme and host, strips fragment, keeps path+query."
+  (let ((parsed (url-generic-parse-url url)))
+    (when (url-type parsed)
+      (setf (url-type parsed) (downcase (url-type parsed))))
+    (when (url-host parsed)
+      (setf (url-host parsed) (downcase (url-host parsed))))
+    (setf (url-target parsed) nil)
+    (url-recreate-url parsed)))
+
+;;;; --- cache I/O (anvil-state ns="http") ----------------------------------
+
+(defun anvil-http--cache-get (norm-url)
+  "Return cached response plist for NORM-URL or nil."
+  (condition-case _err
+      (anvil-state-get norm-url :ns anvil-http--state-ns)
+    (error nil)))
+
+(defun anvil-http--cache-put (norm-url entry)
+  "Store ENTRY under NORM-URL in `anvil-state'."
+  (condition-case _err
+      (anvil-state-set norm-url entry :ns anvil-http--state-ns)
+    (error nil)))
+
+(defun anvil-http--cache-delete (norm-url)
+  "Drop NORM-URL from the cache.  Returns t when a row was removed."
+  (condition-case _err
+      (anvil-state-delete norm-url :ns anvil-http--state-ns)
+    (error nil)))
+
+(defun anvil-http--cache-clear-all ()
+  "Wipe every entry in the http namespace.  Returns deleted row count."
+  (condition-case _err
+      (anvil-state-delete-ns anvil-http--state-ns)
+    (error 0)))
+
+;;;; --- metrics ------------------------------------------------------------
+
+(defun anvil-http--metrics-bump (key &optional delta)
+  (let ((n (or (plist-get anvil-http--metrics key) 0)))
+    (setq anvil-http--metrics
+          (plist-put anvil-http--metrics key (+ n (or delta 1))))))
+
+(defun anvil-http--metrics-log (url elapsed-ms status cache-sym)
+  (let* ((log (plist-get anvil-http--metrics :log))
+         (entry (list :url url :elapsed-ms elapsed-ms :status status
+                      :cache cache-sym :at (float-time)))
+         (updated (cons entry log)))
+    (when (> (length updated) anvil-http-metrics-log-size)
+      (setq updated (cl-subseq updated 0 anvil-http-metrics-log-size)))
+    (setq anvil-http--metrics
+          (plist-put anvil-http--metrics :log updated))))
+
+;;;; --- request primitive --------------------------------------------------
+
+(defun anvil-http--parse-response (original-url)
+  "Parse the current url-http response buffer into a plist.
+Expects `url-http-end-of-headers' to be set; returns nil headers and
+empty body otherwise.  The buffer is killed by the caller."
+  (let* ((end-headers
+          (and (boundp 'url-http-end-of-headers)
+               (markerp url-http-end-of-headers)
+               (marker-position url-http-end-of-headers)))
+         (final
+          (or (and (boundp 'url-http-target-url)
+                   (let ((u (symbol-value 'url-http-target-url)))
+                     (cond ((stringp u) u)
+                           ((and u (fboundp 'url-recreate-url))
+                            (url-recreate-url u))
+                           (t nil))))
+              original-url))
+         status headers)
+    (goto-char (point-min))
+    (when (re-search-forward "\\`HTTP/[0-9.]+ +\\([0-9]+\\)"
+                             (or end-headers (point-max)) t)
+      (setq status (string-to-number (match-string 1))))
+    (forward-line 1)
+    (while (and end-headers (< (point) end-headers))
+      (when (looking-at "^\\([^:\r\n]+\\):[ \t]*\\(.*?\\)[ \t]*\r?$")
+        (let ((key (downcase (string-trim (match-string 1))))
+              (val (match-string 2)))
+          (setq headers (plist-put headers
+                                   (intern (concat ":" key))
+                                   val))))
+      (forward-line 1))
+    (let ((body (if end-headers
+                    (buffer-substring-no-properties end-headers (point-max))
+                  "")))
+      ;; url-http leaves one CRLF after headers — trim a single leading newline.
+      (when (and (> (length body) 0)
+                 (or (eq (aref body 0) ?\n)
+                     (eq (aref body 0) ?\r)))
+        (setq body (replace-regexp-in-string "\\`\r?\n" "" body)))
+      (list :status status
+            :headers headers
+            :body body
+            :final-url final))))
+
+(defun anvil-http--request (method url extra-headers timeout)
+  "Issue one METHOD request to URL with EXTRA-HEADERS and TIMEOUT (seconds).
+Returns a response plist (:status :headers :body :final-url) or
+signals `anvil-server-tool-error' on transport failure / timeout."
+  (let* ((url-request-method method)
+         (url-request-extra-headers
+          (append
+           (unless (assoc "User-Agent" extra-headers)
+             (list (cons "User-Agent" anvil-http-user-agent)))
+           (unless (assoc "Accept-Encoding" extra-headers)
+             (list (cons "Accept-Encoding" "gzip")))
+           extra-headers))
+         (url-show-status nil)
+         (url-automatic-caching nil)
+         (url-max-redirections anvil-http-max-redirections)
+         (buf nil))
+    (condition-case err
+        (setq buf (url-retrieve-synchronously url t t timeout))
+      (error
+       (signal 'anvil-server-tool-error
+               (list (format "anvil-http: network error on %s: %s"
+                             url (error-message-string err))))))
+    (unless (buffer-live-p buf)
+      (signal 'anvil-server-tool-error
+              (list (format "anvil-http: no response (timeout %ds?) for %s"
+                            timeout url))))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((resp (anvil-http--parse-response url)))
+            (unless (plist-get resp :status)
+              (signal 'anvil-server-tool-error
+                      (list (format "anvil-http: malformed response from %s"
+                                    url))))
+            resp))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(defun anvil-http--retryable-p (status)
+  "Return non-nil when an HTTP STATUS code should be retried."
+  (and status
+       (or (and (>= status 500) (< status 600))
+           (= status 408)
+           (= status 429))))
+
+(defun anvil-http--backoff-ms (attempt response)
+  "Return the wait time (ms) before retry ATTEMPT.
+RESPONSE is the last response plist; honours `Retry-After' for 429."
+  (let* ((status (plist-get response :status))
+         (headers (plist-get response :headers))
+         (retry-after (and (= (or status 0) 429)
+                           (plist-get headers :retry-after)))
+         (base (* anvil-http-retry-base-ms (expt 2 attempt))))
+    (cond
+     ((and retry-after (string-match "\\`[0-9]+\\'" retry-after))
+      (* 1000 (string-to-number retry-after)))
+     (t base))))
+
+(defun anvil-http--request-with-retry (method url extra-headers timeout)
+  "Run `anvil-http--request' with retry on 5xx / 408 / 429."
+  (let ((attempt 0)
+        (max-total (1+ (max 0 anvil-http-retry-max)))
+        (result nil))
+    (catch 'done
+      (while (< attempt max-total)
+        (setq result (anvil-http--request method url extra-headers timeout))
+        (if (and (anvil-http--retryable-p (plist-get result :status))
+                 (< attempt (1- max-total)))
+            (let ((ms (anvil-http--backoff-ms attempt result)))
+              (sleep-for (/ ms 1000.0))
+              (setq attempt (1+ attempt)))
+          (throw 'done result))))
+    result))
+
+;;;; --- conditional-request header assembly --------------------------------
+
+(defun anvil-http--format-http-date (epoch)
+  "Format EPOCH (unix seconds) as an RFC 7231 IMF-fixdate string."
+  (let ((system-time-locale "C"))
+    (format-time-string "%a, %d %b %Y %H:%M:%S GMT" epoch t)))
+
+(defun anvil-http--build-request-headers (user-headers accept cached if-newer-than)
+  "Assemble the outgoing request header alist.
+USER-HEADERS is the caller-supplied alist (string keys).  CACHED is
+a cache entry plist (or nil).  ACCEPT is a short-hand MIME string."
+  (let ((h (copy-sequence (or user-headers nil))))
+    (when (and accept (not (assoc "Accept" h)))
+      (push (cons "Accept" accept) h))
+    (when-let* ((etag (and cached (plist-get cached :etag))))
+      (unless (assoc "If-None-Match" h)
+        (push (cons "If-None-Match" etag) h)))
+    (when-let* ((lm (and cached (plist-get cached :last-modified))))
+      (unless (assoc "If-Modified-Since" h)
+        (push (cons "If-Modified-Since" lm) h)))
+    (when (and (integerp if-newer-than)
+               (not (assoc "If-Modified-Since" h)))
+      (push (cons "If-Modified-Since"
+                  (anvil-http--format-http-date if-newer-than))
+            h))
+    h))
+
+;;;; --- response assembly --------------------------------------------------
+
+(defun anvil-http--cache-entry (status headers body fetched-at final-url)
+  (list :status status
+        :headers headers
+        :body body
+        :fetched-at fetched-at
+        :final-url final-url
+        :etag (plist-get headers :etag)
+        :last-modified (plist-get headers :last-modified)))
+
+(defun anvil-http--response-plist (entry from-cache elapsed-ms)
+  "Turn a cache-entry plist into the public response plist."
+  (list :status (plist-get entry :status)
+        :headers (plist-get entry :headers)
+        :body (plist-get entry :body)
+        :from-cache from-cache
+        :cached-at (plist-get entry :fetched-at)
+        :final-url (plist-get entry :final-url)
+        :elapsed-ms elapsed-ms))
+
+;;;; --- public Elisp API ---------------------------------------------------
+
+;;;###autoload
+(cl-defun anvil-http-get (url &key headers accept timeout-sec
+                              no-cache cache-ttl-sec if-newer-than)
+  "GET URL and return a response plist.
+
+Keyword args:
+  :headers         alist of (STRING . STRING) extra request headers
+  :accept          MIME string added as Accept header (short-hand)
+  :timeout-sec     override `anvil-http-timeout-sec'
+  :no-cache        skip cache reads AND writes
+  :cache-ttl-sec   override `anvil-http-cache-ttl-sec'
+  :if-newer-than   unix epoch int; sends If-Modified-Since
+
+Returns (:status :headers :body :from-cache :cached-at :final-url
+:elapsed-ms)."
+  (anvil-http--check-url url)
+  (anvil-state-enable)
+  (anvil-http--metrics-bump :requests)
+  (let* ((norm-url (anvil-http--normalize-url url))
+         (ttl (or cache-ttl-sec anvil-http-cache-ttl-sec))
+         (now (float-time))
+         (cached (unless no-cache (anvil-http--cache-get norm-url))))
+    ;; Fresh TTL hit → zero network.
+    (if (and cached
+             (numberp ttl) (> ttl 0)
+             (numberp (plist-get cached :fetched-at))
+             (< (- now (plist-get cached :fetched-at)) ttl))
+        (progn
+          (anvil-http--metrics-bump :cache-fresh)
+          (anvil-http--metrics-log url 0
+                                    (plist-get cached :status) 'fresh)
+          (anvil-http--response-plist cached t 0))
+      ;; Otherwise hit network, possibly conditionally.
+      (let* ((extra (anvil-http--build-request-headers
+                     headers accept cached if-newer-than))
+             (timeout (or timeout-sec anvil-http-timeout-sec))
+             (start (float-time))
+             (resp (anvil-http--request-with-retry "GET" url extra timeout))
+             (elapsed-ms (round (* 1000 (- (float-time) start))))
+             (status (plist-get resp :status))
+             (headers* (plist-get resp :headers))
+             (body (plist-get resp :body))
+             (final (plist-get resp :final-url)))
+        (cond
+         ((= status 304)
+          (unless cached
+            (anvil-http--metrics-bump :errors)
+            (signal 'anvil-server-tool-error
+                    (list (format "anvil-http: 304 from %s but no cache entry"
+                                  url))))
+          (let* ((merged-headers
+                  ;; Prefer the new validators / Date but keep cached body.
+                  (anvil-http--merge-headers (plist-get cached :headers)
+                                             headers*))
+                 (refreshed (anvil-http--cache-entry
+                             (plist-get cached :status)
+                             merged-headers
+                             (plist-get cached :body)
+                             now
+                             (or final (plist-get cached :final-url)))))
+            (unless no-cache (anvil-http--cache-put norm-url refreshed))
+            (anvil-http--metrics-bump :cache-revalidated)
+            (anvil-http--metrics-log url elapsed-ms 304 'revalidated)
+            (anvil-http--response-plist refreshed t elapsed-ms)))
+         ((and (>= status 200) (< status 300))
+          (let ((entry (anvil-http--cache-entry status headers* body now final)))
+            (unless no-cache (anvil-http--cache-put norm-url entry))
+            (anvil-http--metrics-bump :network-200)
+            (anvil-http--metrics-log url elapsed-ms status 'miss)
+            (anvil-http--response-plist entry nil elapsed-ms)))
+         (t
+          (anvil-http--metrics-bump :errors)
+          (anvil-http--metrics-log url elapsed-ms status 'error)
+          (signal 'anvil-server-tool-error
+                  (list (format "anvil-http: HTTP %d for %s" status url)))))))))
+
+(defun anvil-http--merge-headers (base override)
+  "Shallow-merge two header plists, OVERRIDE winning on clashes."
+  (let ((out (copy-sequence base)))
+    (let ((tail override))
+      (while tail
+        (setq out (plist-put out (car tail) (cadr tail)))
+        (setq tail (cddr tail))))
+    out))
+
+;;;###autoload
+(cl-defun anvil-http-head (url &key headers timeout-sec)
+  "HEAD URL and return (:status :headers :final-url :elapsed-ms).
+HEAD responses never touch the cache."
+  (anvil-http--check-url url)
+  (anvil-http--metrics-bump :requests)
+  (let* ((extra (anvil-http--build-request-headers headers nil nil nil))
+         (timeout (or timeout-sec anvil-http-timeout-sec))
+         (start (float-time))
+         (resp (anvil-http--request-with-retry "HEAD" url extra timeout))
+         (elapsed-ms (round (* 1000 (- (float-time) start))))
+         (status (plist-get resp :status)))
+    (anvil-http--metrics-log url elapsed-ms status 'head)
+    (list :status status
+          :headers (plist-get resp :headers)
+          :final-url (plist-get resp :final-url)
+          :elapsed-ms elapsed-ms)))
+
+;;;###autoload
+(defun anvil-http-cache-clear (&optional url)
+  "Remove cache entries.  With URL, drop just that key; nil flushes http ns."
+  (anvil-state-enable)
+  (if (and (stringp url) (not (string-empty-p url)))
+      (if (anvil-http--cache-delete (anvil-http--normalize-url url)) 1 0)
+    (or (anvil-http--cache-clear-all) 0)))
+
+;;;; --- MCP tool handlers --------------------------------------------------
+
+(defun anvil-http--tool-fetch (url &optional if_newer_than accept
+                                   timeout_sec no_cache)
+  "GET URL through `anvil-http-get' and return the response plist.
+
+MCP Parameters:
+  url          - Absolute http/https URL to fetch.
+  if_newer_than - Optional unix epoch seconds; adds If-Modified-Since so
+                  the server can return 304 when nothing changed.
+  accept       - Optional Accept header value (e.g. \"application/json\").
+                  Passed through verbatim.
+  timeout_sec  - Optional request timeout override (integer seconds).
+  no_cache     - Non-nil skips cache on both read and write (any truthy
+                  value).
+
+Returns (:status :headers :body :from-cache :cached-at :final-url
+:elapsed-ms).  Same-URL calls within `anvil-http-cache-ttl-sec'
+seconds are served from the cache without any network round-trip.
+Otherwise conditional GET (If-None-Match / If-Modified-Since) is
+performed and a 304 revalidates the cached body with zero body
+transfer."
+  (anvil-server-with-error-handling
+   (let ((if-newer (cond ((null if_newer_than) nil)
+                         ((integerp if_newer_than) if_newer_than)
+                         ((and (stringp if_newer_than)
+                               (string-match "\\`[0-9]+\\'" if_newer_than))
+                          (string-to-number if_newer_than))
+                         (t nil)))
+         (timeout (cond ((null timeout_sec) nil)
+                        ((integerp timeout_sec) timeout_sec)
+                        ((and (stringp timeout_sec)
+                              (string-match "\\`[0-9]+\\'" timeout_sec))
+                         (string-to-number timeout_sec))
+                        (t nil)))
+         (accept* (and (stringp accept) (not (string-empty-p accept)) accept))
+         (no-c (and no_cache (not (equal no_cache "")))))
+     (anvil-http-get url
+                     :accept accept*
+                     :timeout-sec timeout
+                     :no-cache no-c
+                     :if-newer-than if-newer))))
+
+(defun anvil-http--tool-head (url &optional timeout_sec)
+  "HEAD URL and return (:status :headers :final-url :elapsed-ms).
+
+MCP Parameters:
+  url          - Absolute http/https URL to probe.
+  timeout_sec  - Optional request timeout override (integer seconds).
+
+HEAD responses are never cached; the tool exists for cheap metadata
+probes (Content-Type, Content-Length, reachability checks)."
+  (anvil-server-with-error-handling
+   (let ((timeout (cond ((null timeout_sec) nil)
+                        ((integerp timeout_sec) timeout_sec)
+                        ((and (stringp timeout_sec)
+                              (string-match "\\`[0-9]+\\'" timeout_sec))
+                         (string-to-number timeout_sec))
+                        (t nil))))
+     (anvil-http-head url :timeout-sec timeout))))
+
+(defun anvil-http--tool-cache-clear (&optional url)
+  "Remove cached entries from the http namespace.
+
+MCP Parameters:
+  url - Optional URL to drop.  When absent or empty, flushes every
+        entry under the http namespace.
+
+Returns the number of deleted rows (0 or 1 for single-URL, or the
+total removed for a namespace flush)."
+  (anvil-server-with-error-handling
+   (let ((u (and (stringp url) (not (string-empty-p url)) url)))
+     (anvil-http-cache-clear u))))
+
+;;;; --- status / introspection ---------------------------------------------
+
+;;;###autoload
+(defun anvil-http-status ()
+  "Show request counters and recent-request log in *Anvil HTTP*."
+  (interactive)
+  (with-help-window "*Anvil HTTP*"
+    (princ "Anvil HTTP — url-retrieve wrapper\n")
+    (princ (format "User-Agent : %s\n" anvil-http-user-agent))
+    (princ (format "Cache TTL  : %s sec\n" anvil-http-cache-ttl-sec))
+    (princ (format "Timeout    : %s sec\n" anvil-http-timeout-sec))
+    (princ (format "Retry      : max=%d, base=%dms\n"
+                   anvil-http-retry-max anvil-http-retry-base-ms))
+    (princ (format "Redirect   : max=%d\n" anvil-http-max-redirections))
+    (princ (format "Requests   : %d   fresh: %d   revalidated: %d   net-200: %d   errors: %d\n"
+                   (or (plist-get anvil-http--metrics :requests) 0)
+                   (or (plist-get anvil-http--metrics :cache-fresh) 0)
+                   (or (plist-get anvil-http--metrics :cache-revalidated) 0)
+                   (or (plist-get anvil-http--metrics :network-200) 0)
+                   (or (plist-get anvil-http--metrics :errors) 0)))
+    (princ "\nRecent requests:\n")
+    (dolist (entry (plist-get anvil-http--metrics :log))
+      (princ (format "  %5dms  %3s  %-12s %s\n"
+                     (or (plist-get entry :elapsed-ms) 0)
+                     (or (plist-get entry :status) "?")
+                     (symbol-name (or (plist-get entry :cache) 'unknown))
+                     (plist-get entry :url))))))
+
+;;;; --- module lifecycle ---------------------------------------------------
+
+(defun anvil-http--register-tools ()
+  "Register http-* MCP tools under `anvil-http--server-id'."
+  (anvil-server-register-tool
+   #'anvil-http--tool-fetch
+   :id "http-fetch"
+   :server-id anvil-http--server-id
+   :description
+   "GET an http/https URL and return status, headers and body with
+cache awareness.  Within `anvil-http-cache-ttl-sec' the cached entry
+is served without any network call; otherwise a conditional GET
+revalidates via If-None-Match / If-Modified-Since and a 304 is
+served from cache with zero body transfer.  Retries 5xx / 408 / 429
+with exponential backoff (honours Retry-After on 429)."
+   :read-only t)
+
+  (anvil-server-register-tool
+   #'anvil-http--tool-head
+   :id "http-head"
+   :server-id anvil-http--server-id
+   :description
+   "HEAD an http/https URL and return its status + response headers.
+Cheap liveness / metadata probe; responses are never cached."
+   :read-only t)
+
+  (anvil-server-register-tool
+   #'anvil-http--tool-cache-clear
+   :id "http-cache-clear"
+   :server-id anvil-http--server-id
+   :description
+   "Drop cached entries for the http namespace.  With a URL argument
+removes just that entry; without, flushes every cached response."))
+
+(defun anvil-http--unregister-tools ()
+  "Remove every http-* MCP tool from the shared server."
+  (dolist (id '("http-fetch" "http-head" "http-cache-clear"))
+    (anvil-server-unregister-tool id anvil-http--server-id)))
+
+;;;###autoload
+(defun anvil-http-enable ()
+  "Register http-* MCP tools and open the anvil-state backing store."
+  (interactive)
+  (anvil-state-enable)
+  (anvil-http--register-tools))
+
+(defun anvil-http-disable ()
+  "Unregister http-* MCP tools."
+  (interactive)
+  (anvil-http--unregister-tools))
+
+(provide 'anvil-http)
+;;; anvil-http.el ends here

--- a/anvil.el
+++ b/anvil.el
@@ -88,7 +88,9 @@ These are not loaded by default.  Available modules:
                 Doc 07 Phase A)
 - `state'     — Persistent SQLite-backed KV store shared across modules
                 (ns / TTL / Lisp prin1 values, requires Emacs 29+,
-                Doc 08 Phase 1)"
+                Doc 08 Phase 1)
+- `http'      — HTTP client via `url-retrieve-synchronously' with a
+                state-backed ETag/TTL cache (Doc 09 Phase 1a)"
   :type '(repeat symbol)
   :group 'anvil)
 

--- a/docs/design/09-http.org
+++ b/docs/design/09-http.org
@@ -1,0 +1,655 @@
+#+title: HTTP Client — url-retrieve Wrapper with ETag/TTL Cache
+#+date: 2026-04-18
+#+author: zawatton
+#+property: status DRAFT
+
+* STATUS
+~APPROVED~ (2026-04-18) — Review Questions Q1-Q10 すべて既定案で
+resolved、Windows libxml fallback を明記した上で確定。Phase 1a 着手可能。
+Doc 07 Vision 節の Phase C1 を本 doc に切り出したもの。
+
+* Goal
+
+anvil.el 第三の fetch primitive として、**静的 HTTP/JSON リソース** を
+LLM 経由で取得する軽量 client を提供する。
+
+位置付け (Doc 07 Vision "ACTION" レイヤー):
+
+| 用途                                            | ツール            |
+|-------------------------------------------------+-------------------|
+| 静的 HTML / JSON / txt / RSS をトークン最小で取る | *anvil-http* ← 本 doc |
+| JS rendering 必須 / accessibility tree 欲しい   | anvil-browser      |
+| 定期巡回 robot・録画スクレイピング              | Maxun (外部、REST で叩く) |
+| ブラウザ対話・ログイン後操作                    | Claude in Chrome   |
+
+anvil-http は上記 4 つのうち「軽量 fetch」を担当し、Maxun / 公開 REST
+API を LLM から叩くための primitive にもなる。
+
+** 命名について
+
+=anvil-net.el= は既存の *listening port inspection* (netstat / ss / lsof
+wrapper)。命名空間は別で衝突しない。混同防止のため本 doc と module
+commentary に 1 行ガードを書く。
+
+* Problem
+
+** 現状の "HTTP fetch" 経路の散在
+
+2026-04 時点で anvil に汎用 HTTP client はなく、以下の経路が並立している:
+
+1. WebFetch / WebSearch tool (Claude 側組込) — markdown 化+要約が
+   強制的に走り、生 JSON が取れない。認証ヘッダ不可
+2. =agent-browser= + anvil-browser — Chrome cold start ~500ms/call、
+   Reddit の =.json= endpoint も JS challenge で弾かれるため本来不要な
+   overhead
+3. bash =curl= / =wget= — 1 call ごと process 起動 + shell quoting
+   + output parse を Claude が毎回書く。ETag / cache 一切なし
+
+結果として以下が発生 (本日 2026-04-18 soak で実測):
+
+- Reddit =reddit.com/r/.../comments/.../.json= を anvil-browser で叩く
+  と JS challenge + 404 っぽい HTML が返る (~15KB の無駄 token)
+- 公開 docs サイトを 10 分毎に polling する場合、ETag を使えば 304
+  で body 0B のはずが 毎回全量 (数百 KB) 転送 + Claude context に流入
+- Maxun (Docker self-host scraper) の REST API は素の JSON。browser で
+  叩くと HTML viewer が挟まって本体取得 1 段階増える
+
+** url-retrieve の罠
+
+Emacs 29 組込 =url-retrieve-synchronously= は使える状態だが:
+
+- callback ベースで sync 取得すると process sentinel が
+  =accept-process-output= を内側で呼び、MCP server の他 request 処理を
+  詰まらせる可能性 (memory =feedback_emacs_server_concurrency_model.md=)
+- gzip / brotli の自動 decode 挙動がバージョン依存
+- redirect loop の guard が弱い (=url-max-redirections= 既定 30)
+- charset 検出が HTML5 の =<meta charset>= をうまく拾わない
+- error response body を読み捨てる default 挙動 (=url-http-parse-response=
+  のエラー時挙動)
+
+anvil-http はこれらを 1 箇所で吸収する薄い wrapper として機能する。
+
+** ETag / Last-Modified cache がないコスト
+
+Claude が「このドキュメントページを 5 分毎にチェックして変化があれば知らせて」
+と言われて polling する場合、ETag を使えば:
+
+- 初回: 200 OK, body 全量 (例: 80KB)
+- 2-10 回目 (変化なし): 304 Not Modified, body 0B, LLM token 消費も 0
+- 11 回目 (更新あり): 200 OK, body 全量
+
+cache 無しの現状だと毎回 80KB が Claude context を食う。90%+ 削減の
+余地がある。
+
+* Proposed Design
+
+** Module boundary
+
+- 新規ファイル: =anvil-http.el=
+- 依存 (hard):
+  - =anvil-server= (MCP tool 登録)
+  - =anvil-state= (ETag/body cache の backing store)
+- 依存 (soft): =anvil-offload= — 長時間 fetch を offload したい時のみ
+- 依存 (built-in): =url=, =url-http= (Emacs 29+)
+- 公開 MCP tool: server-id は =emacs-eval= に合流 (anvil-browser と同方針)
+
+** Public Elisp API
+
+#+begin_src elisp
+;; 設定
+(defcustom anvil-http-user-agent
+  (format "anvil.el/%s (+https://github.com/zawatton/anvil.el)" anvil-version)
+  "Default User-Agent header." :type 'string)
+
+(defcustom anvil-http-cache-ttl-sec 300
+  "Default freshness TTL in seconds for `anvil-http-get' responses.
+0 disables TTL check (cache still stores validators for If-None-Match)."
+  :type 'integer)
+
+(defcustom anvil-http-timeout-sec 30
+  "Per-call transport timeout (seconds)." :type 'integer)
+
+(defcustom anvil-http-retry-max 3 :type 'integer)
+(defcustom anvil-http-retry-base-ms 200 :type 'integer)
+
+(defcustom anvil-http-max-inline-body-bytes 200000
+  "Body size threshold above which `http-fetch' spills to disk.
+Body > この値なら :body に head (先頭 2KB) を残し、全量は tempfile に
+書き出して :body-overflow-path で path を返す。呼び出し元は
+file-read offset/limit で部分読みできる。0 で無効化 (常に inline)。"
+  :type 'integer)
+
+(defcustom anvil-http-overflow-head-bytes 2048
+  "Leading bytes of body to keep inline when overflowing to disk."
+  :type 'integer)
+
+(defcustom anvil-http-batch-max 16
+  "Maximum number of URLs accepted by `http-fetch-batch' in one call."
+  :type 'integer)
+
+(defcustom anvil-http-batch-concurrency 4
+  "Parallel in-flight requests for `http-fetch-batch'.
+url-queue が sync fetch を裏で multiplex する。1 で直列。"
+  :type 'integer)
+
+(defcustom anvil-http-respect-robots-txt t
+  "When non-nil, consult robots.txt before each fetch (cached).
+User-Agent で `anvil-http-user-agent' が Disallow されている path は
+user-error で refuse。" :type 'boolean)
+
+;; 中核 API
+(anvil-http-get URL &rest ARGS)
+  ;; URL: string。
+  ;; ARGS (plist):
+  ;;   ;; transport
+  ;;   :headers         ALIST of (STRING . STRING) extra request headers
+  ;;   :accept          MIME type, short-hand for Accept header
+  ;;   :timeout-sec     override `anvil-http-timeout-sec'
+  ;;   ;; cache
+  ;;   :no-cache        skip cache on both read and write when non-nil
+  ;;   :cache-ttl-sec   override `anvil-http-cache-ttl-sec'
+  ;;   :if-newer-than   UNIX-EPOCH-INT, adds If-Modified-Since
+  ;;   ;; efficiency levers (token reduction、§ "Efficiency levers" 参照)
+  ;;   :selector        CSS selector STRING — text/html の時のみ、body を
+  ;;                    libxml + dom で抽出して返す (matched subtree の
+  ;;                    visible text、既定は内部)
+  ;;   :json-path       dotted path STRING (e.g. "items[0].title") —
+  ;;                    application/json の時 server 側で抽出
+  ;;   :body-mode       'full (既定、ただし max-inline-body-bytes 超過時
+  ;;                            は自動 'overflow) / 'head / 'meta-only
+  ;;   :max-inline-body-bytes  override `anvil-http-max-inline-body-bytes'
+  ;;   :header-filter   'minimal (既定) / 'all
+  ;;
+  ;; 戻り値 plist:
+  ;;   (:status 200 :headers PLIST :body STRING
+  ;;    :from-cache BOOL :cached-at FLOAT-TIME
+  ;;    :final-url STRING  ; redirect 後の実 URL
+  ;;    :elapsed-ms INT
+  ;;    ;; overflow 時のみ:
+  ;;    :body-truncated t :total-bytes N :body-sha256 STR
+  ;;    :body-overflow-path "/tmp/anvil-http-XXX"
+  ;;    ;; selector / json-path 使用時のみ:
+  ;;    :extract-applied SYMBOL :extract-miss BOOL)
+
+(anvil-http-head URL &rest ARGS)
+  ;; :body は常に ""、headers + status のみ。liveness / metadata probe 用。
+
+(anvil-http-get-batch URLS &rest ARGS)
+  ;; URLS: list of strings (max `anvil-http-batch-max', 既定 16)
+  ;; ARGS は `anvil-http-get' と同形式、全 URL に適用
+  ;; 戻り値: URLS と同順の response plist リスト
+  ;; 並列度は `anvil-http-batch-concurrency' (既定 4)
+
+(anvil-http-cache-clear &optional URL)
+  ;; URL 省略で http ns 全削除、指定で該当 key のみ。戻り値: 削除件数。
+#+end_src
+
+~anvil-http-post~ は Phase C1.5 に分離 (Review Q4 で議論)。
+
+** Public MCP tools
+
+| id                    | 主要引数                                              | 戻り値                               | 備考                              |
+|-----------------------+-------------------------------------------------------+--------------------------------------+-----------------------------------|
+| ~http-fetch~          | url, selector?, json_path?, body_mode?, no_cache?, if_newer_than?, accept?, timeout_sec?, header_filter? | status, headers, body(+overflow meta) | GET、cache + 抽出 + disk overflow |
+| ~http-fetch-batch~    | urls (array ≤16), ...http-fetch 全 option          | responses (同順 array)               | 並列 4 (defcustom override 可)    |
+| ~http-head~           | url, timeout_sec?                                     | status, headers                      | HEAD、metadata probe              |
+| ~http-cache-clear~    | url?                                                  | removed_count                        | 引数なしなら http ns 全 flush     |
+
+全 tool は body を *文字列として* 返す。JSON 自動 parse はしない
+(Review Q5): raw で返し、抽出が必要なら =json_path= で server 側に寄せる。
+
+** Efficiency levers (Phase C1 MVP で入れる)
+
+本 MCP tool の **最大の存在価値はトークン削減**。以下 5 つを既定動作に
+組み込み、「素朴に URL 投げる → 無駄なく最小 body だけ返る」状態を作る。
+
+*** Lever 1: server-side extract (selector / json-path)
+
+Claude が巨大 HTML / JSON の一部分を見たいだけの時、body 全量を往復
+させるのは純粋な浪費。anvil-http は content-type を見て server 側で
+抽出する:
+
+- =text/html=: primary path は =libxml-parse-html-region= + dom.el で
+  CSS selector を評価し、matched element の visible text を返す。
+  libxml 未搭載ビルド (稀だが Windows の一部) に向けて **regex-subset
+  fallback** を同梱: =tag=, =.class=, =#id=, =tag.class=, =tag#id=
+  レベルを自前で評価して text 抽出。combinator (="a > b"=) や
+  pseudo-class (=:nth-child=) は libxml 必須
+- =application/json=: =json-parse-string= → dotted path walk
+  (e.g. =items[0].title=、=data.results[*].id=)。JMESPath full 実装は
+  Phase C1' 以降。json-parse-string は Emacs 27+ 全 platform で built-in
+- =application/xml= / =text/xml=: libxml あれば同機構、無ければ fallback
+  せず =:extract-miss t= + full body を返す
+- selector が何も match しなかった時: body を full 返し =:extract-miss t=
+  付与 (silently 空返しは罠)
+
+実測期待値: HTML 100KB → selector 適用で 2-5KB、**~20-50x 削減**
+(libxml path)、fallback path は 70-90% 削減 (簡易 parser ゆえ構造情報が
+減るぶん控えめ)。
+
+=anvil-http-enable= 時に =(fboundp 'libxml-parse-html-region)= を
+確認し、無い場合は message で "fallback selector mode (simple)" を告知。
+
+*** Lever 2: body size management (disk overflow)
+
+大量 body を inline で返すと Claude の context が一気に消費される。
+=anvil-http-max-inline-body-bytes= (既定 200KB) 超過時の挙動:
+
+- =:body= には先頭 =anvil-http-overflow-head-bytes= (既定 2KB) のみ
+- 残りは tempfile (=temporary-file-directory=/=anvil-http-SHA-.bin=) に
+  書き出し
+- 戻り値に =:body-truncated t :total-bytes N :body-overflow-path PATH
+  :body-sha256 HEX= を付与
+- 呼び出し元 (Claude) は ~file-read~ tool で offset/limit を使って必要な
+  部分のみ読み直せる (既存 anvil-file と dovetail)
+
+常時 inline 欲しい時は =:body-mode 'full= を明示 (MCP 引数
+=body_mode="full"=)、逆に probe だけしたい時は =:body-mode 'meta-only=
+で body は捨てる。
+
+Phase C1 の cache 層は body 自体を SQLite に入れる (Q1 既定案 A)。
+overflow 発生 body は =SHA:length:overflow_path= のみを state に格納
+し、実体は disk。cache hit 時は overflow path の存在チェック → 無ければ
+再 fetch、という lazy rehydrate。
+
+*** Lever 3: header filter (既定 minimal)
+
+url-http の response headers は 20-40 entries 返ってくるが、LLM が
+typically 必要なのは 5-7 個:
+
+| key                | 用途                                    |
+|--------------------+-----------------------------------------|
+| =content-type=     | 抽出ロジックと encoding 判定            |
+| =content-length=   | 予想サイズ / overflow 判定              |
+| =etag=             | 次回 If-None-Match                      |
+| =last-modified=    | 次回 If-Modified-Since                  |
+| =content-encoding= | gzip 既に decode 済かの可視化           |
+| =location=         | redirect 追跡デバッグ                   |
+| =retry-after=      | 429 時の backoff 判断                   |
+
+=:header-filter 'minimal= (既定) でこの 7 key のみ返す。=:header-filter
+'all= でフル headers。Minimal だけで 1 req あたり ~200-500 bytes 削減、
+塵も積もって batch で効いてくる。
+
+*** Lever 4: batch fetch (http-fetch-batch)
+
+LLM が URL 複数を順次調べる workflow は頻出 (RSS list → 各記事 fetch、
+API index → 各 detail、等)。単純 loop だと:
+
+- N x MCP envelope overhead (~200-400 bytes/ call)
+- N x 往復 latency (Claude roundtrip、概ね 300-500ms/call)
+- cache も N 回 check (同 origin なら keep-alive も逃している)
+
+=http-fetch-batch= で 1 call に畳み込み、内部は url-queue で =anvil-http-
+batch-concurrency= (既定 4) 並列。envelope は 1 つ、cache 共有、ETag
+も独立。URL 上限は =anvil-http-batch-max= (既定 16)。
+
+Emacs 29 の =url-queue-retrieve= は既に存在、concurrency 制御を持つ。
+本体コスト ~50 行。
+
+*** Lever 5: conditional / 304 fast path
+
+既定設計を再掲 + 強調:
+
+- TTL 内 cache hit → body も含めて **0 network** serve
+- TTL 超過 + ETag/Last-Modified あり → =If-None-Match= + =If-Modified-
+  Since= 送信、304 なら *body 転送なし* + cache 再利用
+- cache miss / 200 → 全量転送 → cache 書き込み
+
+**304 時の body** は Claude には従来通り返す (cache から)。完全な
+metadata-only revalidation が欲しいケースは =:body-mode 'meta-only=
+で明示。
+
+*** 効率の合計目安 (期待値)
+
+| シナリオ                              | 削減ソース                                     | 体感    |
+|---------------------------------------+------------------------------------------------+---------|
+| 同 URL 5 分以内再 fetch               | TTL hit                                        | 100%    |
+| ETag ありサイトの 1 日 polling        | 304 body skip                                  | ~99%    |
+| 巨大 HTML から 1 section              | selector extract                               | 90-98%  |
+| 巨大 JSON から 1 field                | json-path extract                              | 95-99%  |
+| 200KB+ body 全読み                    | overflow + file-read offset                    | 90% (初回 inline 分のみ) |
+| URL 10 件順次 (no cache)              | batch + concurrency=4                          | 遅延 ~4x短縮、envelope -90% |
+
+上記はいずれも "既存 anvil-browser / bash curl 経路比" の粗見積。
+
+** Internal: cache semantics
+
+anvil-state ns = =http=、key = 正規化 URL (lowercase scheme + host、fragment
+除去、query は保持)。
+
+#+begin_src elisp
+;; cache value 形式
+(:status 200
+ :headers PLIST         ; :content-type :content-length :etag :last-modified ...
+ :body "..."            ; RAW STRING。gzip は転送層で展開済み
+ :fetched-at FLOAT-TIME
+ :final-url "..."
+ :etag STRING-OR-NIL
+ :last-modified STRING-OR-NIL)
+#+end_src
+
+*** GET アルゴリズム (pseudo)
+
+#+begin_src
+entry = state-get ns=http key=norm-url
+if entry and not :no-cache:
+  if (now - entry.fetched-at) < cache-ttl:
+    return entry with :from-cache t          ; fresh serve
+  else:
+    req = GET url
+    if entry.etag:       req.headers += If-None-Match: entry.etag
+    if entry.last-modified: req.headers += If-Modified-Since: entry.last-modified
+    resp = do-request(req)
+    if resp.status == 304:
+      entry.fetched-at = now                 ; revalidate-only
+      state-set entry
+      return entry with :from-cache t
+    if resp.status == 200:
+      new-entry = build-entry(resp)
+      state-set ns=http key=norm-url new-entry
+      return new-entry with :from-cache nil
+    ; 4xx/5xx → エラー、cache 据え置き
+else:
+  resp = do-request(GET url)
+  if resp.status == 200:
+    state-set ... new-entry
+  return new-entry with :from-cache nil
+#+end_src
+
+*** 304 Not Modified の扱い
+
+- body は cache のものを返す
+- headers は cache + 新 response headers を shallow merge (Date 等の
+  揮発 header は新側優先)
+- =:from-cache t= 付与、=:fetched-at= は更新 (TTL 延長)
+
+*** cache eviction
+
+- TTL は lazy (anvil-state 既定動作と同じ)
+- =anvil-http-cache-clear= で明示 flush
+- 自動 LRU / size limit は Phase C1 MVP では入れない (Review Q7 候補、
+  body が大量に積もったら必要)
+
+** robots.txt
+
+=anvil-http-respect-robots-txt= が non-nil (既定) の時:
+
+1. 対象 URL の origin から =/robots.txt= を取得 (anvil-http 自身で GET、
+   ただし robots.txt 自身に対しては再帰的 robots.txt check を skip)
+2. robots.txt は anvil-state ns =http-robots=、TTL 24h で cache
+3. RFC 9309 パーサで User-Agent (anvil-http-user-agent の product token) 向けの
+   Allow/Disallow を評価
+4. Disallow hit → =user-error "anvil-http: %s is Disallowed for %s by robots.txt"=
+5. parse 失敗 / robots.txt 自体が 404 → permissive (fail open)
+
+parser は既存 Emacs にないので小さな自前実装 (Phase 1 実装時に 50 行
+程度見込み)。
+
+** redirect
+
+- =url-max-redirections= を呼び出し毎に =let= で 5 に絞る (既定 30 は多すぎ)
+- redirect 後の URL を =:final-url= で返す
+- cache key は *元 URL* を使う (同 origin の redirect が cache を汚さない)
+
+** charset / encoding
+
+- =Content-Type: */*; charset=XXX= を最優先
+- 無ければ =text/html= の場合のみ body 先頭 4KB から HTML5
+  =<meta charset>= を検出
+- それ以外は UTF-8 仮定 → decode 失敗時 =:encoding-warning= を headers に足す
+
+body は常に *Emacs 内部表現の文字列* として返す (multibyte)。バイナリ
+(image など) は Phase C1 MVP では想定しない — =http-head= で content-type
+を事前確認し、binary なら別手段 (=http-download-to-file=、Phase C1.5) に
+回す。
+
+** timeout / retry
+
+- transport timeout: =anvil-http-timeout-sec= 既定 30s
+- retry 対象: network error, 5xx, 408, 429
+- retry なし: 4xx (429 除く), 3xx (redirect は url-http が自前で処理)
+- backoff: =base-ms * (2 ^ attempt)=、jitter なし (簡素、将来入れる)
+- 429 の =Retry-After= header を尊重 (秒数 or HTTP-date 両対応)
+
+** concurrency
+
+- 1 call ごとに url-retrieve を sync で spawn
+- url-retrieve は内部で =accept-process-output= を呼ぶため *他 MCP
+  request の処理は継続可能* (memory =feedback_emacs_server_concurrency_model.md=
+  参照、yield point あり)
+- ただし main daemon が tight loop 中だと詰まる。長時間 fetch は Phase
+  C1' で anvil-offload 経由 (=:offload t= 引数) に出す設計 (本 MVP 非対象)
+
+** 認証 / headers
+
+Phase C1 MVP では =:headers= で任意 header を足せる I/F のみ provide:
+
+#+begin_src elisp
+(anvil-http-get "https://api.example.com/v1/foo"
+                :headers '(("Authorization" . "Bearer ...")
+                           ("X-Api-Key"    . "...")))
+#+end_src
+
+Bearer / Basic helper や auth-source 連携は Phase C1' 候補。
+
+* Non-goals (Phase C1)
+
+- *WebSocket / SSE / HTTP/3* — url-http は 1.1 のみ、本 scope 外
+- *大容量 download* (>数 MB) の in-memory body — Phase C1.5 で
+  =http-download-to-file= として分離 (disk-first)
+- *Cookie jar* — Claude in Chrome / anvil-browser の session 機能に委譲
+- *JSON schema validation* — anvil-validate (Phase E) に委譲
+- *OAuth2 flow* — browser-assisted 認証は anvil-browser、server-side
+  flow は init.org composition
+- *MIME multipart POST* — Phase C1.5+
+- *CLI (shell) からの利用* — anvil は MCP tool server。CLI が欲しければ
+  =curl= を使う
+- *proxy 設定 UI* — =url-proxy-services= (built-in) を尊重、docstring で案内
+- *binary response* — =:body= は text 前提、binary は content-type で
+  早期 refuse
+
+* Migration / Backward Compatibility
+
+- 新規モジュール。既存 tool 挙動変更なし
+- =anvil-optional-modules= に =http= を追加、=anvil-enable= で有効化
+- 既存の anvil-browser は Phase C1 完了後も in-memory cache のまま
+  並立 (browser は JS rendering 必須 path 用)。anvil-http が Reddit
+  =.json= / 公開 REST 用の速い経路を提供する棲み分け
+
+* Risks
+
+- *url-retrieve の subtle bug*
+  → Emacs 29 以降に絞る (Doc 08 と同方針)。28.2 は非対応
+- *robots.txt 解釈の protocol-compliance*
+  → RFC 9309 の Allow/Disallow 優先度 + wildcard 扱いを test で固定。
+    parse 失敗は fail open
+- *redirect を悪用した SSRF/内部網到達*
+  → scheme 制限 (http/https のみ)、=127.0.0.1= / =localhost= / RFC1918
+    は defcustom =anvil-http-allow-private-hosts= (既定 =t= だが、
+    docstring で「公開自動化 context では nil 推奨」を明示)
+- *gzip / brotli decode*
+  → url-http は gzip 自動 decode。brotli は Emacs built-in 未対応 →
+    =Accept-Encoding: gzip, deflate= のみ送る
+- *libxml 欠損ビルド (稀な Windows カスタム build)*
+  → enable 時に =fboundp 'libxml-parse-html-region= を check、無ければ
+    message + regex-subset fallback。selector 精度は下がるが crash なし。
+    =anvil-http-status= に mode 表示
+- *DNS / TLS エラーの分類*
+  → anvil-server-tool-error にマップ、エラーメッセージに URL/phase を含める
+- *cache が SQLite に膨れる*
+  → body が毎回 100KB+ だと 1 day で MB 単位増殖。Phase 後半で
+    =anvil-http-cache-max-bytes= + LRU を Review Q7 で検討
+
+* Platform Notes
+
+** Windows
+
+- proxy 設定は =url-proxy-services= 経由、Emacs が MSYS でも native でも
+  同じ形式
+- TLS は url が gnutls / openssl を呼ぶ。Emacs 29 Windows 公式 build は
+  gnutls 同梱、HTTPS は問題なし。証明書 chain は OS 側 trust store を参照
+- *libxml* は Emacs 26 以降 Windows 公式 binary にも同梱されており、
+  通常 =libxml-parse-html-region= が動く。MSYS2 mingw64 で自前 build
+  した Emacs 等 libxml 無しの場合は Lever 1 の fallback selector (tag /
+  .class / #id) に自動切替。=M-x anvil-http-status= で mode を可視化
+- overflow の tempfile path は =temporary-file-directory= (native 側
+  =%TEMP%= / MSYS 側 =/tmp=) に作成。anvil-file は両 path を扱えるため
+  後続の =file-read= 連携で path 変換は不要
+
+** macOS / Linux
+
+- 特記なし
+
+* Success Metrics
+
+軸 1: *機能* (Reddit / Maxun / ETag)
+
+- Reddit =.json= を 1 call で取得 (現状 anvil-browser 経由で 0 成功)
+- 同 URL を 2 回 fetch した時 304 経路で body 0B wire 転送確認
+- Maxun REST endpoint を =http-fetch= で叩いて JSON 取得
+
+軸 2: *トークン効率* (本 doc の目玉、実測目標値)
+
+- selector 付き HTML fetch: body 全量比 **80% 以上削減**
+  (jmatsuzaki.com 約 16KB → selector "article" で 3KB 想定)
+- json-path 付き JSON fetch: body 全量比 **95% 以上削減**
+  (typical REST list → item 1 field)
+- batch fetch 10 URLs: 単発 loop 比 MCP envelope overhead **80% 削減**
+- 200KB+ body overflow: Claude context に流入する bytes **90% 以上削減**
+  (= overflow_head=2KB のみ inline)
+- header-filter minimal: 1 response あたり headers 表現 **50% 以上削減**
+
+軸 3: *latency / スループット*
+
+- batch concurrency=4 で 10 URL 直列比 **3x 以上高速化** (ネットワーク
+  律速が前提)
+- TTL cache hit 時 1 call あたり 2ms 未満 (10,000 entry bench)
+
+* Review Questions (RESOLVED 2026-04-18)
+
+初回レビューですべて既定案を採用 (+ Windows libxml fallback 追加):
+
+- [X] *Q1: body を state に cache するか、validators のみか?* →
+  **body も cache (TTL 300s)**。daemon 再起動跨ぎで 304 経路が効く。
+  cache 膨張は Q7 の Phase C1' LRU で対処
+- [X] *Q2: robots.txt 既定有効 / 無効?* → **有効 (opt-out)**。
+  anvil は公開 package、LLM 自動 fetch context だからこそ default on
+- [X] *Q3: sync-only / offload 併用?* → **Phase C1 sync のみ**、
+  Phase 2 で =:offload t= 引数追加
+- [X] *Q4: POST support* → **Phase C1.5 で別立て**。Phase C1 は
+  GET/HEAD に集中して API 型を固める
+- [X] *Q5: content-type aware body parse (JSON auto-parse)?* →
+  **raw string + server-side extract (=json_path=)**。全量 auto-parse
+  は LLM 側の表現自由度を奪う。抽出が欲しい時は json-path で明示
+- [X] *Q6: user-agent string の既定値* → =anvil.el/VERSION (+github)=。
+  override は =anvil-http-user-agent= defcustom。bot-unfriendly サイト
+  向け spoofing はユーザー自身の判断で
+- [X] *Q7: cache サイズ上限 / LRU eviction* → **Phase C1 MVP 無し**、
+  Phase 3 で =anvil-http-cache-max-bytes= + LRU 追加
+- [X] *Q8: server-side extract の parser 範囲* → **libxml primary +
+  regex-subset fallback** (Windows 互換維持)。tag/.class/#id レベルは
+  fallback でも動く。combinator / pseudo-class は libxml 必須。JMESPath
+  / XPath は Phase C1' 以降
+- [X] *Q9: batch fetch の並列度 / URL 上限* → **concurrency=4,
+  batch-max=16**。concurrency は same-origin polite crawler の慣習値、
+  url-http が HTTP/1.1 のみなので 8+ にしても接続効率は伸びない。
+  batch-max は MCP envelope と 1 call の安全率で初期値 16 (必要なら
+  defcustom で上げる)
+- [X] *Q10: body-mode 既定値 / overflow 閾値* → =:body-mode 'full=
+  (ただし =max-inline-body-bytes 200KB= 超過で自動 overflow)。
+  200KB ≈ 50-70K tokens、Claude Opus 1M context の 7% 程度で "1 fetch
+  が context を食い潰さない" 安全ライン。overflow head 2KB ≈ 500-700
+  tokens、"何の body か" 判断できる最小情報量
+
+* Phase 分解
+
+Phase 1 は 5 つの sub-phase に分割し、各 sub-phase 単体で ship 可能な
+粒度に落とす (1 PR = 1 sub-phase、レビューと soak が刻める)。
+
+| Phase | 内容                                                   | 1st user             | 工数 |
+|-------+--------------------------------------------------------+----------------------+------|
+| 1a    | GET/HEAD + state cache + ETag/304 + MCP 登録           | Reddit =.json=       | 中   |
+| 1b    | selector + json-path (libxml primary + regex fallback) | 公開 docs 抽出        | 中   |
+| 1c    | overflow (disk spill + head slice) + header-filter     | 大 HTML 取り込み      | 小   |
+| 1d    | =http-fetch-batch= (url-queue concurrency)             | RSS index 一括        | 小   |
+| 1e    | robots.txt fetcher + RFC 9309 parser                   | 公開 crawler etiquette | 小   |
+| 1.5   | POST + auth headers + retry policy refine              | Maxun REST            | 中   |
+| 2     | =:offload t= 引数で anvil-offload 経由                 | 長時間 fetch          | 小   |
+| 3     | LRU eviction + size cap + metrics instrumentation      | 運用監視              | 中   |
+
+各 sub-phase ship 時 ~make test-all~ + 1 live bench + README の該当節を
+1 PR で流す。Phase 1a 単体でも Reddit =.json= 取得は可能 (selector 無し、
+raw JSON をそのまま Claude が parse) なので、1a だけでも価値を届けられる。
+
+Phase 1b〜1d は *独立に並ぶ* (依存なし)。1a 完了後、体力とユースケース
+優先度で順序を決める。robots.txt (1e) は 1a-1d のどこに挟んでも良いが、
+公開 site へ自動 fetch が増えてくる 1d の前に入れるのが礼儀として自然。
+
+* Implementation Plan (sub-phase 別)
+
+** Phase 1a — Core fetch + cache (所要 2-3 日)
+
+1. =anvil-http.el= スケルトン + =anvil-http-get= 最小実装
+   (url-retrieve-synchronously + timeout + retry + redirect guard +
+    encoding detection)
+2. anvil-state ns="http" cache + ETag / If-None-Match / If-Modified-Since
+3. =anvil-http-head= + =anvil-http-cache-clear=
+4. MCP tool 登録 (=http-fetch= / =http-head= / =http-cache-clear=、この
+   時点の =http-fetch= は selector / batch / overflow なし版)
+5. =anvil-optional-modules= に =http= 追加、enable で libxml 有無を
+   message
+6. ERT 10-14 tests (mock + live httpbin.org / example.com)
+7. README / docstring → PR → ship
+
+ここまでで Reddit =.json= 直叩き / 単純 API 取得 / 公開 docs polling が
+動く。anvil-browser との棲み分けが確立する。
+
+** Phase 1b — Server-side extract (所要 2 日)
+
+1. libxml 判定 helper (=anvil-http--libxml-p=)
+2. =anvil-http--select-html-libxml= (dom.el + matcher)
+3. =anvil-http--select-html-fallback= (regex-subset: tag / .class / #id)
+4. =anvil-http--select-json-dotted= (JSON dotted path walker)
+5. =http-fetch= tool に =selector= / =json_path= 引数追加
+6. ERT +6 (libxml あり/無し分岐、miss ケース含む)
+
+** Phase 1c — Overflow + header filter (所要 1 日)
+
+1. =anvil-http--spill-to-disk= (sha256 base + tempfile)
+2. =:body-mode= 引数 dispatch
+3. =:header-filter 'minimal= default + 'all opt-in
+4. cache に overflow path を保存、cache hit 時の lazy rehydrate
+5. ERT +4 (overflow / head-only / meta-only / filter variants)
+
+** Phase 1d — Batch fetch (所要 1-2 日)
+
+1. =anvil-http-get-batch= + url-queue 並列制御
+2. per-URL cache / ETag 独立
+3. =http-fetch-batch= tool 登録
+4. ERT +4 (直列比較 / concurrency=1 / concurrency=4 / 部分失敗)
+5. bench (10 URL 単発 loop vs batch)
+
+** Phase 1e — robots.txt (所要 1-2 日)
+
+1. robots.txt fetcher (ns=http-robots、TTL 24h)
+2. RFC 9309 parser (Allow / Disallow / User-Agent matching / longest-match
+   rule)
+3. =anvil-http-respect-robots-txt= defcustom hook-in
+4. ERT +5 (parser + fetcher + disallow refuse + fail-open behavior)
+
+合計: Phase 1a-1e で 7-10 日目安 (単一 sub-phase ship + 挟み PR 間隔
+込み)。各 sub-phase 独立に shippable なので本業の合間でも刻める。
+
+* References
+
+- Doc 07 Vision 節 ~anvil-http~ 概要: [[file:07-browser-framework.org][07-browser-framework.org]]
+- Doc 08 anvil-state (本 doc の cache backend): [[file:08-state.org][08-state.org]]
+- Phase A soak で判明した Reddit JS challenge / X login wall:
+  =memory/feedback_anvil_browser_login_antibot_limits.md=
+- Emacs server concurrency / yield 点の限界:
+  =memory/feedback_emacs_server_concurrency_model.md=
+- url-retrieve の挙動: Emacs manual =(info "(url) Retrieving URLs")=
+- RFC 9309 — Robots Exclusion Protocol
+- 既存の異名モジュール (命名衝突ガード): =anvil-net.el= は listening
+  port 調査 (netstat/ss/lsof wrapper)。HTTP fetch は本 =anvil-http= が担当

--- a/tests/anvil-http-test.el
+++ b/tests/anvil-http-test.el
@@ -1,0 +1,277 @@
+;;; anvil-http-test.el --- Tests for anvil-http -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Unit tests for `anvil-http' that stub `anvil-http--request' so no
+;; real network traffic happens.  One live smoke test at the bottom
+;; fetches https://example.com when ANVIL_ALLOW_LIVE=1 is set.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'anvil-http)
+(require 'anvil-state)
+
+;;;; --- fixtures -----------------------------------------------------------
+
+(defvar anvil-http-test--calls nil
+  "List of `(:method :url :headers :timeout)' recorded by the stub,
+newest first.")
+
+(defvar anvil-http-test--responses nil
+  "Queue of fake response plists to hand back to successive calls.")
+
+(defun anvil-http-test--pop-response ()
+  (or (pop anvil-http-test--responses)
+      (error "anvil-http-test: response queue exhausted")))
+
+(defmacro anvil-http-test--with-stub (responses &rest body)
+  "Run BODY with `anvil-http--request' returning successive RESPONSES.
+Provides a fresh `anvil-state' DB and zeroed metrics."
+  (declare (indent 1))
+  `(let ((anvil-http-test--calls nil)
+         (anvil-http-test--responses (copy-sequence ,responses))
+         (anvil-state-db-path (make-temp-file "anvil-http-st-" nil ".db"))
+         (anvil-state--db nil)
+         (anvil-http--metrics
+          (list :requests 0 :cache-fresh 0 :cache-revalidated 0
+                :network-200 0 :errors 0 :log nil)))
+     (unwind-protect
+         (progn
+           (anvil-state-enable)
+           (cl-letf (((symbol-function 'anvil-http--request)
+                      (lambda (method url headers timeout)
+                        (push (list :method method :url url
+                                    :headers headers :timeout timeout)
+                              anvil-http-test--calls)
+                        (anvil-http-test--pop-response)))
+                     ((symbol-function 'sleep-for)
+                      (lambda (&rest _) nil)))
+             ,@body))
+       (anvil-state-disable)
+       (ignore-errors (delete-file anvil-state-db-path)))))
+
+(defun anvil-http-test--response (status &optional headers body final-url)
+  (list :status status
+        :headers headers
+        :body (or body "")
+        :final-url (or final-url "https://example.com/")))
+
+;;;; --- URL validation -----------------------------------------------------
+
+(ert-deftest anvil-http-test-check-url-rejects-empty ()
+  "Empty or non-string URL → user-error."
+  (should-error (anvil-http-get "") :type 'user-error)
+  (should-error (anvil-http-get nil) :type 'user-error))
+
+(ert-deftest anvil-http-test-check-url-rejects-bad-scheme ()
+  "file:// / javascript: scheme are refused."
+  (should-error (anvil-http-get "file:///etc/passwd") :type 'user-error)
+  (should-error (anvil-http-get "javascript:alert(1)") :type 'user-error))
+
+(ert-deftest anvil-http-test-normalize-url-lowercases-and-strips-fragment ()
+  (should (equal "https://example.com/path?q=1"
+                 (anvil-http--normalize-url
+                  "HTTPS://Example.COM/path?q=1#section"))))
+
+;;;; --- happy path GET -----------------------------------------------------
+
+(ert-deftest anvil-http-test-get-returns-body-and-status ()
+  "200 response surfaces status/headers/body and records a cache entry."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response
+             200
+             (list :etag "\"abc\"" :content-type "text/html")
+             "<h1>hi</h1>"
+             "https://example.com/"))
+    (let ((resp (anvil-http-get "https://example.com/" :cache-ttl-sec 0)))
+      (should (= 200 (plist-get resp :status)))
+      (should (string-match-p "<h1>hi</h1>" (plist-get resp :body)))
+      (should-not (plist-get resp :from-cache))
+      (let ((entry (anvil-http--cache-get
+                    (anvil-http--normalize-url "https://example.com/"))))
+        (should entry)
+        (should (equal "\"abc\"" (plist-get entry :etag)))))))
+
+;;;; --- cache fresh-serve --------------------------------------------------
+
+(ert-deftest anvil-http-test-ttl-fresh-hit-avoids-network ()
+  "Second GET within TTL serves from cache with zero requests."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response
+             200 (list :etag "\"x\"") "body-v1"
+             "https://example.com/"))
+    (anvil-http-get "https://example.com/" :cache-ttl-sec 600)
+    (let ((before (length anvil-http-test--calls))
+          (resp (anvil-http-get "https://example.com/" :cache-ttl-sec 600)))
+      (should (= before (length anvil-http-test--calls)))
+      (should (plist-get resp :from-cache))
+      (should (string= "body-v1" (plist-get resp :body)))
+      (should (= 1 (plist-get anvil-http--metrics :cache-fresh))))))
+
+;;;; --- conditional revalidation / 304 -------------------------------------
+
+(ert-deftest anvil-http-test-304-serves-cached-body ()
+  "Expired TTL triggers conditional GET; 304 serves cached body."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response
+             200 (list :etag "\"v1\"" :last-modified "Wed, 01 Jan 2025 00:00:00 GMT")
+             "first-body" "https://example.com/")
+            (anvil-http-test--response 304 nil "" "https://example.com/"))
+    ;; Seed the cache with TTL=0 so next request revalidates.
+    (anvil-http-get "https://example.com/" :cache-ttl-sec 0)
+    (let ((resp (anvil-http-get "https://example.com/" :cache-ttl-sec 0)))
+      (should (= 200 (plist-get resp :status)))
+      (should (plist-get resp :from-cache))
+      (should (string= "first-body" (plist-get resp :body))))
+    (let* ((revalidate-call (car anvil-http-test--calls))
+           (headers (plist-get revalidate-call :headers)))
+      (should (equal "\"v1\"" (cdr (assoc "If-None-Match" headers))))
+      (should (assoc "If-Modified-Since" headers)))
+    (should (= 1 (plist-get anvil-http--metrics :cache-revalidated)))))
+
+;;;; --- if-newer-than forwarded as If-Modified-Since ------------------------
+
+(ert-deftest anvil-http-test-if-newer-than-sends-ims ()
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 200 nil "body"))
+    (anvil-http-get "https://example.com/" :if-newer-than 1700000000)
+    (let ((headers (plist-get (car anvil-http-test--calls) :headers)))
+      (should (assoc "If-Modified-Since" headers)))))
+
+;;;; --- retry on 5xx --------------------------------------------------------
+
+(ert-deftest anvil-http-test-retry-on-500-then-success ()
+  "500 is retried; second attempt's 200 is returned."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 500 nil "")
+            (anvil-http-test--response 200 nil "ok"))
+    (let ((resp (anvil-http-get "https://example.com/" :cache-ttl-sec 0)))
+      (should (= 200 (plist-get resp :status)))
+      (should (= 2 (length anvil-http-test--calls))))))
+
+(ert-deftest anvil-http-test-no-retry-on-404 ()
+  "4xx (non-408/429) is NOT retried and surfaces as tool-error."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 404 nil ""))
+    (should-error (anvil-http-get "https://example.com/404")
+                  :type 'anvil-server-tool-error)
+    (should (= 1 (length anvil-http-test--calls)))
+    (should (= 1 (plist-get anvil-http--metrics :errors)))))
+
+(ert-deftest anvil-http-test-429-retry-after-numeric ()
+  "429 with numeric Retry-After is honoured before retry."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 429 (list :retry-after "2") "")
+            (anvil-http-test--response 200 nil "ok"))
+    (let ((resp (anvil-http-get "https://example.com/rate" :cache-ttl-sec 0)))
+      (should (= 200 (plist-get resp :status)))
+      (should (= 2 (length anvil-http-test--calls))))))
+
+;;;; --- user-agent / Accept-Encoding injection -----------------------------
+
+(ert-deftest anvil-http-test-user-agent-and-accept-encoding ()
+  "Default UA + Accept-Encoding gzip are injected when absent.
+The real `anvil-http--request' inserts these — verified by letting it run
+in a fake url-retrieve."
+  (cl-letf* ((captured nil)
+             ((symbol-function 'url-retrieve-synchronously)
+              (lambda (&rest _)
+                (setq captured url-request-extra-headers)
+                ;; Return a buffer shaped like a minimal url-http response.
+                (with-current-buffer (generate-new-buffer " *anvil-http-fake*")
+                  (insert "HTTP/1.1 200 OK\r\n"
+                          "Content-Type: text/plain\r\n"
+                          "\r\n"
+                          "ok")
+                  (goto-char (point-min))
+                  (re-search-forward "\r\n\r\n")
+                  (setq-local url-http-end-of-headers
+                              (copy-marker (match-end 0)))
+                  (setq-local url-http-target-url "https://example.com/")
+                  (current-buffer)))))
+    (let ((anvil-state-db-path (make-temp-file "anvil-http-ua-" nil ".db"))
+          (anvil-state--db nil)
+          (anvil-http--metrics
+           (list :requests 0 :cache-fresh 0 :cache-revalidated 0
+                 :network-200 0 :errors 0 :log nil)))
+      (unwind-protect
+          (progn
+            (anvil-state-enable)
+            (anvil-http-get "https://example.com/" :cache-ttl-sec 0)
+            (should (assoc "User-Agent" captured))
+            (should (string-match-p "^anvil\\.el/"
+                                    (cdr (assoc "User-Agent" captured))))
+            (should (equal "gzip" (cdr (assoc "Accept-Encoding" captured)))))
+        (anvil-state-disable)
+        (ignore-errors (delete-file anvil-state-db-path))))))
+
+;;;; --- HEAD ---------------------------------------------------------------
+
+(ert-deftest anvil-http-test-head-does-not-cache ()
+  "HEAD bypasses the cache on both read and write."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response
+             200 (list :content-length "42") ""))
+    (let ((resp (anvil-http-head "https://example.com/")))
+      (should (= 200 (plist-get resp :status)))
+      (should (equal "42" (plist-get (plist-get resp :headers) :content-length)))
+      (should-not (anvil-http--cache-get
+                   (anvil-http--normalize-url "https://example.com/"))))))
+
+;;;; --- cache clear --------------------------------------------------------
+
+(ert-deftest anvil-http-test-cache-clear-by-url ()
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 200 nil "body"))
+    (anvil-http-get "https://example.com/page" :cache-ttl-sec 600)
+    (should (anvil-http--cache-get
+             (anvil-http--normalize-url "https://example.com/page")))
+    (should (= 1 (anvil-http-cache-clear "https://example.com/page")))
+    (should-not (anvil-http--cache-get
+                 (anvil-http--normalize-url "https://example.com/page")))))
+
+(ert-deftest anvil-http-test-cache-clear-all ()
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 200 nil "a")
+            (anvil-http-test--response 200 nil "b"))
+    (anvil-http-get "https://example.com/a" :cache-ttl-sec 600)
+    (anvil-http-get "https://example.com/b" :cache-ttl-sec 600)
+    (should (>= (anvil-http-cache-clear) 2))
+    (should-not (anvil-http--cache-get
+                 (anvil-http--normalize-url "https://example.com/a")))))
+
+;;;; --- MCP tool argument coercion -----------------------------------------
+
+(ert-deftest anvil-http-test-tool-fetch-coerces-string-timeout ()
+  "MCP params arrive as strings; the tool coerces digit strings."
+  (anvil-http-test--with-stub
+      (list (anvil-http-test--response 200 nil "ok"))
+    (anvil-http--tool-fetch "https://example.com/" nil nil "42" nil)
+    (should (= 42 (plist-get (car anvil-http-test--calls) :timeout)))))
+
+;;;; --- live smoke test ----------------------------------------------------
+
+(ert-deftest anvil-http-test-live-example-com ()
+  "Hit the real server when ANVIL_ALLOW_LIVE=1."
+  (skip-unless (and (not (getenv "ANVIL_SKIP_LIVE"))
+                    (getenv "ANVIL_ALLOW_LIVE")))
+  (let ((anvil-state-db-path (make-temp-file "anvil-http-live-" nil ".db"))
+        (anvil-state--db nil)
+        (anvil-http--metrics
+         (list :requests 0 :cache-fresh 0 :cache-revalidated 0
+               :network-200 0 :errors 0 :log nil)))
+    (unwind-protect
+        (progn
+          (anvil-state-enable)
+          (let ((resp (anvil-http-get "https://example.com/"
+                                      :cache-ttl-sec 0)))
+            (should (= 200 (plist-get resp :status)))
+            (should (string-match-p "Example Domain"
+                                    (plist-get resp :body)))))
+      (anvil-state-disable)
+      (ignore-errors (delete-file anvil-state-db-path)))))
+
+(provide 'anvil-http-test)
+;;; anvil-http-test.el ends here


### PR DESCRIPTION
## Summary

Phase C1 anvil-http の **Phase 1a sub-phase** を ship。Emacs の
`url-retrieve-synchronously` に薄い wrapper を重ね、LLM client が
token 最小で静的 HTTP/JSON リソースを取れる MCP tool 3 本を提供する。

- `http-fetch` — GET、`anvil-state` ns=\"http\" 経由の ETag/TTL cache 付き
- `http-head`  — HEAD probe (no cache)
- `http-cache-clear` — URL 指定 or http ns 全 flush

### なぜ今これを

anvil-browser (Chrome + agent-browser) は accessibility tree 抽出に強いが
Chrome cold-start ~500ms/call、Reddit `.json` のような軽量 JSON / 公開
REST API に対しては純粋なオーバーヘッド。本 MCP tool でこの経路を埋める。

Efficiency levers (selector / overflow / batch / robots) は意図的に
Phase 1b-1e へ分離。1a 単体でも Reddit `.json` / Maxun REST / 公開 docs
polling の価値が届く粒度にした。

### 主要な挙動

1. **TTL fresh-hit** — `anvil-http-cache-ttl-sec` (既定 300s) 内の同 URL は
   zero-network で cache から serve
2. **条件付き GET** — 期限切れ時 `If-None-Match` / `If-Modified-Since` を
   自動送信、304 で body 再利用 + fetched-at 更新
3. **リトライ** — 5xx / 408 / 429 を exponential backoff、429 は
   `Retry-After` (数値) 尊重
4. **SSRF 防衛** — `anvil-http-allowed-schemes` (既定 http/https) で
   file:// / javascript: は user-error
5. **metrics** — `M-x anvil-http-status` で requests / cache-fresh /
   revalidated / errors + 直近 20 件 log

### Phase 境界 (Doc 09 より)

| Phase | Scope |
|-------|-------|
| **1a** ← **this PR** | Core GET/HEAD + cache + 304 + MCP 登録 |
| 1b | selector + json-path (libxml primary + regex fallback) |
| 1c | overflow (disk spill) + header-filter |
| 1d | http-fetch-batch (url-queue concurrency) |
| 1e | robots.txt parser + fetcher |

## Test plan

- [x] `make test-all` 292/293 pass (previous 277 + 15 new http tests; 1 live test skipped unless `ANVIL_ALLOW_LIVE=1`)
- [x] Unit coverage: URL validation / scheme guard / normalize / happy path / TTL fresh hit / 304 revalidate (If-None-Match + If-Modified-Since) / if-newer-than / 500→200 retry / 404 no-retry / 429 Retry-After / UA + Accept-Encoding injection / HEAD no-cache / cache-clear (URL / all) / MCP tool string-arg coercion
- [x] Live smoke: `ANVIL_ALLOW_LIVE=1` 経由で https://example.com 実取得 passed
- [ ] 実機 integration: main daemon に reload → `/mcp` で `http-fetch` を叩いて Reddit `.json` 取得体感確認 (post-merge、Phase 1b 着手前)

🤖 Generated with [Claude Code](https://claude.com/claude-code)