### PR TITLE
fix(mcp): normalize encoded tool handlers

### DIFF
--- a/anvil-git.el
+++ b/anvil-git.el
@@ -419,7 +419,7 @@ Keys: :ref (commit-ish to check out, default \"HEAD\"),
 MCP Parameters:
   path - Directory or file path inside the repo."
   (anvil-server-with-error-handling
-   (or (anvil-git-repo-root path) :null)))
+   (or (anvil-git-repo-root path) "null")))
 
 (defun anvil-git--tool-head-sha (path &optional short)
   "Return HEAD SHA for the repo containing PATH.
@@ -429,7 +429,7 @@ MCP Parameters:
   short - Truthy → return the abbreviated SHA."
   (anvil-server-with-error-handling
    (or (anvil-git-head-sha path (and short (not (equal short ""))))
-       :null)))
+       "null")))
 
 (defun anvil-git--tool-branch-current (path)
   "Return the current branch for PATH, or nil when detached.
@@ -437,7 +437,7 @@ MCP Parameters:
 MCP Parameters:
   path - Directory inside the repo."
   (anvil-server-with-error-handling
-   (or (anvil-git-branch-current path) :null)))
+   (or (anvil-git-branch-current path) "null")))
 
 (defun anvil-git--tool-log (path &optional limit)
   "Return recent commits for repo at PATH.
@@ -451,7 +451,7 @@ MCP Parameters:
                         (string-match "\\`[0-9]+\\'" limit))
                    (string-to-number limit))
                   (t nil))))
-     (or (anvil-git-log path n) :empty-array))))
+     (or (anvil-git-log path n) "[]"))))
 
 (defun anvil-git--tool-diff-names (path &optional from to)
   "Return changed paths between FROM and TO in repo at PATH.
@@ -463,7 +463,7 @@ MCP Parameters:
   (anvil-server-with-error-handling
    (let ((f  (and (stringp from) (not (string-empty-p from)) from))
          (t* (and (stringp to)   (not (string-empty-p to))   to)))
-     (or (anvil-git-diff-names path f t*) :empty-array))))
+     (or (anvil-git-diff-names path f t*) "[]"))))
 
 (defun anvil-git--tool-diff-stats (path &optional rev)
   "Return structured diff counts for repo at PATH.
@@ -489,14 +489,14 @@ MCP Parameters:
 MCP Parameters:
   path - Directory inside the repo."
   (anvil-server-with-error-handling
-   (or (anvil-git-worktree-list path) :empty-array)))
+   (or (anvil-git-worktree-list path) "[]")))
 
 ;;;; --- module lifecycle ---------------------------------------------------
 
 (defun anvil-git--register-tools ()
   "Register git-* MCP tools under `anvil-git--server-id'."
   (anvil-server-register-tool
-   #'anvil-git--tool-repo-root
+   (anvil-server-encode-handler #'anvil-git--tool-repo-root)
    :id "git-repo-root"
    :server-id anvil-git--server-id
    :description
@@ -505,7 +505,7 @@ not inside a repository."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-head-sha
+   (anvil-server-encode-handler #'anvil-git--tool-head-sha)
    :id "git-head-sha"
    :server-id anvil-git--server-id
    :description
@@ -514,7 +514,7 @@ short=1 for the abbreviated form."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-branch-current
+   (anvil-server-encode-handler #'anvil-git--tool-branch-current)
    :id "git-branch-current"
    :server-id anvil-git--server-id
    :description
@@ -522,7 +522,7 @@ short=1 for the abbreviated form."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-log
+   (anvil-server-encode-handler #'anvil-git--tool-log)
    :id "git-log"
    :server-id anvil-git--server-id
    :description
@@ -531,7 +531,7 @@ limit defaults to 20."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-diff-names
+   (anvil-server-encode-handler #'anvil-git--tool-diff-names)
    :id "git-diff-names"
    :server-id anvil-git--server-id
    :description
@@ -540,7 +540,7 @@ unstaged-vs-HEAD)."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-diff-stats
+   (anvil-server-encode-handler #'anvil-git--tool-diff-stats)
    :id "git-diff-stats"
    :server-id anvil-git--server-id
    :description
@@ -549,7 +549,7 @@ for REV or unstaged-vs-HEAD."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-status
+   (anvil-server-encode-handler #'anvil-git--tool-status)
    :id "git-status"
    :server-id anvil-git--server-id
    :description
@@ -558,7 +558,7 @@ as one plist.  Buckets: staged / modified / untracked / unmerged."
    :read-only t)
 
   (anvil-server-register-tool
-   #'anvil-git--tool-worktree-list
+   (anvil-server-encode-handler #'anvil-git--tool-worktree-list)
    :id "git-worktree-list"
    :server-id anvil-git--server-id
    :description

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -50,7 +50,10 @@
 (declare-function treesit-node-child-count "treesit" (node))
 (declare-function treesit-node-check "treesit" (node property))
 (declare-function treesit-parser-list "treesit" (&optional buffer language))
+(declare-function treesit-parser-create "treesit" (language &optional buffer no-reuse tag))
 (declare-function treesit-parser-root-node "treesit" (parser))
+(autoload 'anvil-treesit-language-for-file "anvil-treesit" nil nil)
+(autoload 'anvil-treesit-ensure-grammar "anvil-treesit" nil nil)
 
 ;; Flycheck declarations
 (defvar flycheck-current-errors)
@@ -232,6 +235,32 @@ LEVEL is indentation level, MAX-DEPTH is the limit."
                                 child (1+ level) max-depth)))))
       result)))
 
+(defun anvil-ide--treesit-parse-integer (value name minimum)
+  "Parse VALUE as an integer MCP parameter named NAME.
+VALUE may already be an integer or a decimal string.
+MINIMUM is the inclusive lower bound."
+  (let ((n (cond
+            ((null value) nil)
+            ((integerp value) value)
+            ((and (stringp value)
+                  (string-match-p "\\`[0-9]+\\'" value))
+             (string-to-number value))
+            (t
+             (user-error "%s must be an integer, got %S" name value)))))
+    (when (and n (< n minimum))
+      (user-error "%s must be >= %d, got %S" name minimum value))
+    n))
+
+(defun anvil-ide--treesit-ensure-parser (file-path)
+  "Return a tree-sitter parser for the current buffer visiting FILE-PATH.
+If no parser exists yet, infer the language from FILE-PATH and create
+one after verifying the grammar is installed."
+  (or (car (treesit-parser-list))
+      (let ((lang (anvil-treesit-language-for-file file-path)))
+        (when lang
+          (anvil-treesit-ensure-grammar lang)
+          (treesit-parser-create lang)))))
+
 (defun anvil-ide--treesit-info (file-path &optional line column whole_file include_ancestors include_children)
   "Get tree-sitter syntax tree information for FILE-PATH.
 
@@ -243,22 +272,24 @@ MCP Parameters:
   include_ancestors - include parent node hierarchy
   include_children - include child nodes"
   (anvil-server-with-error-handling
-   (if (not (treesit-available-p))
+   (if (not (and (fboundp 'treesit-available-p)
+                 (treesit-available-p)))
        "Tree-sitter is not available in this Emacs build"
-     (let ((target-buffer (or (find-buffer-visiting file-path)
-                              (find-file-noselect file-path))))
+     (let* ((line-number (anvil-ide--treesit-parse-integer line "line" 1))
+            (column-number (anvil-ide--treesit-parse-integer column "column" 0))
+            (target-buffer (or (find-buffer-visiting file-path)
+                               (find-file-noselect file-path))))
        (with-current-buffer target-buffer
-         (let* ((parsers (treesit-parser-list))
-                (parser (car parsers)))
+         (let ((parser (anvil-ide--treesit-ensure-parser file-path)))
            (if (not parser)
                (format "No tree-sitter parser available for %s" file-path)
              (let* ((root-node (treesit-parser-root-node parser))
                     (pos (cond (whole_file nil)
-                               (line (save-excursion
-                                       (goto-char (point-min))
-                                       (forward-line (1- line))
-                                       (move-to-column (or column 0))
-                                       (point)))
+                               (line-number (save-excursion
+                                              (goto-char (point-min))
+                                              (forward-line (1- line-number))
+                                              (move-to-column (or column-number 0))
+                                              (point)))
                                (t (point))))
                     (node (if whole_file root-node (treesit-node-at pos parser)))
                     (results '()))

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'anvil-server)
+(require 'apropos)
 (require 'xref)
 (require 'cl-lib)
 (require 'imenu)

--- a/anvil-orchestrator.el
+++ b/anvil-orchestrator.el
@@ -2443,10 +2443,10 @@ through `anvil-orchestrator--to-json-value' then `json-encode'."
 
 Keeps the underlying tool body returning a rich plist for direct
 Elisp / ERT callers while the MCP transport receives a JSON string.
-HANDLER is called with whatever positional/rest arguments the
-wrapper receives."
-  (lambda (&rest args)
-    (anvil-orchestrator--encode-for-mcp (apply handler args))))
+Schema extraction and MCP argument binding continue to use HANDLER's
+raw signature/docstring via `anvil-server--make-encoded-handler'."
+  (anvil-server--make-encoded-handler
+   handler #'anvil-orchestrator--encode-for-mcp))
 
 ;;;; --- MCP tool wrappers --------------------------------------------------
 

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -1788,6 +1788,18 @@ will be caught by the resource handler infrastructure."
   "Return non-nil when X is a plist (keyword-keyed list)."
   (and (consp x) (keywordp (car x))))
 
+(defun anvil-server--list-to-json-array (xs)
+  "Recursively convert proper or improper list XS into a JSON array.
+A dotted tail becomes the final array element, so `(1 . 2)' becomes
+`[1, 2]' on the wire."
+  (let (out)
+    (while (consp xs)
+      (push (anvil-server--to-json-value (car xs)) out)
+      (setq xs (cdr xs)))
+    (when xs
+      (push (anvil-server--to-json-value xs) out))
+    (vconcat (nreverse out))))
+
 (defun anvil-server--to-json-value (x)
   "Recursively convert X into a value that `json-encode' renders sensibly.
 Plists become alists with symbol keys (leading colon stripped).
@@ -1805,7 +1817,7 @@ through unchanged.  Keywords serialize as their bare name (no colon)."
              collect (cons (intern (substring (symbol-name k) 1))
                            (anvil-server--to-json-value v))))
    ((listp x)
-    (apply #'vector (mapcar #'anvil-server--to-json-value x)))
+    (anvil-server--list-to-json-array x))
    (t x)))
 
 (defun anvil-server-encode-for-mcp (value)

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -366,6 +366,25 @@ fills them with nil at dispatch time."
         ;; No user-visible arguments case (all args are `_'-prefixed or empty)
         '((type . "object"))))))
 
+(defun anvil-server--normalize-tool-handler (handler)
+  "Return registration metadata derived from HANDLER.
+Wrappers created by `anvil-server-encode-handler' (or compatible helpers
+that set the `anvil-server-raw-handler' / `anvil-server-encode-result'
+symbol properties) keep the original handler as the source of truth for
+schema extraction and argument binding while transport encoding happens
+after execution."
+  (let* ((raw-handler
+          (if-let ((wrapped (and (symbolp handler)
+                                 (get handler 'anvil-server-raw-handler))))
+              wrapped
+            handler))
+         (encode-result
+          (and (symbolp handler)
+               (get handler 'anvil-server-encode-result))))
+    (list :handler raw-handler
+          :arglist (help-function-arglist raw-handler t)
+          :encode-result encode-result)))
+
 (defun anvil-server--ref-counted-register (key item table)
   "Register ITEM with KEY in TABLE with reference counting.
 If KEY already exists, increment its reference count.
@@ -951,18 +970,21 @@ virtual server-ids share the same handler pool."
               (context (list :id id)))
           (condition-case err
               (let*
-                  ;; Check if handler is defined before trying to get arglist
                   ((arglist
-                    (if (fboundp handler)
-                        (help-function-arglist handler t)
-                      ;; If undefined, signal early with proper error
-                      (signal 'void-function (list handler))))
+                    (progn
+                      (unless (functionp handler)
+                        (signal 'void-function (list handler)))
+                      ;; Keep dispatch aligned with registration-time
+                      ;; schema extraction, including transport-only
+                      ;; wrappers created by `anvil-server-encode-handler'.
+                      (or (plist-get tool :arglist)
+                          (help-function-arglist handler t))))
                    (expected-params '())
                    (required-params '())
                    (provided-params '())
                    (arg-values '())
                    (seen-optional nil)
-                   (result
+                   (raw-result
                     (progn
                       ;; Collect expected and required parameter names.
                       ;; `_'-prefixed args follow the Elisp unused-arg
@@ -1022,6 +1044,13 @@ virtual server-ids share the same handler pool."
                             (anvil-server--offload-apply
                              tool handler final-args)
                           (apply handler final-args)))))
+                   ;; `anvil-server-encode-handler' marks tools that want
+                   ;; transport-level JSON encoding while their raw
+                   ;; handler keeps returning rich Lisp data.
+                   (result
+                    (if (plist-get tool :encode-result)
+                        (anvil-server-encode-for-mcp raw-result)
+                      raw-result))
                    ;; Ensure result is string or nil, error on other types
                    (result-text
                     (cond
@@ -1336,6 +1365,10 @@ Optional properties:
   :server-id       Server identifier (defaults to \"default\")
 
 The HANDLER function's signature determines its input schema.
+When HANDLER is wrapped by `anvil-server-encode-handler' (or a
+compatible wrapper), registration still derives schema and
+parameter validation from the underlying raw handler and only
+encodes the result at the MCP transport boundary.
 Currently only no-argument and single-argument handlers are supported.
 
 Example:
@@ -1385,17 +1418,25 @@ See also:
     ;; Check for existing registration
     (if-let* ((existing (gethash id tools-table)))
       (anvil-server--ref-counted-register id existing tools-table)
-      (let* ((schema
-              (anvil-server--generate-schema-from-function handler))
+      (let* ((handler-meta
+              (anvil-server--normalize-tool-handler handler))
+             (raw-handler (plist-get handler-meta :handler))
+             (arglist (plist-get handler-meta :arglist))
+             (encode-result (plist-get handler-meta :encode-result))
+             (schema
+              (anvil-server--generate-schema-from-function raw-handler))
              (tool
               (list
                :id id
                :description description
-               :handler handler
+               :handler raw-handler
+               :arglist arglist
                :schema schema)))
         ;; Add optional properties if provided
         (when title
           (setq tool (plist-put tool :title title)))
+        (when encode-result
+          (setq tool (plist-put tool :encode-result t)))
         ;; Always include :read-only if it was specified, even if nil
         (when (plist-member properties :read-only)
           (setq tool (plist-put tool :read-only read-only)))
@@ -1404,6 +1445,8 @@ See also:
         ;; subprocess instead of the main daemon.  The handler must be a
         ;; symbol (not a lambda) because the subprocess identifies it by
         ;; name after loading the features listed in :offload-require.
+        ;; Encoded registration wrappers are normalized back to the raw
+        ;; handler before offload metadata is stored.
         (dolist (k '(:offload :offload-require :offload-load-path
                               :offload-inherit-load-path
                               :offload-timeout
@@ -1732,9 +1775,11 @@ will be caught by the resource handler infrastructure."
 ;;      flags any `(list :K ...)' that is still the terminal form.
 ;;
 ;;   2. Tag the file with the `;;; anvil-audit: tools-wrapped-at-registration'
-;;      header and wrap each registered handler with `anvil-server-encode-
-;;      handler' at registration time (the pattern anvil-orchestrator uses
-;;      for its ~25 tools).
+;;      header and wrap each registered handler with
+;;      `anvil-server-encode-handler' at registration time.  The wrapper is
+;;      transport-only: registration still inspects the underlying raw
+;;      handler and applies JSON encoding after execution (the pattern
+;;      anvil-orchestrator uses for its ~25 tools).
 ;;
 ;; Option 1 is the smaller, per-tool fix; option 2 is the whole-module
 ;; pattern.  Both produce the same wire format and pass the scanner.
@@ -1771,14 +1816,36 @@ Strings and nil pass through unchanged; other shapes round-trip through
    ((or (null value) (stringp value)) value)
    (t (json-encode (anvil-server--to-json-value value)))))
 
+(defun anvil-server--encoded-handler-dispatch (encoder handler &rest args)
+  "Apply HANDLER to ARGS, then pass the result through ENCODER."
+  (funcall encoder (apply handler args)))
+
+(defun anvil-server--make-encoded-handler (handler encoder)
+  "Return a symbol-backed transport wrapper around HANDLER using ENCODER.
+The wrapper records the underlying raw handler on the
+`anvil-server-raw-handler' symbol property and marks
+`anvil-server-encode-result' so registration can preserve the raw
+signature/docstring for schema extraction and dispatch."
+  (let* ((name (if (symbolp handler)
+                   (symbol-name handler)
+                 "handler"))
+         (sym (make-symbol (format "anvil-encoded:%s" name))))
+    (put sym 'anvil-server-raw-handler handler)
+    (put sym 'anvil-server-encode-result t)
+    (put sym 'function-documentation (documentation handler t))
+    (fset sym
+          (apply-partially #'anvil-server--encoded-handler-dispatch
+                           encoder handler))
+    sym))
+
 (defun anvil-server-encode-handler (handler)
   "Return a wrapper around HANDLER that JSON-encodes its result.
 Lets the underlying tool body keep returning a rich plist for direct
 Elisp / ERT callers while the MCP transport receives a JSON string.
-HANDLER is called with whatever positional/rest arguments the
-wrapper receives."
-  (lambda (&rest args)
-    (anvil-server-encode-for-mcp (apply handler args))))
+Schema extraction and MCP argument binding still use HANDLER's raw
+signature/docstring via `anvil-server-register-tool'."
+  (anvil-server--make-encoded-handler
+   handler #'anvil-server-encode-for-mcp))
 
 (provide 'anvil-server)
 ;;; anvil-server.el ends here

--- a/anvil-worker.el
+++ b/anvil-worker.el
@@ -1052,7 +1052,7 @@ cheap enough to poll at interactive rates."
                      (alive  (anvil-worker--quick-alive-p w))
                      (busy   (plist-get w :busy))
                      (sfile  (plist-get w :server-file))
-                     (pid    (and server-use-tcp alive
+                     (pid    (and alive
                                   (anvil-worker--server-file-pid sfile))))
                 (push (format "    %s: %s%s%s"
                               (plist-get w :name)

--- a/anvil-worker.el
+++ b/anvil-worker.el
@@ -465,8 +465,9 @@ Each worker plist carries:
 (defun anvil-worker--server-file (lane index)
   "Return server file path for worker LANE/INDEX."
   (expand-file-name
-   (concat "server/" (anvil-worker--name lane index))
-   user-emacs-directory))
+   (anvil-worker--name lane index)
+   (expand-file-name
+    (if server-use-tcp server-auth-dir server-socket-dir))))
 
 (defun anvil-worker--log (event &optional details)
   "Append EVENT with optional DETAILS to the lifecycle log."
@@ -578,17 +579,20 @@ Emacs server files start with `HOST:PORT PID' on line one."
         (string-to-number (match-string 1))))))
 
 (defun anvil-worker--server-file-stale-p (server-file)
-  "Return non-nil if SERVER-FILE's recorded PID is no longer running.
-A missing PID (unparseable file) is treated as stale too."
-  (let ((pid (anvil-worker--server-file-pid server-file)))
-    (or (null pid)
-        (null (process-attributes pid)))))
+  "Return non-nil if SERVER-FILE no longer points at a live server.
+TCP auth files are checked via the recorded PID.  Local socket
+servers are checked via `server-running-p' on the socket basename."
+  (if server-use-tcp
+      (let ((pid (anvil-worker--server-file-pid server-file)))
+        (or (null pid)
+            (null (process-attributes pid))))
+    (not (server-running-p (file-name-nondirectory server-file)))))
 
 (defun anvil-worker--worker-alive-p (worker)
   "Return non-nil if WORKER plist is reachable.
-Performs the same three checks as `anvil-worker-alive-p'
-(file-exists / PID still alive / bounded `emacsclient' probe)
-and deletes a stale server file as a side-effect."
+Performs the same cheap checks as `anvil-worker--quick-alive-p'
+followed by a bounded `emacsclient' probe, and deletes a stale
+server file as a side-effect."
   (let ((server-file (plist-get worker :server-file)))
     (cond
      ((not (file-exists-p server-file)) nil)
@@ -637,9 +641,10 @@ its server socket before we start firing `emacsclient' at it."
 (defun anvil-worker--quick-alive-p (worker)
   "Fast, non-blocking alive check for WORKER.
 Unlike `anvil-worker--worker-alive-p', this never spawns an
-`emacsclient' probe — it only checks file existence and PID
-liveness.  Returns non-nil when the server file exists AND its
-PID is still running.  Deletes stale server files as a side
+`emacsclient' probe — it only checks file existence plus cheap
+liveness (`server-running-p' for local sockets, PID parsing for
+TCP auth files).  Returns non-nil when the server file exists and
+still points at a live server.  Deletes stale server files as a side
 effect."
   (let ((server-file (plist-get worker :server-file)))
     (cond
@@ -1047,7 +1052,7 @@ cheap enough to poll at interactive rates."
                      (alive  (anvil-worker--quick-alive-p w))
                      (busy   (plist-get w :busy))
                      (sfile  (plist-get w :server-file))
-                     (pid    (and alive
+                     (pid    (and server-use-tcp alive
                                   (anvil-worker--server-file-pid sfile))))
                 (push (format "    %s: %s%s%s"
                               (plist-get w :name)

--- a/tests/anvil-orchestrator-test.el
+++ b/tests/anvil-orchestrator-test.el
@@ -2666,6 +2666,49 @@ becomes a JSON string (the fix for MCP transport)."
     (should (= 21 (plist-get back :echo)))
     (should (= 42 (plist-get back :doubled)))))
 
+(ert-deftest anvil-orchestrator--encode-handler-registers-with-server ()
+  "`anvil-orchestrator--encode-handler' must remain compatible with server registration."
+  (defun anvil-orchestrator-test--wrapped-tool (task_id &optional note)
+    "Return TASK_ID and NOTE in a plist.
+
+MCP Parameters:
+  task_id - Task identifier string.
+  note - Optional note string."
+    (list :task_id task_id :note note))
+  (let ((tool-id "anvil-orchestrator-test-wrapped")
+        (server-id "anvil-orchestrator-test")
+        (wrapped
+         (anvil-orchestrator--encode-handler
+          #'anvil-orchestrator-test--wrapped-tool)))
+    (unwind-protect
+        (progn
+          (anvil-server-register-tool
+           wrapped
+           :id tool-id
+           :description "orchestrator wrapped tool"
+           :server-id server-id)
+          (let* ((tool (gethash tool-id
+                                (anvil-server--get-server-tools server-id)))
+                 (resp (anvil-server--handle-tools-call
+                        "t-orch-wrap"
+                        `((name . ,tool-id)
+                          (arguments . ((task_id . "t-1")
+                                        (note . "hello"))))
+                        (make-anvil-server-metrics) server-id))
+                 (decoded (json-read-from-string resp))
+                 (result (alist-get 'result decoded))
+                 (text (alist-get 'text
+                                  (aref (alist-get 'content result) 0)))
+                 (payload (json-parse-string text :object-type 'plist)))
+            (should (eq 'anvil-orchestrator-test--wrapped-tool
+                        (plist-get tool :handler)))
+            (should (plist-get tool :encode-result))
+            (should (equal '(task_id &optional note)
+                           (plist-get tool :arglist)))
+            (should (equal "t-1" (plist-get payload :task_id)))
+            (should (equal "hello" (plist-get payload :note)))))
+      (anvil-server-unregister-tool tool-id server-id))))
+
 (ert-deftest anvil-orchestrator--batch-task-ids-accessor ()
   "Encapsulates the `--batches' storage shape so callers stay decoupled."
   (let ((anvil-orchestrator--batches (make-hash-table :test 'equal)))

--- a/tests/anvil-test.el
+++ b/tests/anvil-test.el
@@ -173,6 +173,80 @@ MCP Parameters:
     (should (assoc "task_id" props))
     (should (equal ["task_id"] required))))
 
+;;;; --- encoded registration wrappers -------------------------------------
+
+(ert-deftest anvil-test-register-tool-normalizes-encoded-handler ()
+  "`anvil-server-register-tool' must introspect wrapped tools via the raw handler."
+  (defun anvil-test--wrapped-schema-tool (path &optional mode)
+    "Return PATH and MODE in a plist.
+
+MCP Parameters:
+  path - Absolute path to inspect.
+  mode - Optional mode string."
+    (list :path path :mode mode))
+  (let ((tool-id "anvil-test-wrapped-schema")
+        (server-id "anvil-test")
+        (wrapped
+         (anvil-server-encode-handler #'anvil-test--wrapped-schema-tool)))
+    (unwind-protect
+        (progn
+          (anvil-server-register-tool
+           wrapped
+           :id tool-id
+           :description "wrapped schema test"
+           :server-id server-id)
+          (let* ((tool (gethash tool-id
+                                (anvil-server--get-server-tools server-id)))
+                 (schema (plist-get tool :schema))
+                 (props (alist-get 'properties schema))
+                 (required (alist-get 'required schema)))
+            (should (eq 'anvil-test--wrapped-schema-tool
+                        (plist-get tool :handler)))
+            (should (equal '(path &optional mode)
+                           (plist-get tool :arglist)))
+            (should (plist-get tool :encode-result))
+            (should (assoc "path" props))
+            (should (assoc "mode" props))
+            (should (equal ["path"] required))))
+      (anvil-server-unregister-tool tool-id server-id))))
+
+(ert-deftest anvil-test-dispatch-encodes-wrapped-handler-result ()
+  "`tools/call' must validate args against the raw signature, then encode the result."
+  (defun anvil-test--wrapped-dispatch-tool (task_id &optional mode)
+    "Echo TASK_ID and MODE as a plist.
+
+MCP Parameters:
+  task_id - Task identifier string.
+  mode - Optional execution mode string."
+    (list :task_id task_id :mode mode))
+  (let ((tool-id "anvil-test-wrapped-dispatch")
+        (server-id "anvil-test")
+        (wrapped
+         (anvil-server-encode-handler #'anvil-test--wrapped-dispatch-tool)))
+    (unwind-protect
+        (progn
+          (anvil-server-register-tool
+           wrapped
+           :id tool-id
+           :description "wrapped dispatch test"
+           :server-id server-id)
+          (let* ((params `((name . ,tool-id)
+                           (arguments . ((task_id . "task-7")
+                                         (mode . "fast")))))
+                 (resp (anvil-server--handle-tools-call
+                        "t-wrapped" params
+                        (make-anvil-server-metrics) server-id))
+                 (decoded (json-read-from-string resp))
+                 (result (alist-get 'result decoded))
+                 (text (alist-get 'text
+                                  (aref (alist-get 'content result) 0)))
+                 (payload (json-parse-string text :object-type 'plist)))
+            (should (eq :json-false (alist-get 'isError result)))
+            (should (stringp text))
+            (should (equal "task-7" (plist-get payload :task_id)))
+            (should (equal "fast" (plist-get payload :mode)))))
+      (anvil-server-unregister-tool tool-id server-id))))
+
 ;;; :offload dispatch (Doc 03 Phase 2b) ------------------------------
 
 (defun anvil-test--offload-stub-dir ()


### PR DESCRIPTION
## Summary

Fix MCP tool registration and dispatch for handlers wrapped with
`anvil-server-encode-handler` (and the orchestrator's equivalent wrapper).

Previously, wrapped handlers exposed a `(&rest args)` signature to
`anvil-server-register-tool`, which caused schema generation to reject them
and made optional modules like `sexp` and `py` get skipped during enable.

## What changed

- Normalize encoded registration wrappers back to their raw handler during tool registration
- Cache the raw arglist on the tool plist for dispatch-time parameter binding
- Keep transport JSON encoding at the MCP boundary via `:encode-result`
- Switch encoded handler wrappers to symbol-backed wrappers with raw-handler metadata
- Update the orchestrator wrapper to use the same encoded-handler machinery
- Add regression tests for:
  - wrapped handler registration/schema generation
  - wrapped handler dispatch/result encoding
  - orchestrator wrapper compatibility with server registration

## Verification

Manually verified after reloading the modified source:

- `anvil-sexp-enable` registers successfully
- `anvil-py-enable` registers successfully
- `anvil-bench-enable` registers successfully
- `anvil-git-msg-enable` registers successfully

Added regression tests:

- `anvil-test-register-tool-normalizes-encoded-handler`
- `anvil-test-dispatch-encodes-wrapped-handler-result`
- `anvil-orchestrator--encode-handler-registers-with-server`
