### PR TITLE
fix(py,ide,discovery): fix MCP import spec handling and project resolution

### DIFF
--- a/README.org
+++ b/README.org
@@ -826,8 +826,8 @@ The =git= module is part of the default =anvil-modules= list.  It
 exposes read-only git inspection tools under the shared
 =emacs-eval= server id:
 
-- =git-repo-root= — top-level directory for a path, nil outside
-  a repo.
+- =git-repo-root= — top-level directory for a directory path, nil
+  outside a repo.
 - =git-head-sha= — full or abbreviated HEAD commit.
 - =git-branch-current= — current branch name, nil for detached.
 - =git-log= — recent commits as =(hash, date, author, subject)=

--- a/anvil-discovery.el
+++ b/anvil-discovery.el
@@ -1,7 +1,6 @@
 ;;; anvil-discovery.el --- Intent-based MCP tool discovery  -*- lexical-binding: t; -*-
 
 ;; Author: zawatton
-;; Package-Requires: ((emacs "29.1") (anvil-server "0.1"))
 ;; Keywords: tools, mcp
 
 ;;; Commentary:

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -1014,14 +1014,27 @@ caller does not have to scan it."
       (error (push (error-message-string err) errors)))
     (with-current-buffer log-buf
       (goto-char (point-min))
-      (while (re-search-forward
-              "^\\(?:.*?:\\)?\\(?:[0-9]+:[0-9]+: ?\\)?\\(Warning\\|Error\\): \\(.*\\)$"
-              nil t)
-        (let ((kind (match-string 1))
-              (msg  (match-string 2)))
-          (if (equal kind "Warning")
-              (push msg warnings)
-            (push msg errors)))))
+      (while (not (eobp))
+        (let ((line-text (buffer-substring-no-properties
+                          (line-beginning-position) (line-end-position))))
+          (cond
+           ((string-match
+             "^\\(?:.*?\\):\\([0-9]+\\):\\([0-9]+\\):\\s-*\\(Warning\\|Error\\):\\s-*\\(.*\\)$"
+             line-text)
+            (let ((kind (match-string 3 line-text))
+                  (msg  (match-string 4 line-text)))
+              (if (equal kind "Warning")
+                  (push msg warnings)
+                (push msg errors))))
+           ((string-match
+             "^\\(?:.*?\\):\\s-*\\(Warning\\|Error\\):\\s-*\\(.*\\)$"
+             line-text)
+            (let ((kind (match-string 1 line-text))
+                  (msg  (match-string 2 line-text)))
+              (if (equal kind "Warning")
+                  (push msg warnings)
+                (push msg errors)))))
+        (forward-line 1))))
     (format "%S" (list :ok (and result (null errors))
                        :output (concat (file-name-sans-extension path) ".elc")
                        :warnings (nreverse warnings)

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -845,14 +845,44 @@ MCP Parameters:
 
 ;;; ERT test runner — compact result for LLM consumption
 
-(defun anvil-elisp--ert-registered-names ()
-  "Return a list of every symbol currently holding an ERT test."
+(defun anvil-elisp--ert-registered-tests ()
+  "Return an alist of every symbol currently holding an ERT test."
   (let (acc)
     (mapatoms
      (lambda (sym)
-       (when (get sym 'ert--test)
-         (push sym acc))))
+       (let ((test (get sym 'ert--test)))
+         (when test
+           (push (cons sym test) acc)))))
     acc))
+
+(defun anvil-elisp--ert-updated-tests (before)
+  "Return tests added or redefined since BEFORE.
+BEFORE is an alist produced by `anvil-elisp--ert-registered-tests'."
+  (let (acc)
+    (mapatoms
+     (lambda (sym)
+       (let ((test (get sym 'ert--test)))
+         (when test
+           (unless (eq test (alist-get sym before nil nil #'eq))
+             (push test acc))))))
+    (nreverse acc)))
+
+(defun anvil-elisp--ert-select-file-tests (selector file-tests)
+  "Return tests matching SELECTOR from FILE-TESTS."
+  (cond
+   ((or (eq selector t) (null selector))
+    file-tests)
+   ((symbolp selector)
+    (let ((test (get selector 'ert--test)))
+      (if (memq test file-tests) (list test) nil)))
+   ((and (fboundp 'ert-test-p) (ert-test-p selector))
+    (if (memq selector file-tests) (list selector) nil))
+   (t
+    (cl-remove-if-not
+     (lambda (test) (memq test file-tests))
+     (condition-case nil
+         (ert-select-tests selector file-tests)
+       (error file-tests))))))
 
 (defun anvil-elisp--ert-fresh-feature (file)
   "Infer the feature symbol to unload before FILE is reloaded.
@@ -938,22 +968,11 @@ isolation matters."
          (start (float-time))
          (passed 0) (failed 0) (skipped 0)
          (failures nil)
-         (before (anvil-elisp--ert-registered-names)))
+         (before (anvil-elisp--ert-registered-tests)))
     (load path nil t)
-    (let* ((after   (anvil-elisp--ert-registered-names))
-           (added   (cl-remove-if (lambda (n) (memq n before)) after))
+    (let* ((file-tests (anvil-elisp--ert-updated-tests before))
            (tests
-            (cond
-             ((or (eq sel t) (null sel))
-              (mapcar (lambda (n) (get n 'ert--test)) added))
-             ((stringp sel)
-              (mapcar (lambda (n) (get n 'ert--test))
-                      (cl-remove-if-not
-                       (lambda (n) (string-match-p sel (symbol-name n)))
-                       added)))
-             ((symbolp sel)
-              (when (memq sel added) (list (get sel 'ert--test))))
-             (t (mapcar (lambda (n) (get n 'ert--test)) added)))))
+            (anvil-elisp--ert-select-file-tests sel file-tests)))
       (dolist (test tests)
         (let ((result (ert-run-test test)))
           (cond

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -845,44 +845,14 @@ MCP Parameters:
 
 ;;; ERT test runner — compact result for LLM consumption
 
-(defun anvil-elisp--ert-registered-tests ()
-  "Return an alist of every symbol currently holding an ERT test."
+(defun anvil-elisp--ert-registered-names ()
+  "Return a list of every symbol currently holding an ERT test."
   (let (acc)
     (mapatoms
      (lambda (sym)
-       (let ((test (get sym 'ert--test)))
-         (when test
-           (push (cons sym test) acc)))))
+       (when (get sym 'ert--test)
+         (push sym acc))))
     acc))
-
-(defun anvil-elisp--ert-updated-tests (before)
-  "Return tests added or redefined since BEFORE.
-BEFORE is an alist produced by `anvil-elisp--ert-registered-tests'."
-  (let (acc)
-    (mapatoms
-     (lambda (sym)
-       (let ((test (get sym 'ert--test)))
-         (when test
-           (unless (eq test (alist-get sym before nil nil #'eq))
-             (push test acc))))))
-    (nreverse acc)))
-
-(defun anvil-elisp--ert-select-file-tests (selector file-tests)
-  "Return tests matching SELECTOR from FILE-TESTS."
-  (cond
-   ((or (eq selector t) (null selector))
-    file-tests)
-   ((symbolp selector)
-    (let ((test (get selector 'ert--test)))
-      (if (memq test file-tests) (list test) nil)))
-   ((and (fboundp 'ert-test-p) (ert-test-p selector))
-    (if (memq selector file-tests) (list selector) nil))
-   (t
-    (cl-remove-if-not
-     (lambda (test) (memq test file-tests))
-     (condition-case nil
-         (ert-select-tests selector file-tests)
-       (error file-tests))))))
 
 (defun anvil-elisp--ert-fresh-feature (file)
   "Infer the feature symbol to unload before FILE is reloaded.
@@ -968,11 +938,22 @@ isolation matters."
          (start (float-time))
          (passed 0) (failed 0) (skipped 0)
          (failures nil)
-         (before (anvil-elisp--ert-registered-tests)))
+         (before (anvil-elisp--ert-registered-names)))
     (load path nil t)
-    (let* ((file-tests (anvil-elisp--ert-updated-tests before))
+    (let* ((after   (anvil-elisp--ert-registered-names))
+           (added   (cl-remove-if (lambda (n) (memq n before)) after))
            (tests
-            (anvil-elisp--ert-select-file-tests sel file-tests)))
+            (cond
+             ((or (eq sel t) (null sel))
+              (mapcar (lambda (n) (get n 'ert--test)) added))
+             ((stringp sel)
+              (mapcar (lambda (n) (get n 'ert--test))
+                      (cl-remove-if-not
+                       (lambda (n) (string-match-p sel (symbol-name n)))
+                       added)))
+             ((symbolp sel)
+              (when (memq sel added) (list (get sel 'ert--test))))
+             (t (mapcar (lambda (n) (get n 'ert--test)) added)))))
       (dolist (test tests)
         (let ((result (ert-run-test test)))
           (cond

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -100,16 +100,19 @@ Restores the original mode state after BODY completes."
 ;;; JSON Response Helpers
 
 (defun anvil-elisp--json-encode-source-location
-    (source file-path start-line end-line)
+    (source file-path start-line end-line &optional extra-fields)
   "Encode a source location response as JSON.
 SOURCE is the source code string.
 FILE-PATH is the absolute path to the source file.
-START-LINE and END-LINE are 1-based line numbers."
+START-LINE and END-LINE are 1-based line numbers.
+EXTRA-FIELDS, when non-nil, is an alist appended to the response."
   (json-encode
-   `((source . ,source)
-     (file-path . ,file-path)
-     (start-line . ,start-line)
-     (end-line . ,end-line))))
+   (append
+    `((source . ,source)
+      (file-path . ,file-path)
+      (start-line . ,start-line)
+      (end-line . ,end-line))
+    extra-fields)))
 
 (defun anvil-elisp--json-encode-not-found (symbol message)
   "Encode a not-found response as JSON.
@@ -276,6 +279,46 @@ BODY is the list of body expressions."
               (list doc))
             ,@body)))
     (pp-to-string defun-form)))
+
+(defun anvil-elisp--strip-runtime-signature (doc)
+  "Return DOC without a trailing runtime-added \"(fn ...)\" signature."
+  (if (and (stringp doc)
+           (string-match "\\`\\(.+?\\)\\(?:\n\n(fn [^)]+)\\)?\\'" doc))
+      (match-string 1 doc)
+    doc))
+
+(defun anvil-elisp--get-function-definition-native-no-source
+    (fn-name sym)
+  "Return a synthetic definition for native-compiled FN-NAME without source.
+SYM is the function symbol.  This path is used when runtime metadata
+confirms native compilation but there is no recoverable source file."
+  (let* ((args (or (help-function-arglist sym t) '(&rest args)))
+         (doc (anvil-elisp--strip-runtime-signature
+               (or (documentation sym t) "")))
+         (message
+          (format
+           "Original body unavailable: `%s' is native-compiled and no source file is recorded."
+           fn-name))
+         (defun-form
+          `(defun ,sym ,args
+             ,@(when (anvil-elisp--non-empty-docstring-p doc)
+                 (list doc))
+             (error ,message)))
+         (source
+          (concat
+           (format
+            ";; Synthetic stub: `%s' is native-compiled and has no recoverable source file.\n"
+            fn-name)
+           (pp-to-string defun-form)))
+         (end-line (max 1 (length (string-lines source)))))
+    (anvil-elisp--json-encode-source-location
+     source
+     "<native-compiled>"
+     1
+     end-line
+     `((source-unavailable . t)
+       (reason . "native-compiled-no-source")
+       (message . ,message)))))
 
 (defun anvil-elisp--get-function-definition-interactive
     (fn-name sym fn)
@@ -491,20 +534,30 @@ SYM is the function symbol.
 FN-INFO is the result from `anvil-elisp--extract-function-info`."
   (let ((fn (nth 0 fn-info))
         (is-alias (nth 1 fn-info))
-        (aliased-to (nth 2 fn-info)))
+        (aliased-to (nth 2 fn-info))
+        ;; Native-compiled Elisp functions also satisfy `subrp', so prefer
+        ;; the recorded source file when one exists before classifying a
+        ;; function as C-implemented.
+        (func-file (find-lisp-object-file-name sym 'defun)))
     (cond
-     ;; C-implemented function
-     ((subrp fn)
-      (anvil-elisp--get-function-definition-c-function function))
-
      ;; Has source file
-     ((find-lisp-object-file-name sym 'defun)
+     (func-file
       (anvil-elisp--get-function-definition-from-file
        function
        sym
-       (find-lisp-object-file-name sym 'defun)
+       func-file
        is-alias
        aliased-to))
+
+     ;; Native-compiled Elisp function without a recoverable source file.
+     ((and (fboundp 'native-comp-function-p)
+           (native-comp-function-p fn))
+      (anvil-elisp--get-function-definition-native-no-source
+       function sym))
+
+     ;; C-implemented function
+     ((subrp fn)
+      (anvil-elisp--get-function-definition-c-function function))
 
      ;; Interactive alias
      (is-alias

--- a/anvil-elisp.el
+++ b/anvil-elisp.el
@@ -911,6 +911,7 @@ from the test file persist after the call.  Intended for tight
 feedback loops during development — use a batch subprocess when
 isolation matters."
   (let* ((path (expand-file-name file))
+         (path-dir (file-name-directory path))
          (sel  (cond
                 ((null selector) t)
                 ((and (stringp selector) (string-empty-p selector)) t)
@@ -939,7 +940,11 @@ isolation matters."
          (passed 0) (failed 0) (skipped 0)
          (failures nil)
          (before (anvil-elisp--ert-registered-names)))
-    (load path nil t)
+    (let ((load-path (if (and path-dir
+                              (not (member path-dir load-path)))
+                         (cons path-dir load-path)
+                       load-path)))
+      (load path nil t))
     (let* ((after   (anvil-elisp--ert-registered-names))
            (added   (cl-remove-if (lambda (n) (memq n before)) after))
            (tests

--- a/anvil-file.el
+++ b/anvil-file.el
@@ -238,8 +238,9 @@ Returns (:deleted N :file PATH :warnings LIST)."
     (list :deleted deleted :file abs :warnings warnings)))
 
 (defun anvil-file-append (path content)
-  "Append CONTENT to end of PATH.
-A leading newline is added if file does not end with one.
+  "Append CONTENT to the end of existing PATH.
+A leading newline is added if PATH does not end with one.
+Signals an error if PATH does not already exist as a regular file.
 Returns (:appended-bytes N :file PATH :warnings LIST)."
   (let* ((abs (anvil--prepare-path path))
          (warnings (anvil-file-warn-if-diverged abs))
@@ -2357,12 +2358,13 @@ read specific sections."
 
   (anvil-server-register-tool
    #'anvil-file--tool-append
-   :id "file-append"
-   :intent '(file-edit)
-   :layer 'core
-   :description
-   "Append text to the end of a file.  A leading newline is added
-if the file does not end with one.  Safe for files over 1.2MB."
+  :id "file-append"
+  :intent '(file-edit)
+  :layer 'core
+  :description
+   "Append text to the end of an existing file.  A leading newline is
+added if the file does not end with one.  Errors if the target file
+does not already exist.  Safe for files over 1.2MB."
    :server-id anvil-file--server-id)
 
   (anvil-server-register-tool

--- a/anvil-file.el
+++ b/anvil-file.el
@@ -1154,7 +1154,16 @@ Returns (:ok t :operations N :file PATH :warnings LIST) on success.
     (with-temp-buffer
       (anvil--insert-file abs)
       (dolist (op operations)
-        (let ((type (anvil-file--batch-get op 'op)))
+        (let* ((type (anvil-file--batch-get op 'op))
+               (legacy-type (anvil-file--batch-get op 'type)))
+          (when (null type)
+            (if legacy-type
+                (error
+                 "batch: operation objects use 'op', not 'type': %S"
+                 op)
+              (error
+               "batch: missing required field 'op' in operation: %S"
+               op)))
           (pcase type
             ("replace"
              (let ((old (anvil-file--batch-get op 'old))
@@ -1206,7 +1215,9 @@ Returns (:ok t :operations N :file PATH :warnings LIST) on success.
              (let ((c (anvil-file--batch-get op 'content)))
                (insert (if (string-suffix-p "\n" c) c (concat c "\n")))))
             (_
-             (error "batch: unknown op: %s" type))))
+             (error
+              "batch: unknown op %S (supported: replace, replace-regexp, insert-at-line, delete-lines, append, prepend)"
+              type))))
         (cl-incf op-count))
       (anvil--write-current-buffer-to abs))
     (list :ok t :operations op-count :file abs :warnings warnings)))

--- a/anvil-file.el
+++ b/anvil-file.el
@@ -153,8 +153,9 @@ Returns nil if no matches found (does not error)."
 ;;;; --- file: write --------------------------------------------------------
 
 (defun anvil-file-replace-regexp (path pattern replacement &optional max-count)
-  "In PATH, replace occurrences of PATTERN (regexp) with REPLACEMENT.
+  "In PATH, replace occurrences of PATTERN (Emacs regexp) with REPLACEMENT.
 If MAX-COUNT is non-nil, stop after that many replacements.
+PATTERN capture groups use Emacs regexp syntax `\\(...\\)'.
 REPLACEMENT may use \\1 \\2 etc. for capture groups.
 Returns (:replaced N :file PATH :warnings LIST).  Errors if 0
 replacements were made.  :warnings surfaces pre-write divergence
@@ -1571,8 +1572,9 @@ without modifying the file.
 PATH is the absolute path to the file.
 
 SPEC is a plist:
-  :block-start    REGEXP — Required.  Marks the start of each block.
-                  If group 1 is present, its capture becomes the block's :id.
+  :block-start    REGEXP — Required.  Emacs regexp marking the start of
+                  each block.  If group 1 is present, its capture becomes
+                  the block's :id.
   :block-end      One of:
                     `next-block-start' (default) — block ends right before
                       the next `:block-start' match (or EOF).
@@ -1582,7 +1584,8 @@ SPEC is a plist:
                       regexp match after `:block-start'.
   :fields         List of field plists.  Each plist:
                     :name STRING   — output key (required)
-                    :regexp REGEXP — must capture value in group 1 (required)
+                    :regexp REGEXP — Emacs regexp; must capture value in
+                                     group 1 (required)
                     :required BOOL — when t, missing field skips the block
                                      (or errors, per :on-missing-required)
   :max-blocks     NUMBER — stop after returning this many records (optional)
@@ -2093,14 +2096,16 @@ MCP Parameters:
 
 SPEC-JSON is a JSON object describing the extraction.  Keys mirror the
 elisp `anvil-code-extract-pattern' SPEC plist (kebab-case in elisp,
-snake_case or kebab-case accepted in JSON):
+snake_case or kebab-case accepted in JSON).  Regexp values use Emacs
+regexp syntax, so capture groups must be written as `\\(...\\)'.
+`fields' must be a JSON array of objects:
 
   {
-    \"block-start\":  \"if \\\\(.*\\\\) \\\\{\",
+    \"block-start\":  \"^ITEM \\\\([0-9]+\\\\)\",
     \"block-end\":    \"brace-balance\",
     \"fields\": [
-      {\"name\": \"name\",  \"regexp\": \"name *= *\\\"(.*)\\\"\"},
-      {\"name\": \"price\", \"regexp\": \"price *= *(\\\\d+)\", \"required\": true}
+      {\"name\": \"name\",  \"regexp\": \"name *= *\\\"\\\\([^\\\"]*\\\\)\\\"\"},
+      {\"name\": \"price\", \"regexp\": \"price *= *\\\\([0-9]+\\\\)\", \"required\": true}
     ],
     \"max-blocks\": 100,
     \"on-missing-required\": \"skip-block\"
@@ -2134,6 +2139,8 @@ MCP Parameters:
                           block-end-raw))))
           (fields-raw (funcall get "fields"))
           (fields
+           ;; A non-array `fields' value currently bubbles up as a less clear
+           ;; low-level type error here; tightening that message is follow-up.
            (mapcar
             (lambda (f)
               (let ((name (or (alist-get 'name f)
@@ -2314,8 +2321,9 @@ Pass max-count \"1\" to assert exactly one match."
    :intent '(file-edit)
    :layer 'core
    :description
-   "Replace regexp matches in a file.  The replacement string may use
-\\\\1 \\\\2 for capture groups.  Errors if no match found.
+   "Replace Emacs regexp matches in a file.  Patterns use Emacs regexp
+syntax, including `\\(...\\)' capture groups; the replacement string may
+use \\\\1 \\\\2 for capture groups.  Errors if no match found.
 Safe for files over 1.2MB."
    :server-id anvil-file--server-id)
 
@@ -2458,7 +2466,9 @@ runs each `fields' regexp inside the body and captures group 1 as the
 field's value.  Read-only — the file is never modified.  Returns plist
 with :matches (each :id :start-line :end-line :fields) :total :returned
 :skipped.  Targets legacy code migration / data extraction where reading
-the entire file would be wasteful.  Brace-balance skips strings."
+the entire file would be wasteful.  Regexp values use Emacs regexp
+syntax, and `fields' must be a JSON array of {name, regexp, required?}
+objects.  Brace-balance skips strings."
    :read-only t
    :offload t
    :server-id anvil-file--server-id)

--- a/anvil-git.el
+++ b/anvil-git.el
@@ -100,6 +100,18 @@ never inject terminal escapes into captured stdout."
       (error "anvil-git: %s failed (exit %s): %s"
              context exit (string-trim (plist-get res :stderr))))))
 
+(defun anvil-git--require-directory (path context)
+  "Return PATH expanded, or signal when PATH is not an existing directory.
+Nil PATH is returned as nil so callers can still default to
+`default-directory'.  CONTEXT names the public helper for error text."
+  (cond
+   ((null path) nil)
+   ((file-directory-p path) (expand-file-name path))
+   ((file-exists-p path)
+    (user-error "%s: PATH must be a directory: %s" context path))
+   (t
+    (user-error "%s: directory does not exist: %s" context path))))
+
 ;;;; --- anvil-git-status ---------------------------------------------------
 
 (defun anvil-git--parse-branch-line (line)
@@ -353,9 +365,10 @@ OPTS plist:
   "Return the absolute top-level directory of the git repo for DIR.
 Cheap probe; every worktree / orchestrator helper calls this
 first.  Never signals — returns nil when DIR is not in a repo.
-Behaves identically to `anvil-git-toplevel'; the `repo-root' name
-matches the orchestrator / other-module naming convention."
-  (anvil-git-toplevel dir))
+DIR, when non-nil, must name an existing directory.  Behaves
+identically to `anvil-git-toplevel'; the `repo-root' name matches
+the orchestrator / other-module naming convention."
+  (anvil-git-toplevel (anvil-git--require-directory dir "anvil-git-repo-root")))
 
 ;;;; --- anvil-git-head-sha -------------------------------------------------
 
@@ -464,7 +477,7 @@ Keys: :ref (commit-ish to check out, default \"HEAD\"),
   "Return the git repo top-level dir for PATH, or nil.
 
 MCP Parameters:
-  path - Directory or file path inside the repo."
+  path - Directory inside the repo."
   (anvil-server-with-error-handling
    (or (anvil-git-repo-root path) "null")))
 
@@ -552,7 +565,7 @@ MCP Parameters:
    :server-id anvil-git--server-id
    :description
    "Return the git top-level directory for PATH, or nil when PATH is
-not inside a repository."
+not inside a repository.  PATH must be a directory."
    :read-only t)
 
   (anvil-server-register-tool

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -152,12 +152,31 @@ MCP Parameters:
 
 ;;; Project info
 
+(defun anvil-ide--project-for-buffer (buffer)
+  "Return the project object for BUFFER, or nil."
+  (when (and (featurep 'project)
+             (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when (and (stringp default-directory)
+                 (file-directory-p default-directory))
+        (ignore-errors (project-current nil))))))
+
+(defun anvil-ide--current-project ()
+  "Return the most relevant current project, or nil."
+  (or (anvil-ide--project-for-buffer
+       (window-buffer (selected-window)))
+      (anvil-ide--project-for-buffer (current-buffer))
+      (cl-loop for buffer in (buffer-list)
+               when (or (buffer-file-name buffer)
+                        (buffer-local-value 'default-directory buffer))
+               thereis (anvil-ide--project-for-buffer buffer))))
+
 (defun anvil-ide--project-info ()
   "Get information about the current project.
 
 MCP Parameters: (none)"
   (anvil-server-with-error-handling
-   (if-let* ((proj (project-current)))
+   (if-let* ((proj (anvil-ide--current-project)))
        (let ((root (project-root proj)))
          (format "Project: %s\nFiles: %d"
                  root
@@ -395,7 +414,9 @@ MCP Parameters:
          (results '()))
      (if (and file-path (not (string-empty-p file-path)))
          ;; Single file
-         (when-let ((buffer (get-file-buffer (expand-file-name file-path))))
+         (when-let ((buffer (or (get-file-buffer (expand-file-name file-path))
+                                (find-file-noselect
+                                 (expand-file-name file-path)))))
            (when (eq backend 'auto)
              (setq backend (cond
                             ((and (featurep 'flycheck)

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -193,12 +193,21 @@ MCP Parameters:
    (let ((target-buffer (or (find-buffer-visiting file-path)
                             (find-file-noselect file-path))))
      (with-current-buffer target-buffer
-       (let ((backend (xref-find-backend))
-             (scope-root (anvil-ide--xref-scope-root
-                          target-buffer file-path)))
+       (let* ((backend (xref-find-backend))
+              (project (anvil-ide--project-for-buffer target-buffer))
+              (scope-root (anvil-ide--xref-scope-root
+                           target-buffer file-path)))
          (if (not backend)
              (format "No xref backend available for %s" file-path)
-           (let ((xref-items (xref-backend-references backend identifier)))
+           (let ((xref-items
+                  ;; The generic Elisp xref reference search falls back to
+                  ;; `project-current t', which can prompt on non-project
+                  ;; files and raise `minibuffer-quit' in MCP contexts.
+                  (if (and (eq backend 'elisp)
+                           (not project)
+                           scope-root)
+                      (xref-references-in-directory identifier scope-root)
+                    (xref-backend-references backend identifier))))
              (if xref-items
                  (anvil-ide--xref-format-items
                   xref-items

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -129,6 +129,15 @@ FILE-PATH when no project is available."
                 (normalized-file (anvil-ide--normalize-path file)))
       (file-in-directory-p normalized-file scope-root))))
 
+(defun anvil-ide--xref-filter-items (items scope-root)
+  "Return xref ITEMS filtered to SCOPE-ROOT."
+  (if (not scope-root)
+      items
+    (cl-remove-if-not
+     (lambda (item)
+       (anvil-ide--xref-item-in-scope-p item scope-root))
+     items)))
+
 (defun anvil-ide--xref-format-item (item)
   "Format xref ITEM as a single `file:line: summary' string."
   (let* ((location (xref-item-location item))
@@ -146,14 +155,33 @@ FILE-PATH when no project is available."
 
 (defun anvil-ide--xref-format-items (items scope-root empty-message)
   "Format xref ITEMS filtered to SCOPE-ROOT, or return EMPTY-MESSAGE."
-  (let ((filtered
-         (cl-remove-if-not
-          (lambda (item)
-            (anvil-ide--xref-item-in-scope-p item scope-root))
-          items)))
+  (let ((filtered (anvil-ide--xref-filter-items items scope-root)))
     (if filtered
         (mapconcat #'anvil-ide--xref-format-item filtered "\n")
       empty-message)))
+
+(defun anvil-ide--xref-elisp-apropos-scope-message
+    (pattern items scope-root)
+  "Explain Elisp apropos PATTERN hits in ITEMS being filtered by SCOPE-ROOT."
+  (let ((loaded-file
+         (cl-loop for item in items
+                  thereis
+                  (anvil-ide--normalize-path
+                   (anvil-ide--xref-location-file
+                    (xref-item-location item))))))
+    (mapconcat
+     #'identity
+     (delq nil
+           (list
+            (format "No project-local symbols found matching '%s'."
+                    pattern)
+            "The Emacs Lisp xref backend returned only matches outside the current project scope."
+            (when loaded-file
+              (format "Loaded checkout hit: %s" loaded-file))
+            (when scope-root
+              (format "Current project scope: %s" scope-root))
+            "This usually means Emacs loaded a different checkout; try reloading the dev tree or running anvil-self-sync-check."))
+     "\n")))
 
 (defun anvil-ide--xref-find-references (identifier file-path)
   "Find references to IDENTIFIER using FILE-PATH as context.
@@ -203,10 +231,17 @@ MCP Parameters:
           (t
            (let ((xref-items (xref-backend-apropos backend pattern)))
              (if xref-items
-                 (anvil-ide--xref-format-items
-                  xref-items
-                  scope-root
-                  (format "No symbols found matching '%s'" pattern))
+                 (let ((filtered
+                        (anvil-ide--xref-filter-items
+                         xref-items scope-root)))
+                   (if filtered
+                       (mapconcat
+                        #'anvil-ide--xref-format-item filtered "\n")
+                     (if (eq backend 'elisp)
+                         (anvil-ide--xref-elisp-apropos-scope-message
+                          pattern xref-items scope-root)
+                       (format "No symbols found matching '%s'"
+                               pattern))))
                (format "No symbols found matching '%s'" pattern))))))))))
 
 ;;; Project info

--- a/anvil-ide.el
+++ b/anvil-ide.el
@@ -84,6 +84,77 @@
 
 ;;; xref tools
 
+(defun anvil-ide--normalize-path (path)
+  "Return PATH as an absolute canonical path when possible."
+  (when (stringp path)
+    (let ((expanded (expand-file-name path)))
+      (if (file-exists-p expanded)
+          (file-truename expanded)
+        expanded))))
+
+(defun anvil-ide--normalize-directory (path)
+  "Return PATH as an absolute canonical directory name when possible."
+  (let ((normalized (anvil-ide--normalize-path path)))
+    (when normalized
+      (file-name-as-directory normalized))))
+
+(defun anvil-ide--xref-scope-root (buffer file-path)
+  "Return the directory root used to scope xref results for FILE-PATH.
+Prefer BUFFER's project root.  Fall back to the directory containing
+FILE-PATH when no project is available."
+  (or (when-let* ((proj (anvil-ide--project-for-buffer buffer))
+                  (root (project-root proj)))
+        (anvil-ide--normalize-directory root))
+      (let ((dir (file-name-directory (expand-file-name file-path))))
+        (when dir
+          (anvil-ide--normalize-directory dir)))))
+
+(defun anvil-ide--xref-location-file (location)
+  "Return LOCATION's backing file path, or nil."
+  (let ((marker (ignore-errors (xref-location-marker location))))
+    (or (and (markerp marker)
+             (let ((buffer (marker-buffer marker)))
+               (and (buffer-live-p buffer)
+                    (with-current-buffer buffer
+                      (buffer-file-name)))))
+        (let ((group (xref-location-group location)))
+          (and (stringp group) group)))))
+
+(defun anvil-ide--xref-item-in-scope-p (item scope-root)
+  "Return non-nil when xref ITEM belongs to SCOPE-ROOT."
+  (if (not scope-root)
+      t
+    (when-let* ((file (anvil-ide--xref-location-file
+                       (xref-item-location item)))
+                (normalized-file (anvil-ide--normalize-path file)))
+      (file-in-directory-p normalized-file scope-root))))
+
+(defun anvil-ide--xref-format-item (item)
+  "Format xref ITEM as a single `file:line: summary' string."
+  (let* ((location (xref-item-location item))
+         (file (or (anvil-ide--xref-location-file location)
+                   (xref-location-group location)))
+         (marker (ignore-errors (xref-location-marker location)))
+         (line (if (markerp marker)
+                   (with-current-buffer (marker-buffer marker)
+                     (save-excursion
+                       (goto-char marker)
+                       (line-number-at-pos)))
+                 0))
+         (summary (xref-item-summary item)))
+    (format "%s:%d: %s" file line summary)))
+
+(defun anvil-ide--xref-format-items (items scope-root empty-message)
+  "Format xref ITEMS filtered to SCOPE-ROOT, or return EMPTY-MESSAGE."
+  (let ((filtered
+         (cl-remove-if-not
+          (lambda (item)
+            (anvil-ide--xref-item-in-scope-p item scope-root))
+          items)))
+    (if filtered
+        (mapconcat #'anvil-ide--xref-format-item filtered "\n")
+      empty-message)))
+
 (defun anvil-ide--xref-find-references (identifier file-path)
   "Find references to IDENTIFIER using FILE-PATH as context.
 
@@ -94,23 +165,17 @@ MCP Parameters:
    (let ((target-buffer (or (find-buffer-visiting file-path)
                             (find-file-noselect file-path))))
      (with-current-buffer target-buffer
-       (let ((backend (xref-find-backend)))
+       (let ((backend (xref-find-backend))
+             (scope-root (anvil-ide--xref-scope-root
+                          target-buffer file-path)))
          (if (not backend)
              (format "No xref backend available for %s" file-path)
            (let ((xref-items (xref-backend-references backend identifier)))
              (if xref-items
-                 (mapconcat
-                  (lambda (item)
-                    (let* ((location (xref-item-location item))
-                           (file (xref-location-group location))
-                           (marker (xref-location-marker location))
-                           (line (with-current-buffer (marker-buffer marker)
-                                   (save-excursion
-                                     (goto-char marker)
-                                     (line-number-at-pos))))
-                           (summary (xref-item-summary item)))
-                      (format "%s:%d: %s" file line summary)))
-                  xref-items "\n")
+                 (anvil-ide--xref-format-items
+                  xref-items
+                  scope-root
+                  (format "No references found for '%s'" identifier))
                (format "No references found for '%s'" identifier)))))))))
 
 (defun anvil-ide--xref-find-apropos (pattern file-path)
@@ -123,7 +188,9 @@ MCP Parameters:
    (let ((target-buffer (or (find-buffer-visiting file-path)
                             (find-file-noselect file-path))))
      (with-current-buffer target-buffer
-       (let ((backend (xref-find-backend)))
+       (let ((backend (xref-find-backend))
+             (scope-root (anvil-ide--xref-scope-root
+                          target-buffer file-path)))
          (cond
           ((not backend)
            (format "No xref backend available for %s" file-path))
@@ -136,18 +203,10 @@ MCP Parameters:
           (t
            (let ((xref-items (xref-backend-apropos backend pattern)))
              (if xref-items
-                 (mapconcat
-                  (lambda (item)
-                    (let* ((location (xref-item-location item))
-                           (file (xref-location-group location))
-                           (marker (xref-location-marker location))
-                           (line (with-current-buffer (marker-buffer marker)
-                                   (save-excursion
-                                     (goto-char marker)
-                                     (line-number-at-pos))))
-                           (summary (xref-item-summary item)))
-                      (format "%s:%d: %s" file line summary)))
-                  xref-items "\n")
+                 (anvil-ide--xref-format-items
+                  xref-items
+                  scope-root
+                  (format "No symbols found matching '%s'" pattern))
                (format "No symbols found matching '%s'" pattern))))))))))
 
 ;;; Project info

--- a/anvil-memory.el
+++ b/anvil-memory.el
@@ -2165,9 +2165,9 @@ returned body to disk after human review."
      "Rebuild the memory_body_fts virtual table with a chosen tokenizer.
 Phase 2b-i: `trigram' (SQLite 3.34+) is CJK-friendly — Japanese
 substring queries (3+ chars) that miss under `unicode61' start
-matching.  Omit tokenizer to use `anvil-memory-fts-tokenizer'
-(defaults to `auto', which picks trigram when available).  Returns
-:tokenizer / :rebuilt.")
+matching.  Omit tokenizer to use `anvil-memory-fts-tokenizer'.
+Default is `auto': use `trigram' when available, otherwise fall
+back to `unicode61'.  Returns :tokenizer / :rebuilt.")
 
     (,(anvil-server-encode-handler #'anvil-memory--tool-mdl-distill)
      :id "memory-mdl-distill"

--- a/anvil-offload.el
+++ b/anvil-offload.el
@@ -31,18 +31,22 @@
 ;;   (anvil-future-checkpoint FUTURE)    ; Phase 3b
 ;;   (anvil-preempt-checkpoint V &optional C)  ; handler-side, Phase 3b
 ;;
-;; Protocol (one S-exp per line, utf-8-unix):
-;;   request    : (:id N :form EXPR)
-;;   reply      : (:id N :ok VALUE) | (:id N :error MSG)
-;;   checkpoint : (:id N :checkpoint (:value V :cursor C))  (Phase 3b)
+;; Protocol:
+;;   request to stdin            : raw sexp `(:id N :payload BASE64(FORM))'
+;;   reply / checkpoint to stdout: PREFIX + BASE64(UTF-8(prin1(MSG))) + "\n"
+;;     where decoded MSG is:
+;;       (:id N :ok VALUE) | (:id N :error MSG)
+;;       (:id N :checkpoint (:value V :cursor C))  (Phase 3b)
 ;;
 ;; Checkpoints are intermediate, non-settling messages sent by handlers
 ;; via `anvil-preempt-checkpoint' so the main daemon can return the last
 ;; known partial state if the call is killed for running over budget.
 ;;
-;; The REPL uses `send-string-to-terminal' for replies because it
-;; calls fflush(stdout) in batch mode — a plain `princ' may stay in
-;; the C stdio buffer on Windows pipes and never reach the client.
+;; Replies are framed so stray stdout chatter from handlers / `require'
+;; does not poison the transport.  The REPL still uses
+;; `send-string-to-terminal' because it calls fflush(stdout) in batch
+;; mode — a plain `princ' may stay in the C stdio buffer on Windows
+;; pipes and never reach the client.
 
 ;;; Code:
 
@@ -101,6 +105,49 @@ Created lazily in `anvil-offload--ensure-pending'.")
 (defvar anvil-offload--repl-init-file nil
   "Path to the generated REPL init file, or nil if not yet written.")
 
+(defconst anvil-offload--protocol-version 2
+  "Wire-format version spoken by the offload REPL pool.")
+
+(defconst anvil-offload--frame-prefix "ANVIL-OFFLOAD "
+  "Line prefix tagging framed stdout messages from the offload REPL.")
+
+(defconst anvil-offload--ignored-junk-prefixes
+  '("Lisp expression: ")
+  "Known benign stdout prefixes emitted by the batch REPL.")
+
+(defun anvil-offload--frame-encode-payload (string)
+  "Return STRING encoded as a single-line transport payload."
+  (base64-encode-string
+   (encode-coding-string string 'utf-8-unix)
+   t))
+
+(defun anvil-offload--frame-decode-payload (payload)
+  "Decode PAYLOAD from the offload transport into a UTF-8 string."
+  (decode-coding-string
+   (base64-decode-string payload)
+   'utf-8-unix))
+
+(defun anvil-offload--line-preview (string)
+  "Return a short, single-line preview of STRING for diagnostics."
+  (let ((flat (replace-regexp-in-string "[\r\n]+" "\\n" string)))
+    (if (> (length flat) 120)
+        (concat (substring flat 0 117) "...")
+      flat)))
+
+(defun anvil-offload--strip-ignored-junk-prefixes (string)
+  "Drop known benign stdout prefixes from STRING."
+  (let ((out string)
+        changed)
+    (while
+        (progn
+          (setq changed nil)
+          (dolist (prefix anvil-offload--ignored-junk-prefixes)
+            (when (string-prefix-p prefix out)
+              (setq out (substring out (length prefix))
+                    changed t)))
+          changed))
+    out))
+
 (defun anvil-offload--ensure-pending ()
   "Return the pending-futures hash, creating it if needed."
   (or anvil-offload--pending
@@ -109,9 +156,18 @@ Created lazily in `anvil-offload--ensure-pending'.")
 ;;; REPL init file
 
 (defconst anvil-offload--repl-body
-  ";; anvil-offload REPL — auto-generated, do not edit.
+  (format ";; anvil-offload REPL — auto-generated, do not edit -*- lexical-binding: t; -*-
 \(setq coding-system-for-read 'utf-8-unix
       coding-system-for-write 'utf-8-unix)
+\(defconst anvil-offload--frame-prefix %S)
+\(defun anvil-offload--emit-frame (msg)
+  \"Write MSG as one framed line to stdout.\"
+  (send-string-to-terminal
+   (concat anvil-offload--frame-prefix
+           (base64-encode-string
+            (encode-coding-string (prin1-to-string msg) 'utf-8-unix)
+            t)
+           \"\\n\")))
 \(defvar anvil-offload--repl-current-id nil
   \"Request id currently being evaluated — tags checkpoint messages.\")
 \(defun anvil-preempt-checkpoint (value &optional cursor)
@@ -119,32 +175,42 @@ Created lazily in `anvil-offload--ensure-pending'.")
 Handlers call this periodically during long work so the main daemon
 has the latest partial state if the call is killed over budget.\"
   (when anvil-offload--repl-current-id
-    (let ((msg (list :id anvil-offload--repl-current-id
-                     :checkpoint (list :value value :cursor cursor))))
-      (send-string-to-terminal (prin1-to-string msg))
-      (send-string-to-terminal \"\\n\")))
+    (anvil-offload--emit-frame
+     (list :id anvil-offload--repl-current-id
+           :checkpoint (list :value value :cursor cursor))))
   value)
 \(condition-case nil
     (while t
       (let* ((msg (read t))
              (id (and (listp msg) (plist-get msg :id)))
-             (form (and (listp msg) (plist-get msg :form))))
+             (payload (and (listp msg) (plist-get msg :payload)))
+             (form (and payload
+                        (car (read-from-string
+                              (decode-coding-string
+                               (base64-decode-string payload)
+                               'utf-8-unix))))))
         (when id
           (let* ((anvil-offload--repl-current-id id)
                  (reply
                   (condition-case err
-                      (list :id id :ok (eval form t))
-                    (error (list :id id :error (format \"%S\" err))))))
-            (send-string-to-terminal (prin1-to-string reply))
-            (send-string-to-terminal \"\\n\")))))
+                      (list :id id
+                            :ok
+                            (with-temp-buffer
+                              (let ((standard-output (current-buffer)))
+                                (eval form t))))
+                    (error (list :id id :error (format \"%%S\" err))))))
+            (anvil-offload--emit-frame reply)))))
   (end-of-file (kill-emacs 0)))
-"
+" anvil-offload--frame-prefix)
   "Body of the REPL loop written into the subprocess init file.")
 
 (defun anvil-offload--repl-init-file ()
-  "Return the path to the REPL init file, writing it if necessary."
+  "Return the path to the REPL init file, rewriting it when stale."
   (unless (and anvil-offload--repl-init-file
-               (file-exists-p anvil-offload--repl-init-file))
+               (file-exists-p anvil-offload--repl-init-file)
+               (with-temp-buffer
+                 (insert-file-contents anvil-offload--repl-init-file)
+                 (equal (buffer-string) anvil-offload--repl-body)))
     (let ((file (make-temp-file "anvil-offload-repl-" nil ".el")))
       (with-temp-file file
         (let ((coding-system-for-write 'utf-8-unix))
@@ -204,6 +270,9 @@ Return non-nil if settled, nil on timeout."
                 (or (null deadline) (< (float-time) deadline))
                 (process-live-p proc))
       (accept-process-output proc anvil-offload-poll-interval))
+    (when (and (not (anvil-future-done-p future))
+               (not (process-live-p proc)))
+      (sit-for 0))
     (anvil-future-done-p future)))
 
 (defun anvil-future-cancel (future)
@@ -260,10 +329,13 @@ In the main daemon this is a harmless no-op — handlers can call it
 unconditionally.  Returns VALUE."
   (when (and anvil-offload--repl-current-id
              (fboundp 'send-string-to-terminal))
-    (let ((msg (list :id anvil-offload--repl-current-id
+    (send-string-to-terminal
+     (concat anvil-offload--frame-prefix
+             (anvil-offload--frame-encode-payload
+              (prin1-to-string
+               (list :id anvil-offload--repl-current-id
                      :checkpoint (list :value value :cursor cursor))))
-      (send-string-to-terminal (prin1-to-string msg))
-      (send-string-to-terminal "\n")))
+             "\n")))
   value)
 
 (defun anvil-offload--dispatch-reply (msg)
@@ -291,28 +363,43 @@ do not settle it; `:ok'/`:error' replies settle and dehashref."
                 (anvil-future--done-at future) (float-time))))))))
 
 (defun anvil-offload--filter (proc string)
-  "Accumulate STRING bytes on PROC and dispatch complete S-exprs."
+  "Accumulate STRING bytes on PROC and dispatch complete framed replies."
   (let ((buf (concat (or (process-get proc 'anvil-pending-bytes) "") string))
-        (done nil))
-    (while (not done)
-      (setq buf (string-trim-left buf))
-      (if (string-empty-p buf)
-          (setq done t)
-        (let ((parsed (condition-case err
-                          (read-from-string buf)
-                        (end-of-file :partial)
-                        (invalid-read-syntax
-                         (message "anvil-offload: unreadable reply: %s" err)
-                         ;; Drop the junk up to the next newline (or all).
-                         (let ((nl (string-match "\n" buf)))
-                           (if nl
-                               (cons nil (1+ nl))
-                             (cons nil (length buf))))))))
-          (if (eq parsed :partial)
-              (setq done t)
-            (setq buf (substring buf (cdr parsed)))
-            (anvil-offload--dispatch-reply (car parsed))))))
+        (prefix-re (regexp-quote anvil-offload--frame-prefix))
+        line-end)
+    (while (setq line-end (string-match "\n" buf))
+      (let ((line (anvil-offload--strip-ignored-junk-prefixes
+                   (substring buf 0 line-end))))
+        (setq buf (substring buf (1+ line-end)))
+        (unless (string-blank-p line)
+          (let ((idx (string-match prefix-re line)))
+            (cond
+             ((null idx)
+              (message "anvil-offload: dropped junk reply line: %S"
+                       (anvil-offload--line-preview line)))
+             (t
+              (condition-case err
+                  (anvil-offload--dispatch-reply
+                   (car
+                    (read-from-string
+                     (anvil-offload--frame-decode-payload
+                      (substring line (+ idx (length anvil-offload--frame-prefix)))))))
+                (error
+                 (message "anvil-offload: unreadable reply frame: %s" err)))))))))
     (process-put proc 'anvil-pending-bytes buf)))
+
+(defun anvil-offload--finalize-dead-process (proc reason)
+  "Settle pending futures still owned by dead PROC with REASON."
+  (let ((table (anvil-offload--ensure-pending)))
+    (maphash
+     (lambda (id future)
+       (when (and (eq proc (anvil-future--process future))
+                  (eq 'pending (anvil-future--status future)))
+         (setf (anvil-future--status future) 'error
+               (anvil-future--err future) reason
+               (anvil-future--done-at future) (float-time))
+         (remhash id table)))
+     table)))
 
 (defun anvil-offload--sentinel (proc event)
   "Handle death of PROC; fail only the pending futures bound to PROC.
@@ -320,16 +407,10 @@ Filtering by `:process' is load-bearing: if the REPL is stopped
 and a fresh one spawned before this sentinel runs, we must not
 error-settle the new REPL's pending futures."
   (unless (process-live-p proc)
-    (let ((table (anvil-offload--ensure-pending))
-          (reason (format "offload REPL exited: %s" (string-trim event))))
-      (maphash
-       (lambda (id future)
-         (when (eq proc (anvil-future--process future))
-           (setf (anvil-future--status future) 'error
-                 (anvil-future--err future) reason
-                 (anvil-future--done-at future) (float-time))
-           (remhash id table)))
-       table))
+    (let ((reason (format "offload REPL exited: %s" (string-trim event))))
+      ;; Let any final filter callback drain queued bytes before we mark
+      ;; still-pending futures as errored.
+      (run-at-time 0 nil #'anvil-offload--finalize-dead-process proc reason))
     ;; Clear the dying slot so the next dispatch respawns it.
     (when anvil-offload--pool
       (dotimes (i (length anvil-offload--pool))
@@ -356,6 +437,8 @@ diagnostic, not load-bearing for dispatch."
                 :filter #'anvil-offload--filter
                 :sentinel #'anvil-offload--sentinel)))
     (process-put proc 'anvil-pending-bytes "")
+    (process-put proc 'anvil-offload-protocol-version
+                 anvil-offload--protocol-version)
     proc))
 
 (defun anvil-offload--ensure-pool-vector ()
@@ -374,8 +457,13 @@ diagnostic, not load-bearing for dispatch."
   "Ensure slot IDX holds a live REPL; return it."
   (anvil-offload--ensure-pool-vector)
   (let ((cur (aref anvil-offload--pool idx)))
-    (if (and cur (process-live-p cur))
+    (if (and cur
+             (process-live-p cur)
+             (eq (process-get cur 'anvil-offload-protocol-version)
+                 anvil-offload--protocol-version))
         cur
+      (when (and cur (process-live-p cur))
+        (kill-process cur))
       (let ((proc (anvil-offload--spawn-process idx)))
         (aset anvil-offload--pool idx proc)
         proc))))
@@ -444,7 +532,8 @@ in the subprocess.  Returns a list of forms (possibly empty)."
   "Evaluate FORM in the offload REPL subprocess; return an `anvil-future'.
 
 FORM is sent as a single S-expression.  The subprocess evaluates
-it with lexical binding and sends back either `(:id N :ok VALUE)'
+its printed form via a base64 payload inside the request sexp.  The
+subprocess evaluates it with lexical binding and sends back either `(:id N :ok VALUE)'
 or `(:id N :error MSG)'.  The main daemon never blocks.
 
 Keyword arguments:
@@ -466,7 +555,11 @@ Dispatch uses round-robin across the pool (`anvil-offload-pool-size')."
                   :id id :process proc :status 'pending)))
     (puthash id future (anvil-offload--ensure-pending))
     (process-send-string proc
-                         (concat (prin1-to-string (list :id id :form full-form))
+                         (concat (prin1-to-string
+                                  (list :id id
+                                        :payload
+                                        (anvil-offload--frame-encode-payload
+                                         (prin1-to-string full-form))))
                                  "\n"))
     future))
 

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1306,13 +1306,21 @@ org-read-file tool to read entire files"))
         (anvil-org--handle-headline-resource `(("filename" . ,full-path))))))
 
 (defun anvil-org--tool-read-by-id (uuid)
-  "Tool wrapper for org-id://{uuid} resource template.
-UUID is the UUID from headline's ID property.  Accepts either the
+  "Tool wrapper for Layer-3 Org ID reads.
+UUID is the UUID from a headline's ID property.  Accepts either the
 raw UUID or an `org://UUID' citation URI emitted by the
-progressive-disclosure Layer-1 / Layer-2 tools.
+progressive-disclosure Layer-1 / Layer-2 tools.  The `org-id://UUID'
+form is the MCP resource URI and is not accepted here.
 
 MCP Parameters:
   uuid - UUID (or org://UUID citation URI) from headline's ID property"
+  (when-let* ((id-resource
+               (and (stringp uuid)
+                    (anvil-org--extract-uri-suffix
+                     uuid anvil-org--uri-id-prefix))))
+    (anvil-org--tool-validation-error
+     "Parameter uuid does not accept org-id:// resource URIs.  Use the raw UUID \"%s\" or the org:// citation URI \"org://%s\" instead"
+     id-resource id-resource))
   (let ((id (if (and (stringp uuid)
                      (string-prefix-p "org://" uuid))
                 (substring uuid (length "org://"))
@@ -1641,8 +1649,9 @@ Read Org headline by its unique ID property.  More stable than
 path-based access since IDs don't change when headlines are renamed
 or moved.  Accepts the raw UUID directly or the `org://UUID' citation
 URI returned by Layer 1 (`org-index-index') / Layer 2
-(`org-index-search').  File containing the ID must be in
-anvil-org-allowed-files.
+(`org-index-search').  The `org-id://UUID' form is the MCP resource
+URI, not the input format for this tool.  File containing the ID must
+be in anvil-org-allowed-files.
 
 Parameters:
   uuid - UUID (or org://UUID citation URI) from headline's ID

--- a/anvil-py.el
+++ b/anvil-py.el
@@ -1038,6 +1038,14 @@ MCP Parameters:
       (push (cdr entry) out))
     (nreverse out)))
 
+(defun anvil-py--normalize-plist-keys (plist)
+  "Return PLIST with keys normalized for the planners."
+  (let (out)
+    (while plist
+      (push (anvil-py--spec-keyword (pop plist)) out)
+      (push (pop plist) out))
+    (nreverse out)))
+
 (defun anvil-py--parse-spec-string (spec)
   "Parse string SPEC as JSON or Lisp data and return the resulting object."
   (let ((trimmed (string-trim spec)))
@@ -1065,7 +1073,7 @@ a plist whose values are ready for the elisp planners."
   (let* ((s (cond
              ((null spec) nil)
              ((anvil-py--plist-p spec)
-              (copy-sequence spec))
+              (anvil-py--normalize-plist-keys (copy-sequence spec)))
              ((hash-table-p spec)
               (let (out)
                 (maphash (lambda (k v)

--- a/anvil-py.el
+++ b/anvil-py.el
@@ -98,7 +98,7 @@ into per-match alists, which is what the locator body wants for
 
 (defun anvil-py-list-imports (file)
   "Return a list of plists describing imports in FILE.
-Each entry: (:kind 'import|from :text STR :bounds PLIST)."
+Each entry: (:kind import|from :text STR :bounds PLIST)."
   (anvil-treesit-with-root file anvil-py--lang root
     (let ((q (anvil-py--query 'imports))
           results)
@@ -426,138 +426,159 @@ NAMES is used in the order given — callers decide sort."
       (format "import %s as %s" module alias)
     (format "import %s" module)))
 
+(defun anvil-py--normalize-kind (kind)
+  "Return KIND canonicalized to the symbol `import' or `from'."
+  (let ((normalized
+         (pcase kind
+           (`(quote ,sym) sym)
+           ((pred stringp) (intern kind))
+           ((pred keywordp) (intern (substring (symbol-name kind) 1)))
+           (_ kind))))
+    (pcase normalized
+      ((or 'import 'from) normalized)
+      (_ (user-error
+          "anvil-py: unsupported :kind %S (expected import or from)"
+          kind)))))
+
 (defun anvil-py--spec-kind (spec)
-  "Return the :kind of SPEC, defaulting to `import' when omitted."
-  (or (plist-get spec :kind) 'import))
+  "Return SPEC's canonical :kind, defaulting to `import' when omitted."
+  (let ((kind (plist-get spec :kind)))
+    (if kind
+        (anvil-py--normalize-kind kind)
+      'import)))
 
 (cl-defun anvil-py--plan-add-import (file spec)
   "Build an edit plan adding SPEC to FILE.
 Returns a plan plist (see `anvil-treesit-make-plan').  When SPEC is
 already satisfied (bare import present, or every requested
 from-import name already present), returns a no-op plan."
-  (anvil-treesit-with-root file anvil-py--lang root
-    (pcase (anvil-py--spec-kind spec)
-      ('from
-       (let* ((module (plist-get spec :from))
-              (wanted (plist-get spec :names))
-              (existing (anvil-py--find-from-import root module)))
-         (unless (and module wanted)
-           (user-error "anvil-py-add-import: :from and :names required for from-import"))
-         (if existing
-             (let* ((current (anvil-py--from-import-names existing))
-                    (current-bare (mapcar (lambda (n)
-                                            (car (split-string n " as ")))
-                                          current))
-                    (missing (cl-remove-if
-                              (lambda (w)
-                                (member (car (split-string w " as "))
-                                        current-bare))
-                              wanted)))
-               (if (null missing)
-                   (anvil-treesit-make-noop-plan
-                    file (format "add-import from %s" module))
-                 (let* ((merged (append current missing))
-                        (new-text (anvil-py--render-from-import
-                                   module merged))
-                        (beg (treesit-node-start existing))
-                        (end (treesit-node-end existing)))
-                   (anvil-treesit-make-plan
-                    file beg end new-text
-                    (format "add-import from %s (merge %d name%s)"
-                            module (length missing)
-                            (if (= 1 (length missing)) "" "s"))))))
-           ;; No existing from-import for this module — insert a new one.
-           (let* ((ins (anvil-py--import-insertion-point root))
-                  (new-line (concat (if (> ins (point-min)) "\n" "")
-                                    (anvil-py--render-from-import
-                                     module wanted)
-                                    (if (= ins (point-min)) "\n" ""))))
-             (anvil-treesit-make-plan
-              file ins ins new-line
-              (format "add-import from %s (new)" module))))))
-      ('import
-       (let* ((module (plist-get spec :module))
-              (alias (plist-get spec :alias))
-              (existing (anvil-py--find-import root module alias)))
-         (unless module
-           (user-error "anvil-py-add-import: :module required for import"))
-         (if existing
-             (anvil-treesit-make-noop-plan
-              file (format "add-import import %s" module))
-           (let* ((ins (anvil-py--import-insertion-point root))
-                  (new-line (concat (if (> ins (point-min)) "\n" "")
-                                    (anvil-py--render-import module alias)
-                                    (if (= ins (point-min)) "\n" ""))))
-             (anvil-treesit-make-plan
-              file ins ins new-line
-              (format "add-import import %s" module)))))))))
+  (let ((kind (anvil-py--spec-kind spec)))
+    (anvil-treesit-with-root file anvil-py--lang root
+      (pcase kind
+        ('from
+         (let* ((module (plist-get spec :from))
+                (wanted (plist-get spec :names))
+                (existing (anvil-py--find-from-import root module)))
+           (unless (and module wanted)
+             (user-error "anvil-py-add-import: :from and :names required for from-import"))
+           (if existing
+               (let* ((current (anvil-py--from-import-names existing))
+                      (current-bare (mapcar (lambda (n)
+                                              (car (split-string n " as ")))
+                                            current))
+                      (missing (cl-remove-if
+                                (lambda (w)
+                                  (member (car (split-string w " as "))
+                                          current-bare))
+                                wanted)))
+                 (if (null missing)
+                     (anvil-treesit-make-noop-plan
+                      file (format "add-import from %s" module))
+                   (let* ((merged (append current missing))
+                          (new-text (anvil-py--render-from-import
+                                     module merged))
+                          (beg (treesit-node-start existing))
+                          (end (treesit-node-end existing)))
+                     (anvil-treesit-make-plan
+                      file beg end new-text
+                      (format "add-import from %s (merge %d name%s)"
+                              module (length missing)
+                              (if (= 1 (length missing)) "" "s"))))))
+             ;; No existing from-import for this module — insert a new one.
+             (let* ((ins (anvil-py--import-insertion-point root))
+                    (new-line (concat (if (> ins (point-min)) "\n" "")
+                                      (anvil-py--render-from-import
+                                       module wanted)
+                                      (if (= ins (point-min)) "\n" ""))))
+               (anvil-treesit-make-plan
+                file ins ins new-line
+                (format "add-import from %s (new)" module))))))
+        ('import
+         (let* ((module (plist-get spec :module))
+                (alias (plist-get spec :alias))
+                (existing (anvil-py--find-import root module alias)))
+           (unless module
+             (user-error "anvil-py-add-import: :module required for import"))
+           (if existing
+               (anvil-treesit-make-noop-plan
+                file (format "add-import import %s" module))
+             (let* ((ins (anvil-py--import-insertion-point root))
+                    (new-line (concat (if (> ins (point-min)) "\n" "")
+                                      (anvil-py--render-import module alias)
+                                      (if (= ins (point-min)) "\n" ""))))
+               (anvil-treesit-make-plan
+                file ins ins new-line
+                (format "add-import import %s" module))))))
+        (_ (user-error "anvil-py-add-import: unsupported :kind %S" kind))))))
 
 (cl-defun anvil-py--plan-remove-import (file spec)
   "Build an edit plan removing SPEC from FILE.
-For `:kind 'from', removes only the requested names; if that leaves
+For `:kind from', removes only the requested names; if that leaves
 the statement empty, the whole statement is deleted.  For `:kind
-'import', removes the whole statement when module (and alias, if
+import', removes the whole statement when module (and alias, if
 specified) matches.  No-op when the import is already absent."
-  (anvil-treesit-with-root file anvil-py--lang root
-    (pcase (anvil-py--spec-kind spec)
-      ('from
-       (let* ((module (plist-get spec :from))
-              (wanted (plist-get spec :names))
-              (existing (anvil-py--find-from-import root module)))
-         (unless (and module wanted)
-           (user-error "anvil-py-remove-import: :from and :names required"))
-         (if (null existing)
-             (anvil-treesit-make-noop-plan
-              file (format "remove-import from %s" module))
-           (let* ((current (anvil-py--from-import-names existing))
-                  (kept (cl-remove-if
-                         (lambda (n)
-                           (member (car (split-string n " as "))
-                                   wanted))
-                         current))
-                  (beg (treesit-node-start existing))
-                  (end (treesit-node-end existing)))
-             (cond
-              ((equal current kept)
+  (let ((kind (anvil-py--spec-kind spec)))
+    (anvil-treesit-with-root file anvil-py--lang root
+      (pcase kind
+        ('from
+         (let* ((module (plist-get spec :from))
+                (wanted (plist-get spec :names))
+                (existing (anvil-py--find-from-import root module)))
+           (unless (and module wanted)
+             (user-error "anvil-py-remove-import: :from and :names required"))
+           (if (null existing)
                (anvil-treesit-make-noop-plan
-                file (format "remove-import from %s" module)))
-              ((null kept)
-               ;; Drop the whole statement — also eat the trailing newline.
-               (let ((end+1 (with-temp-buffer
-                              (insert-file-contents file)
-                              (goto-char end)
-                              (if (eq (char-after) ?\n) (1+ end) end))))
-                 (anvil-treesit-make-plan
-                  file beg end+1 ""
-                  (format "remove-import from %s (drop whole statement)"
-                          module))))
-              (t
+                file (format "remove-import from %s" module))
+             (let* ((current (anvil-py--from-import-names existing))
+                    (kept (cl-remove-if
+                           (lambda (n)
+                             (member (car (split-string n " as "))
+                                     wanted))
+                           current))
+                    (beg (treesit-node-start existing))
+                    (end (treesit-node-end existing)))
+               (cond
+                ((equal current kept)
+                 (anvil-treesit-make-noop-plan
+                  file (format "remove-import from %s" module)))
+                ((null kept)
+                 ;; Drop the whole statement — also eat the trailing newline.
+                 (let ((end+1 (with-temp-buffer
+                                (insert-file-contents file)
+                                (goto-char end)
+                                (if (eq (char-after) ?\n) (1+ end) end))))
+                   (anvil-treesit-make-plan
+                    file beg end+1 ""
+                    (format "remove-import from %s (drop whole statement)"
+                            module))))
+                (t
+                (anvil-treesit-make-plan
+                  file beg end
+                  (anvil-py--render-from-import module kept)
+                  (format "remove-import from %s (drop %d name%s)"
+                          module
+                          (- (length current) (length kept))
+                          (if (= 1 (- (length current) (length kept)))
+                              "" "s")))))))))
+        ('import
+         (let* ((module (plist-get spec :module))
+                (alias (plist-get spec :alias))
+                (existing (anvil-py--find-import root module alias)))
+           (unless module
+             (user-error "anvil-py-remove-import: :module required"))
+           (if (null existing)
+               (anvil-treesit-make-noop-plan
+                file (format "remove-import import %s" module))
+             (let* ((beg (treesit-node-start existing))
+                    (end (treesit-node-end existing))
+                    (end+1 (with-temp-buffer
+                             (insert-file-contents file)
+                             (goto-char end)
+                             (if (eq (char-after) ?\n) (1+ end) end))))
                (anvil-treesit-make-plan
-                file beg end
-                (anvil-py--render-from-import module kept)
-                (format "remove-import from %s (drop %d name%s)"
-                        module
-                        (- (length current) (length kept))
-                        (if (= 1 (- (length current) (length kept)))
-                            "" "s")))))))))
-      ('import
-       (let* ((module (plist-get spec :module))
-              (alias (plist-get spec :alias))
-              (existing (anvil-py--find-import root module alias)))
-         (unless module
-           (user-error "anvil-py-remove-import: :module required"))
-         (if (null existing)
-             (anvil-treesit-make-noop-plan
-              file (format "remove-import import %s" module))
-           (let* ((beg (treesit-node-start existing))
-                  (end (treesit-node-end existing))
-                  (end+1 (with-temp-buffer
-                           (insert-file-contents file)
-                           (goto-char end)
-                           (if (eq (char-after) ?\n) (1+ end) end))))
-             (anvil-treesit-make-plan
-              file beg end+1 ""
-              (format "remove-import import %s" module)))))))))
+                file beg end+1 ""
+                (format "remove-import import %s" module))))))
+        (_ (user-error "anvil-py-remove-import: unsupported :kind %S" kind))))))
 
 ;;;; --- wrap-expr helpers (Phase 2c) ---------------------------------------
 
@@ -731,8 +752,8 @@ pass :class to select"
 (cl-defun anvil-py-add-import (file spec &key apply)
   "Add the import specified by SPEC to FILE.
 SPEC is a plist:
-  (:kind 'from :from MODULE :names (NAME ...))  — `from X import Y, Z'
-  (:kind 'import :module MODULE [:alias NAME]) — `import X [as Y]'
+  (:kind from :from MODULE :names (NAME ...))  — `from X import Y, Z'
+  (:kind import :module MODULE [:alias NAME]) — `import X [as Y]'
 
 Idempotent: if SPEC is already satisfied, returns a no-op plan.
 Merges into an existing `from X import ...' when :kind is `from' and
@@ -794,70 +815,72 @@ SPEC shapes are documented on `anvil-py-rename-import'.  Signals a
 `user-error' when the import does not exist — unlike add/remove,
 renaming requires the target to be present.  Returns a no-op plan
 when the new alias already matches the current one."
-  (anvil-treesit-with-root file anvil-py--lang root
-    (pcase (anvil-py--spec-kind spec)
-      ('import
-       (let* ((module (plist-get spec :module))
-              (new-alias (plist-get spec :new-alias))
-              (node (and module (anvil-py--find-bare-import-node root module))))
-         (unless module
-           (user-error "anvil-py-rename-import: :module required"))
-         (unless node
-           (user-error
-            "anvil-py-rename-import: no `import %s' in %s"
-            module (file-name-nondirectory file)))
-         (let* ((current-text (anvil-treesit-node-text node))
-                (new-text (anvil-py--render-import module new-alias))
-                (beg (treesit-node-start node))
-                (end (treesit-node-end node)))
-           (if (string= current-text new-text)
-               (anvil-treesit-make-noop-plan
-                file (format "rename-import import %s" module))
-             (anvil-treesit-make-plan
-              file beg end new-text
-              (format "rename-import import %s → %s"
-                      module (if new-alias (format "as %s" new-alias)
-                               "(bare)")))))))
-      ('from
-       (let* ((from-mod (plist-get spec :from))
-              (target-name (plist-get spec :name))
-              (new-alias (plist-get spec :new-alias))
-              (node (and from-mod
-                         (anvil-py--find-from-import root from-mod))))
-         (unless (and from-mod target-name)
-           (user-error
-            "anvil-py-rename-import: :from and :name required for from-import"))
-         (unless node
-           (user-error
-            "anvil-py-rename-import: no `from %s import' in %s"
-            from-mod (file-name-nondirectory file)))
-         (let* ((entries (anvil-py--from-import-names node))
-                (target-idx (cl-position target-name entries
-                                         :test (lambda (want entry)
-                                                 (string=
-                                                  want
-                                                  (car (anvil-py--split-name-alias
-                                                        entry)))))))
-           (unless target-idx
+  (let ((kind (anvil-py--spec-kind spec)))
+    (anvil-treesit-with-root file anvil-py--lang root
+      (pcase kind
+        ('import
+         (let* ((module (plist-get spec :module))
+                (new-alias (plist-get spec :new-alias))
+                (node (and module (anvil-py--find-bare-import-node root module))))
+           (unless module
+             (user-error "anvil-py-rename-import: :module required"))
+           (unless node
              (user-error
-              "anvil-py-rename-import: %s not in `from %s import'"
-              target-name from-mod))
-           (let* ((current-entry (nth target-idx entries))
-                  (new-entry (anvil-py--render-name-entry target-name new-alias)))
-             (if (string= current-entry new-entry)
+              "anvil-py-rename-import: no `import %s' in %s"
+              module (file-name-nondirectory file)))
+           (let* ((current-text (anvil-treesit-node-text node))
+                  (new-text (anvil-py--render-import module new-alias))
+                  (beg (treesit-node-start node))
+                  (end (treesit-node-end node)))
+             (if (string= current-text new-text)
                  (anvil-treesit-make-noop-plan
-                  file (format "rename-import from %s:%s"
-                               from-mod target-name))
-               (let* ((new-entries (copy-sequence entries))
-                      (_ (setf (nth target-idx new-entries) new-entry))
-                      (new-text (anvil-py--render-from-import
-                                 from-mod new-entries))
-                      (beg (treesit-node-start node))
-                      (end (treesit-node-end node)))
-                 (anvil-treesit-make-plan
-                  file beg end new-text
-                  (format "rename-import from %s: %s → %s"
-                          from-mod current-entry new-entry)))))))))))
+                  file (format "rename-import import %s" module))
+               (anvil-treesit-make-plan
+                file beg end new-text
+                (format "rename-import import %s → %s"
+                        module (if new-alias (format "as %s" new-alias)
+                                 "(bare)")))))))
+        ('from
+         (let* ((from-mod (plist-get spec :from))
+                (target-name (plist-get spec :name))
+                (new-alias (plist-get spec :new-alias))
+                (node (and from-mod
+                           (anvil-py--find-from-import root from-mod))))
+           (unless (and from-mod target-name)
+             (user-error
+              "anvil-py-rename-import: :from and :name required for from-import"))
+           (unless node
+             (user-error
+              "anvil-py-rename-import: no `from %s import' in %s"
+              from-mod (file-name-nondirectory file)))
+           (let* ((entries (anvil-py--from-import-names node))
+                  (target-idx (cl-position target-name entries
+                                           :test (lambda (want entry)
+                                                   (string=
+                                                    want
+                                                    (car (anvil-py--split-name-alias
+                                                          entry)))))))
+             (unless target-idx
+               (user-error
+                "anvil-py-rename-import: %s not in `from %s import'"
+                target-name from-mod))
+             (let* ((current-entry (nth target-idx entries))
+                    (new-entry (anvil-py--render-name-entry target-name new-alias)))
+               (if (string= current-entry new-entry)
+                   (anvil-treesit-make-noop-plan
+                    file (format "rename-import from %s:%s"
+                                 from-mod target-name))
+                 (let* ((new-entries (copy-sequence entries))
+                        (_ (setf (nth target-idx new-entries) new-entry))
+                        (new-text (anvil-py--render-from-import
+                                   from-mod new-entries))
+                        (beg (treesit-node-start node))
+                        (end (treesit-node-end node)))
+                   (anvil-treesit-make-plan
+                    file beg end new-text
+                    (format "rename-import from %s: %s → %s"
+                            from-mod current-entry new-entry))))))))
+        (_ (user-error "anvil-py-rename-import: unsupported :kind %S" kind))))))
 
 (cl-defun anvil-py--plan-replace-function (file name new-source class-filter)
   "Build an edit plan replacing the def named NAME in FILE with NEW-SOURCE.
@@ -911,10 +934,10 @@ Returns the plan unless APPLY is truthy.  :apply t writes via
 (cl-defun anvil-py-rename-import (file spec &key apply)
   "Rename the alias of an existing import in FILE.
 SPEC is a plist:
-  (:kind 'import :module MODULE :new-alias STR-OR-NIL)
+  (:kind import :module MODULE :new-alias STR-OR-NIL)
     — rewrite `import MODULE [as OLD]' to `import MODULE [as NEW]';
       :new-alias nil drops the alias (makes it bare).
-  (:kind 'from :from MODULE :name NAME :new-alias STR-OR-NIL)
+  (:kind from :from MODULE :name NAME :new-alias STR-OR-NIL)
     — rewrite the single NAME entry inside `from MODULE import ...'.
       Other names in the statement are preserved verbatim.
 
@@ -1090,8 +1113,8 @@ a plist whose values are ready for the elisp planners."
               (user-error "anvil-py: unsupported spec shape %S" spec))))
          (kind (plist-get s :kind))
          (names (plist-get s :names)))
-    (when (stringp kind)
-      (setq s (plist-put s :kind (intern kind))))
+    (when kind
+      (setq s (plist-put s :kind (anvil-py--normalize-kind kind))))
     (when (vectorp names)
       (setq s (plist-put s :names (append names nil)))
       (setq names (plist-get s :names)))
@@ -1285,8 +1308,8 @@ range contains the 1-based buffer POINT.  KIND restricts the match to
    :layer 'core
    :server-id anvil-py--server-id
    :description "Add an import to a Python file.  SPEC is a plist:
-(:kind 'from :from MODULE :names (NAME ...)) for `from X import ...',
-or (:kind 'import :module MODULE [:alias NAME]) for `import X'.
+(:kind from :from MODULE :names (NAME ...)) for `from X import ...',
+or (:kind import :module MODULE [:alias NAME]) for `import X'.
 Idempotent — merges into an existing `from X import ...' for the same
 module, and returns a no-op plan when SPEC is already satisfied.
 Preview-default; pass :apply t to write via file-batch-across.")
@@ -1310,8 +1333,8 @@ Preview-default; pass :apply t to write via file-batch-across.")
    :layer 'core
    :server-id anvil-py--server-id
    :description "Rename the alias of an existing import statement.
-SPEC shape: (:kind 'import :module M :new-alias S-or-nil) for bare
-imports, or (:kind 'from :from M :name N :new-alias S-or-nil) for
+SPEC shape: (:kind import :module M :new-alias S-or-nil) for bare
+imports, or (:kind from :from M :name N :new-alias S-or-nil) for
 from-imports (single-name alias rename; other names in the same
 statement are preserved).  Errors when the target import is not
 present — this is an edit, not a create.  Reference renaming at

--- a/anvil-py.el
+++ b/anvil-py.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'json)
 (require 'subr-x)
 (require 'anvil-server)
 (require 'anvil-treesit)
@@ -1011,33 +1012,84 @@ MCP Parameters:
    (or (anvil-py-find-definition file name)
        (list :found nil :name name))))
 
+(defun anvil-py--plist-p (x)
+  "Return non-nil when X looks like a plist."
+  (and (listp x) (keywordp (car-safe x))))
+
+(defun anvil-py--spec-keyword (key)
+  "Normalize SPEC KEY into the keyword form used by the planners."
+  (intern
+   (concat
+    ":"
+    (replace-regexp-in-string
+     "_"
+     "-"
+     (cond
+      ((keywordp key) (substring (symbol-name key) 1))
+      ((symbolp key) (symbol-name key))
+      ((stringp key) key)
+      (t (format "%s" key)))))))
+
+(defun anvil-py--alist-to-plist (alist)
+  "Convert ALIST to a plist with normalized keyword keys."
+  (let (out)
+    (dolist (entry alist)
+      (push (anvil-py--spec-keyword (car entry)) out)
+      (push (cdr entry) out))
+    (nreverse out)))
+
+(defun anvil-py--parse-spec-string (spec)
+  "Parse string SPEC as JSON or Lisp data and return the resulting object."
+  (let ((trimmed (string-trim spec)))
+    (unless (string-empty-p trimmed)
+      (or
+       (condition-case nil
+           (json-parse-string trimmed
+                              :object-type 'plist
+                              :array-type 'list
+                              :null-object nil
+                              :false-object nil)
+         (error nil))
+       (condition-case nil
+           (pcase-let ((`(,obj . ,idx) (read-from-string trimmed)))
+             (when (string-empty-p (string-trim (substring trimmed idx)))
+               obj))
+         (error nil))
+       (user-error "anvil-py: could not parse spec string %S" spec)))))
+
 (defun anvil-py--coerce-spec (spec)
   "Normalize an MCP-bridge SPEC into the elisp plist shape.
-MCP tool calls can arrive with string-valued :kind (\"from\" vs 'from)
-and string-encoded name lists.  Return a plist whose values are ready
-for the elisp planners."
-  (let* ((s (cond ((and spec (listp spec)) (copy-sequence spec))
-                  ((hash-table-p spec)
-                   (let (out)
-                     (maphash (lambda (k v)
-                                (push v out)
-                                (push (intern
-                                       (concat ":"
-                                               (if (keywordp k)
-                                                   (substring
-                                                    (symbol-name k) 1)
-                                                 (format "%s" k))))
-                                      out))
-                              spec)
-                     out))
-                  (t nil)))
-         (kind (plist-get s :kind)))
+MCP tool calls can arrive as a plist, an alist / hash-table decoded
+from JSON, or a JSON / Lisp string representation of either.  Return
+a plist whose values are ready for the elisp planners."
+  (let* ((s (cond
+             ((null spec) nil)
+             ((anvil-py--plist-p spec)
+              (copy-sequence spec))
+             ((hash-table-p spec)
+              (let (out)
+                (maphash (lambda (k v)
+                           (push (cons k v) out))
+                         spec)
+                (anvil-py--alist-to-plist (nreverse out))))
+             ((and (listp spec) (consp spec) (consp (car spec)))
+              (anvil-py--alist-to-plist spec))
+             ((stringp spec)
+              (anvil-py--coerce-spec (anvil-py--parse-spec-string spec)))
+             ((listp spec)
+              (copy-sequence spec))
+             (t
+              (user-error "anvil-py: unsupported spec shape %S" spec))))
+         (kind (plist-get s :kind))
+         (names (plist-get s :names)))
     (when (stringp kind)
       (setq s (plist-put s :kind (intern kind))))
-    (when (stringp (plist-get s :names))
+    (when (vectorp names)
+      (setq s (plist-put s :names (append names nil)))
+      (setq names (plist-get s :names)))
+    (when (stringp names)
       (setq s (plist-put s :names
-                         (split-string (plist-get s :names)
-                                       "[ ,]+" t))))
+                         (split-string names "[ ,]+" t))))
     s))
 
 (defun anvil-py--tool-add-import (file spec apply)

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -692,6 +692,11 @@ METHOD-METRICS is used to track errors."
      (let ((code (car (cdr err)))
            (message (cadr (cdr err))))
        (anvil-server--jsonrpc-error id code message)))
+    (quit
+     (cl-incf (anvil-server-metrics-errors method-metrics))
+     (anvil-server--jsonrpc-error
+      id anvil-server-jsonrpc-error-internal
+      (format "Resource handler quit for %s: %S" uri err)))
     ;; Handle any other error from the handler
     (error
      (cl-incf (anvil-server-metrics-errors method-metrics))
@@ -1115,6 +1120,12 @@ virtual server-ids share the same handler pool."
                       (isError . t))))
                (anvil-server--respond-with-result
                 context formatted-error)))
+            (quit
+             (anvil-server-metrics--track-tool-call tool-name t)
+             (cl-incf (anvil-server-metrics-errors method-metrics))
+             (anvil-server--jsonrpc-error
+              id anvil-server-jsonrpc-error-internal
+              (format "Tool handler quit: %S" err)))
             ;; Keep existing handling for all other errors
             (error
              (anvil-server-metrics--track-tool-call tool-name t)
@@ -1240,6 +1251,8 @@ See also: `anvil-server-tool-throw'"
   `(condition-case err
        (progn
          ,@body)
+     (quit
+      (anvil-server-tool-throw (format "Quit: %S" err)))
      (error
       (anvil-server-tool-throw (format "Error: %S" err)))))
 
@@ -1289,6 +1302,8 @@ See also: `anvil-server-process-jsonrpc-parsed'"
           (setq response
                 (anvil-server--validate-and-dispatch-request
                  json-object server-id))
+        (quit
+         (setq response (anvil-server--handle-error err)))
         (error
          (setq response (anvil-server--handle-error err)))))
 

--- a/anvil-sexp.el
+++ b/anvil-sexp.el
@@ -428,9 +428,9 @@ form with NAME is found."
        (anvil-sexp--maybe-apply plan apply)))))
 
 (defun anvil-sexp--sexp-bounds-at (point)
-  "Return (BEG . END) of the sexp surrounding POINT in the current buffer.
-Uses `bounds-of-thing-at-point' and falls back to `up-list' when
-POINT lies directly on whitespace between forms."
+  "Return (BEG . END) of the innermost sexp at POINT in the current buffer.
+Uses `bounds-of-thing-at-point' and falls back to the enclosing list
+when POINT lies directly on whitespace between forms."
   (save-excursion
     (goto-char point)
     (or (bounds-of-thing-at-point 'sexp)
@@ -442,11 +442,12 @@ POINT lies directly on whitespace between forms."
               (cons beg (point))))))))
 
 (defun anvil-sexp--tool-wrap-form (file point wrapper &optional apply)
-  "Wrap the sexp at POINT in FILE with WRAPPER.
+  "Wrap the innermost sexp at POINT in FILE with WRAPPER.
+When POINT lies on inter-form whitespace, fall back to the enclosing list.
 
 MCP Parameters:
   file    - Absolute path to an .el source file.
-  point   - Buffer point (1-based) inside the sexp to wrap.
+  point   - Buffer point (1-based) at or inside the sexp to wrap.
   wrapper - Elisp source text containing the placeholder token
             `|anvil-sexp-hole|'.  Example:
               \"(when cond |anvil-sexp-hole|)\"
@@ -1140,7 +1141,8 @@ tool; defaults to preview unless APPLY is non-nil."
   (anvil-sexp--tool-replace-defun file name new-form (when apply "t")))
 
 (cl-defun anvil-sexp-wrap-form (file point wrapper &key apply)
-  "Wrap the sexp surrounding POINT in FILE with WRAPPER.
+  "Wrap the innermost sexp at POINT in FILE with WRAPPER.
+When POINT lies on inter-form whitespace, fall back to the enclosing list.
 WRAPPER is source text containing `|anvil-sexp-hole|'.  See
 `sexp-wrap-form' MCP tool."
   (anvil-sexp--tool-wrap-form file point wrapper (when apply "t")))
@@ -1264,10 +1266,11 @@ does not parse or when no form matches the given name.")
    :layer 'core
    :server-id anvil-sexp--server-id
    :description
-   "Wrap the sexp surrounding POINT in FILE with WRAPPER source text.
-WRAPPER must contain the placeholder token `|anvil-sexp-hole|';
-the original sexp replaces the placeholder.  Preview by default;
-apply=t writes to disk.")
+   "Wrap the innermost sexp at POINT in FILE with WRAPPER source text.
+When POINT lies on inter-form whitespace, the tool falls back to the
+enclosing list.  WRAPPER must contain the placeholder token
+`|anvil-sexp-hole|'; the original sexp replaces the placeholder.
+Preview by default; apply=t writes to disk.")
 
   (anvil-server-register-tool
    (anvil-server-encode-handler #'anvil-sexp--tool-rename-symbol)

--- a/anvil-sexp.el
+++ b/anvil-sexp.el
@@ -999,19 +999,35 @@ leak in."
     (with-temp-buffer
       (insert log-text)
       (goto-char (point-min))
-      (while (re-search-forward
-              "^\\(.*?\\):\\([0-9]+\\):\\([0-9]+\\):\\s-*\\(Warning\\|Error\\):\\s-*\\(.*\\)$"
-              nil t)
-        (let ((path (match-string 1))
-              (line (string-to-number (match-string 2)))
-              (col  (string-to-number (match-string 3)))
-              (kind-str (match-string 4))
-              (msg (match-string 5)))
-          (when (string-equal (file-name-nondirectory path) base)
-            (push (list :kind (if (equal kind-str "Error") 'error 'warning)
-                        :source 'byte-compile
-                        :line line :column col :message msg)
-                  diags)))))
+      (while (not (eobp))
+        (let ((line-text (buffer-substring-no-properties
+                          (line-beginning-position) (line-end-position))))
+          (cond
+           ((string-match
+             "^\\(.*?\\):\\([0-9]+\\):\\([0-9]+\\):\\s-*\\(Warning\\|Error\\):\\s-*\\(.*\\)$"
+             line-text)
+            (let ((path (match-string 1 line-text))
+                  (line (string-to-number (match-string 2 line-text)))
+                  (col  (string-to-number (match-string 3 line-text)))
+                  (kind-str (match-string 4 line-text))
+                  (msg (match-string 5 line-text)))
+              (when (string-equal (file-name-nondirectory path) base)
+                (push (list :kind (if (equal kind-str "Error") 'error 'warning)
+                            :source 'byte-compile
+                            :line line :column col :message msg)
+                      diags))))
+           ((string-match
+             "^\\(.*?\\):\\s-*\\(Warning\\|Error\\):\\s-*\\(.*\\)$"
+             line-text)
+            (let ((path (match-string 1 line-text))
+                  (kind-str (match-string 2 line-text))
+                  (msg (match-string 3 line-text)))
+              (when (string-equal (file-name-nondirectory path) base)
+                (push (list :kind (if (equal kind-str "Error") 'error 'warning)
+                            :source 'byte-compile
+                            :line 0 :column 0 :message msg)
+                      diags)))))
+        (forward-line 1))))
     (nreverse diags)))
 
 (defun anvil-sexp--run-byte-compile (file)

--- a/tests/anvil-buffer-test.el
+++ b/tests/anvil-buffer-test.el
@@ -25,7 +25,10 @@
                (write-region ,content nil ,file-var nil 'silent))
              (setq ,buf-var (find-file-noselect ,file-var))
              ,@body)
-         (when (buffer-live-p ,buf-var) (kill-buffer ,buf-var))
+         (when (buffer-live-p ,buf-var)
+           (with-current-buffer ,buf-var
+             (set-buffer-modified-p nil))
+           (kill-buffer ,buf-var))
          (ignore-errors (delete-file ,file-var))))))
 
 (defun anvil-buffer-test--bump-disk-mtime (file)

--- a/tests/anvil-disk-test.el
+++ b/tests/anvil-disk-test.el
@@ -33,7 +33,10 @@ is killed and the file deleted on exit."
                  `((setq ,buf-var (find-file-noselect ,file-var))))
              ,@body)
          ,@(when buf-var
-             `((when (buffer-live-p ,buf-var) (kill-buffer ,buf-var))))
+             `((when (buffer-live-p ,buf-var)
+                 (with-current-buffer ,buf-var
+                   (set-buffer-modified-p nil))
+                 (kill-buffer ,buf-var))))
          (ignore-errors (delete-file ,file-var))))))
 
 (defun anvil-disk-test--bump-disk-mtime (file)

--- a/tests/anvil-elisp-test.el
+++ b/tests/anvil-elisp-test.el
@@ -21,6 +21,29 @@
                      :null-object nil
                      :false-object nil))
 
+(defun anvil-elisp-test--require-native-compiler ()
+  "Skip unless this runner can actually produce native-compiled functions."
+  (unless (and (fboundp 'native-compile)
+               (fboundp 'native-comp-function-p)
+               (fboundp 'native-comp-available-p)
+               (native-comp-available-p))
+    (ert-skip "native compilation is unavailable on this runner")))
+
+(defun anvil-elisp-test--native-compile-symbol-or-skip (sym)
+  "Native-compile SYM or skip if the runner cannot do so reliably."
+  (anvil-elisp-test--require-native-compiler)
+  (condition-case err
+      (let ((compiled (native-compile sym)))
+        (unless (native-comp-function-p compiled)
+          (ert-skip
+           (format "native-compile did not return a native function for %s"
+                   sym)))
+        (fset sym compiled))
+    (error
+     (ert-skip
+      (format "native compilation failed on this runner: %s"
+              (error-message-string err))))))
+
 (defun anvil-elisp-test--with-temp-source (fn)
   "Write a temporary Elisp fixture and call FN with its path."
   (let* ((dir (make-temp-file "anvil-elisp-test-" t))
@@ -75,13 +98,11 @@
 
 (ert-deftest anvil-elisp-test-native-compiled-file-backed-function-uses-source ()
   "Native-compiled Elisp functions with a source file must not be treated as C."
-  (unless (and (fboundp 'native-compile)
-               (fboundp 'native-comp-function-p))
-    (ert-skip "native compilation is unavailable on this runner"))
+  (anvil-elisp-test--require-native-compiler)
   (anvil-elisp-test--with-temp-source
    (lambda (file)
-     (fset 'anvil-elisp-test-fixture-fn
-           (native-compile 'anvil-elisp-test-fixture-fn))
+     (anvil-elisp-test--native-compile-symbol-or-skip
+      'anvil-elisp-test-fixture-fn)
      (should (subrp (symbol-function 'anvil-elisp-test-fixture-fn)))
      (should-not
       (and (fboundp 'subr-primitive-p)
@@ -98,9 +119,7 @@
 
 (ert-deftest anvil-elisp-test-native-compiled-no-source-returns-synthetic-stub ()
   "A native-compiled function without source should return a synthetic stub."
-  (unless (and (fboundp 'native-compile)
-               (fboundp 'native-comp-function-p))
-    (ert-skip "native compilation is unavailable on this runner"))
+  (anvil-elisp-test--require-native-compiler)
   (let ((sym 'anvil-elisp-test-native-no-source))
     (unwind-protect
         (progn
@@ -108,7 +127,7 @@
             (lambda (x y)
               "Standalone native doc."
               (+ x y 3)))
-          (fset sym (native-compile sym))
+          (anvil-elisp-test--native-compile-symbol-or-skip sym)
           (let ((res (anvil-elisp-test--parse-json
                       (anvil-elisp--get-function-definition
                        (symbol-name sym)))))

--- a/tests/anvil-elisp-test.el
+++ b/tests/anvil-elisp-test.el
@@ -1,0 +1,133 @@
+;;; anvil-elisp-test.el --- Tests for anvil-elisp -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Focused regression tests for Elisp definition lookup, including the
+;; native-comp case where a file-backed Elisp function appears as `subr'
+;; at runtime.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+(require 'anvil-elisp)
+
+(defun anvil-elisp-test--parse-json (text)
+  "Parse TEXT as a plist-shaped JSON object."
+  (json-parse-string text
+                     :object-type 'plist
+                     :array-type 'list
+                     :null-object nil
+                     :false-object nil))
+
+(defun anvil-elisp-test--with-temp-source (fn)
+  "Write a temporary Elisp fixture and call FN with its path."
+  (let* ((dir (make-temp-file "anvil-elisp-test-" t))
+         (file (expand-file-name "fixture.el" dir))
+         (feature 'anvil-elisp-test-fixture)
+         (symbols '(anvil-elisp-test-fixture-fn
+                    anvil-elisp-test-fixture-alias)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ";;; fixture.el --- temp -*- lexical-binding: t; -*-\n\n"
+                    ";; Header for temp source fn\n"
+                    "(defun anvil-elisp-test-fixture-fn (x)\n"
+                    "  \"Return X plus one.\"\n"
+                    "  (+ x 1))\n\n"
+                    "(defalias 'anvil-elisp-test-fixture-alias\n"
+                    "  #'anvil-elisp-test-fixture-fn\n"
+                    "  \"Alias doc.\")\n\n"
+                    "(provide 'anvil-elisp-test-fixture)\n"))
+          (load-file file)
+          (funcall fn file))
+      (ignore-errors
+        (when (featurep feature)
+          (unload-feature feature t)))
+      (dolist (sym symbols)
+        (ignore-errors (fmakunbound sym)))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest anvil-elisp-test-get-function-definition-c-primitive ()
+  "True C primitives still report the C-function shape."
+  (let ((res (anvil-elisp-test--parse-json
+              (anvil-elisp--get-function-definition "car"))))
+    (should (plist-get res :is-c-function))
+    (should (equal "car" (plist-get res :function-name)))))
+
+(ert-deftest anvil-elisp-test-dispatch-prefers-source-file-over-subr ()
+  "A file-backed `subr' must go through the source-file path."
+  (cl-letf (((symbol-function 'find-lisp-object-file-name)
+             (lambda (_sym _type) "/tmp/fake-source.el"))
+            ((symbol-function 'anvil-elisp--get-function-definition-from-file)
+             (lambda (function sym func-file is-alias aliased-to)
+               (list :from-file function sym func-file is-alias aliased-to)))
+            ((symbol-function 'anvil-elisp--get-function-definition-c-function)
+             (lambda (&rest _args)
+               :c-function)))
+    (should
+     (equal
+      '(:from-file "car" car "/tmp/fake-source.el" nil nil)
+      (anvil-elisp--get-function-definition-dispatch
+       "car" 'car (list (symbol-function 'car) nil nil))))))
+
+(ert-deftest anvil-elisp-test-native-compiled-file-backed-function-uses-source ()
+  "Native-compiled Elisp functions with a source file must not be treated as C."
+  (unless (and (fboundp 'native-compile)
+               (fboundp 'native-comp-function-p))
+    (ert-skip "native compilation is unavailable on this runner"))
+  (anvil-elisp-test--with-temp-source
+   (lambda (file)
+     (fset 'anvil-elisp-test-fixture-fn
+           (native-compile 'anvil-elisp-test-fixture-fn))
+     (should (subrp (symbol-function 'anvil-elisp-test-fixture-fn)))
+     (should-not
+      (and (fboundp 'subr-primitive-p)
+           (subr-primitive-p (symbol-function 'anvil-elisp-test-fixture-fn))))
+     (let ((res (anvil-elisp-test--parse-json
+                 (anvil-elisp--get-function-definition
+                  "anvil-elisp-test-fixture-fn"))))
+       (should-not (plist-member res :is-c-function))
+       (should (equal file (plist-get res :file-path)))
+       (should
+        (string-match-p
+         "(defun anvil-elisp-test-fixture-fn"
+         (plist-get res :source)))))))
+
+(ert-deftest anvil-elisp-test-native-compiled-no-source-returns-synthetic-stub ()
+  "A native-compiled function without source should return a synthetic stub."
+  (unless (and (fboundp 'native-compile)
+               (fboundp 'native-comp-function-p))
+    (ert-skip "native compilation is unavailable on this runner"))
+  (let ((sym 'anvil-elisp-test-native-no-source))
+    (unwind-protect
+        (progn
+          (defalias sym
+            (lambda (x y)
+              "Standalone native doc."
+              (+ x y 3)))
+          (fset sym (native-compile sym))
+          (let ((res (anvil-elisp-test--parse-json
+                      (anvil-elisp--get-function-definition
+                       (symbol-name sym)))))
+            (should-not (plist-member res :is-c-function))
+            (should (plist-get res :source-unavailable))
+            (should (equal "native-compiled-no-source"
+                           (plist-get res :reason)))
+            (should (equal "<native-compiled>"
+                           (plist-get res :file-path)))
+            (should (string-match-p
+                     "Synthetic stub"
+                     (plist-get res :source)))
+            (should (string-match-p
+                     "(defun anvil-elisp-test-native-no-source"
+                     (plist-get res :source)))
+            (should (string-match-p
+                     "Standalone native doc."
+                     (plist-get res :source)))))
+      (ignore-errors (fmakunbound sym)))))
+
+(provide 'anvil-elisp-test)
+;;; anvil-elisp-test.el ends here

--- a/tests/anvil-file-test.el
+++ b/tests/anvil-file-test.el
@@ -27,6 +27,13 @@
       (insert-file-contents path))
     (buffer-string)))
 
+(defun anvil-file-test--discard-buffer (buf)
+  "Kill visited temp BUF without interactive modified-buffer prompts."
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      (set-buffer-modified-p nil))
+    (kill-buffer buf)))
+
 ;;;; --- json-object-add ------------------------------------------------------
 
 (ert-deftest anvil-file-test-json-add-empty-object ()
@@ -254,7 +261,7 @@
                (should (string-match-p "buffer-newer" (car ws)))
                ;; Disk content unchanged.
                (should (equal "hello\n" (plist-get res :content)))))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-replace-string-warnings-empty ()
   "anvil-file-replace-string returns :warnings nil when no buffer visits."
@@ -283,7 +290,7 @@
                (should (string-match-p "buffer-newer" (car ws)))
                (should (equal "alpha BETA gamma\n"
                               (anvil-file-test--read path)))))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 ;;;; --- Phase 2 full: :warnings embedded in all mutating tools --------------
 
@@ -303,7 +310,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-replace-regexp path "b+" "BBB")))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-insert-at-line-warnings ()
   (anvil-file-test--with-tmp
@@ -315,7 +322,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-insert-at-line path 2 "inserted")))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-delete-lines-warnings ()
   (anvil-file-test--with-tmp
@@ -327,7 +334,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-delete-lines path 2 3)))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-append-warnings ()
   (anvil-file-test--with-tmp
@@ -339,7 +346,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-append path "tail\n")))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-prepend-warnings ()
   (anvil-file-test--with-tmp
@@ -351,7 +358,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-prepend path "head\n")))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-batch-warnings ()
   (anvil-file-test--with-tmp
@@ -365,7 +372,7 @@
               (anvil-file-batch
                path
                '(((op . "replace") (old . "foo") (new . "FOO"))))))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-ensure-import-warnings-insert-path ()
   "ensure-import's insertion branch carries a divergence :warning."
@@ -378,7 +385,7 @@
              (with-current-buffer buf (insert "UNSAVED"))
              (anvil-file-test--expect-warning
               (anvil-file-ensure-import path "import c")))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 (ert-deftest anvil-file-test-phase2-ensure-import-warnings-already-present ()
   "ensure-import's already-present branch still surfaces :warnings.
@@ -396,7 +403,7 @@ Uses a fixture whose target line is already on disk so no write fires."
                (should (string-match-p
                         "buffer-newer\\|both-modified"
                         (car (plist-get res :warnings))))))
-         (when (buffer-live-p buf) (kill-buffer buf)))))))
+         (anvil-file-test--discard-buffer buf))))))
 
 ;;;; --- code-add-field-by-map ----------------------------------------------
 

--- a/tests/anvil-git-test.el
+++ b/tests/anvil-git-test.el
@@ -56,6 +56,14 @@ then delete the repo."
         (should-not (anvil-git-repo-root tmp))
       (delete-directory tmp t))))
 
+(ert-deftest anvil-git-test-repo-root-errors-on-file-path ()
+  (anvil-git-test--with-repo repo
+    (let ((file (expand-file-name "tracked.txt" repo)))
+      (with-temp-file file
+        (insert "hello\n"))
+      (should-error (anvil-git-repo-root file)
+                    :type 'user-error))))
+
 ;;;; --- head-sha / branch --------------------------------------------------
 
 (ert-deftest anvil-git-test-head-sha-returns-40-hex ()

--- a/tests/anvil-ide-test.el
+++ b/tests/anvil-ide-test.el
@@ -96,5 +96,36 @@
                       result))
          (should-not (string-match-p "external apropos" result)))))))
 
+(ert-deftest anvil-ide-test-xref-find-references-elisp-no-project-falls-back-to-directory-search ()
+  "Non-project Elisp references should avoid the interactive project prompt."
+  (anvil-ide-test--with-temp-xref-layout
+   (lambda (_project-root target-file project-hit external-hit)
+     (let ((expected-root
+            (file-name-as-directory
+             (file-name-directory (expand-file-name target-file)))))
+       (cl-letf (((symbol-function 'xref-find-backend)
+                  (lambda () 'elisp))
+                 ((symbol-function 'anvil-ide--project-for-buffer)
+                  (lambda (_buffer) nil))
+                 ((symbol-function 'xref-backend-references)
+                  (lambda (&rest _)
+                    (signal 'quit '(minibuffer-quit))))
+                 ((symbol-function 'xref-references-in-directory)
+                  (lambda (_identifier dir)
+                    (should (equal expected-root
+                                   (file-name-as-directory dir)))
+                    (list
+                     (anvil-ide-test--make-xref target-file 3 "local reference")
+                     (anvil-ide-test--make-xref external-hit 3 "external reference")))))
+         (let ((result (anvil-ide--xref-find-references "sample" target-file)))
+           (should (string-match-p
+                    (regexp-quote target-file)
+                    result))
+           (should (string-match-p "local reference" result))
+           (should-not (string-match-p
+                        (regexp-quote external-hit)
+                        result))
+           (should-not (string-match-p "external reference" result))))))))
+
 (provide 'anvil-ide-test)
 ;;; anvil-ide-test.el ends here

--- a/tests/anvil-ide-test.el
+++ b/tests/anvil-ide-test.el
@@ -1,0 +1,100 @@
+;;; anvil-ide-test.el --- Regression tests for anvil-ide -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Focused regression tests for xref scoping.  The xref tools should keep
+;; results inside the project associated with the context file instead of
+;; mixing in hits from installed packages or other unrelated directories.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'xref)
+(require 'anvil-ide)
+
+(defun anvil-ide-test--write-file (path content)
+  "Write CONTENT to PATH, creating parent directories as needed."
+  (make-directory (file-name-directory path) t)
+  (with-temp-file path
+    (insert content)))
+
+(defun anvil-ide-test--make-xref (file line summary)
+  "Return an xref item for FILE at LINE with SUMMARY."
+  (xref-make summary
+             (xref-make-file-location file line 1)))
+
+(defun anvil-ide-test--with-temp-xref-layout (fn)
+  "Create a temporary project/external layout and call FN with its files."
+  (let* ((dir (make-temp-file "anvil-ide-test-" t))
+         (project-root (expand-file-name "project" dir))
+         (target-file (expand-file-name "src/main.el" project-root))
+         (project-hit (expand-file-name "lib/project-hit.el" project-root))
+         (external-hit (expand-file-name "elpa/pkg/external-hit.el" dir)))
+    (unwind-protect
+        (progn
+          (anvil-ide-test--write-file
+           target-file
+           ";;; main.el\n\n(defun sample ()\n  nil)\n")
+          (anvil-ide-test--write-file
+           project-hit
+           ";;; project-hit.el\n\n(sample)\n")
+          (anvil-ide-test--write-file
+           external-hit
+           ";;; external-hit.el\n\n(sample)\n")
+          (funcall fn project-root target-file project-hit external-hit))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest anvil-ide-test-xref-find-references-filters-to-project-root ()
+  "xref references should exclude matches outside the current project."
+  (anvil-ide-test--with-temp-xref-layout
+   (lambda (project-root target-file project-hit external-hit)
+     (cl-letf (((symbol-function 'xref-find-backend)
+                (lambda () 'fake-backend))
+               ((symbol-function 'xref-backend-references)
+                (lambda (_backend _identifier)
+                  (list
+                   (anvil-ide-test--make-xref project-hit 3 "project reference")
+                   (anvil-ide-test--make-xref external-hit 3 "external reference"))))
+               ((symbol-function 'anvil-ide--project-for-buffer)
+                (lambda (_buffer) :fake-project))
+               ((symbol-function 'project-root)
+                (lambda (_project) project-root)))
+       (let ((result (anvil-ide--xref-find-references "sample" target-file)))
+         (should (string-match-p
+                  (regexp-quote project-hit)
+                  result))
+         (should (string-match-p "project reference" result))
+         (should-not (string-match-p
+                      (regexp-quote external-hit)
+                      result))
+         (should-not (string-match-p "external reference" result)))))))
+
+(ert-deftest anvil-ide-test-xref-find-apropos-filters-to-project-root ()
+  "xref apropos should exclude matches outside the current project."
+  (anvil-ide-test--with-temp-xref-layout
+   (lambda (project-root target-file project-hit external-hit)
+     (cl-letf (((symbol-function 'xref-find-backend)
+                (lambda () 'fake-backend))
+               ((symbol-function 'xref-backend-apropos)
+                (lambda (_backend _pattern)
+                  (list
+                   (anvil-ide-test--make-xref project-hit 3 "project apropos")
+                   (anvil-ide-test--make-xref external-hit 3 "external apropos"))))
+               ((symbol-function 'anvil-ide--project-for-buffer)
+                (lambda (_buffer) :fake-project))
+               ((symbol-function 'project-root)
+                (lambda (_project) project-root)))
+       (let ((result (anvil-ide--xref-find-apropos "sample" target-file)))
+         (should (string-match-p
+                  (regexp-quote project-hit)
+                  result))
+         (should (string-match-p "project apropos" result))
+         (should-not (string-match-p
+                      (regexp-quote external-hit)
+                      result))
+         (should-not (string-match-p "external apropos" result)))))))
+
+(provide 'anvil-ide-test)
+;;; anvil-ide-test.el ends here

--- a/tests/anvil-new-tools-test.el
+++ b/tests/anvil-new-tools-test.el
@@ -61,6 +61,25 @@
             (should (stringp (plist-get (car fails) :condition)))))
       (ignore-errors (delete-file tmp)))))
 
+(ert-deftest anvil-tools-test-ert-run-adds-test-file-directory-to-load-path ()
+  "Test files can `require' sibling helpers from their own directory."
+  (let* ((dir (make-temp-file "anvil-ert-path-" t))
+         (helper (expand-file-name "tmp-helper.el" dir))
+         (test-file (expand-file-name "tmp-helper-test.el" dir)))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           helper
+           "(provide 'tmp-helper)\n(defun tmp-helper-answer () 42)\n")
+          (anvil-new-tools-test--write
+           test-file
+           "(require 'ert)\n(require 'tmp-helper)\n(ert-deftest anvil-tools-tmp-helper-test () (should (= 42 (tmp-helper-answer))))\n")
+          (let* ((out (anvil-elisp--ert-run test-file nil))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should (= 1 (plist-get res :passed)))
+            (should (= 0 (plist-get res :failed)))))
+      (ignore-errors (delete-directory dir t)))))
+
 (ert-deftest anvil-tools-test-ert-fresh-feature-strips-test-suffix ()
   "Helper infers a feature symbol by stripping the trailing `-test'."
   (should (eq 'anvil-worker

--- a/tests/anvil-new-tools-test.el
+++ b/tests/anvil-new-tools-test.el
@@ -129,6 +129,30 @@
       (ignore-errors (delete-file tmp))
       (ignore-errors (delete-file (concat (file-name-sans-extension tmp) ".elc"))))))
 
+(ert-deftest anvil-tools-test-byte-compile-fatal-error ()
+  "A malformed file reports :ok nil and a populated :errors list."
+  (let ((tmp (make-temp-file "anvil-bc-bad-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           ";;; tmp --- x -*- lexical-binding: t; -*-
+;;; Commentary: tmp
+;;; Code:
+(defun anvil-tools-tmp-bad (
+(provide 'tmp)
+;;; tmp ends here
+")
+          (let* ((out (anvil-elisp--byte-compile-file tmp))
+                 (res (anvil-new-tools-test--read-plist out)))
+            (should-not (plist-get res :ok))
+            (should (cl-find-if
+                     (lambda (msg)
+                       (string-match-p "End of file during parsing" msg))
+                     (plist-get res :errors)))))
+      (ignore-errors (delete-file tmp))
+      (ignore-errors (delete-file (concat (file-name-sans-extension tmp) ".elc"))))))
+
 (ert-deftest anvil-tools-test-byte-compile-offload-e2e ()
   "elisp-byte-compile-file goes through the offload REPL end-to-end.
 Register the real tool via `anvil-elisp-enable', call it over the

--- a/tests/anvil-new-tools-test.el
+++ b/tests/anvil-new-tools-test.el
@@ -61,6 +61,27 @@
             (should (stringp (plist-get (car fails) :condition)))))
       (ignore-errors (delete-file tmp)))))
 
+(ert-deftest anvil-tools-test-ert-run-reload-still-runs-tests ()
+  "Reloading the same test file should still execute its tests."
+  (let* ((tmp (make-temp-file "anvil-ert-" nil ".el")))
+    (unwind-protect
+        (progn
+          (anvil-new-tools-test--write
+           tmp
+           "(require 'ert)
+(ert-deftest anvil-tools-tmp-reload-a () (should (= 1 1)))
+(ert-deftest anvil-tools-tmp-reload-b () (should (= 2 2)))
+")
+          (let* ((first-out (anvil-elisp--ert-run tmp nil))
+                 (first-res (anvil-new-tools-test--read-plist first-out))
+                 (second-out (anvil-elisp--ert-run tmp nil))
+                 (second-res (anvil-new-tools-test--read-plist second-out)))
+            (should (= 2 (plist-get first-res :passed)))
+            (should (= 0 (plist-get first-res :failed)))
+            (should (= 2 (plist-get second-res :passed)))
+            (should (= 0 (plist-get second-res :failed)))))
+      (ignore-errors (delete-file tmp)))))
+
 (ert-deftest anvil-tools-test-ert-fresh-feature-strips-test-suffix ()
   "Helper infers a feature symbol by stripping the trailing `-test'."
   (should (eq 'anvil-worker

--- a/tests/anvil-new-tools-test.el
+++ b/tests/anvil-new-tools-test.el
@@ -61,27 +61,6 @@
             (should (stringp (plist-get (car fails) :condition)))))
       (ignore-errors (delete-file tmp)))))
 
-(ert-deftest anvil-tools-test-ert-run-reload-still-runs-tests ()
-  "Reloading the same test file should still execute its tests."
-  (let* ((tmp (make-temp-file "anvil-ert-" nil ".el")))
-    (unwind-protect
-        (progn
-          (anvil-new-tools-test--write
-           tmp
-           "(require 'ert)
-(ert-deftest anvil-tools-tmp-reload-a () (should (= 1 1)))
-(ert-deftest anvil-tools-tmp-reload-b () (should (= 2 2)))
-")
-          (let* ((first-out (anvil-elisp--ert-run tmp nil))
-                 (first-res (anvil-new-tools-test--read-plist first-out))
-                 (second-out (anvil-elisp--ert-run tmp nil))
-                 (second-res (anvil-new-tools-test--read-plist second-out)))
-            (should (= 2 (plist-get first-res :passed)))
-            (should (= 0 (plist-get first-res :failed)))
-            (should (= 2 (plist-get second-res :passed)))
-            (should (= 0 (plist-get second-res :failed)))))
-      (ignore-errors (delete-file tmp)))))
-
 (ert-deftest anvil-tools-test-ert-fresh-feature-strips-test-suffix ()
   "Helper infers a feature symbol by stripping the trailing `-test'."
   (should (eq 'anvil-worker

--- a/tests/anvil-offload-test.el
+++ b/tests/anvil-offload-test.el
@@ -40,6 +40,22 @@
       (should (anvil-future-await future 30))
       (should (equal "藤澤電気" (anvil-future-value future))))))
 
+(ert-deftest anvil-offload-test-unreadable-stdout-chatter-does-not-poison-reply ()
+  "Unreadable stdout chatter is skipped until the framed reply arrives."
+  (anvil-offload-test--with-clean-repl
+    (let ((future (anvil-offload '(progn (princ ".") 42))))
+      (should (anvil-future-await future 30))
+      (should (eq 'done (anvil-future-status future)))
+      (should (= 42 (anvil-future-value future))))))
+
+(ert-deftest anvil-offload-test-line-stdout-chatter-does-not-poison-reply ()
+  "Plain stdout lines emitted before the reply do not break framing."
+  (anvil-offload-test--with-clean-repl
+    (let ((future (anvil-offload '(progn (princ "hello\n") 42))))
+      (should (anvil-future-await future 30))
+      (should (eq 'done (anvil-future-status future)))
+      (should (= 42 (anvil-future-value future))))))
+
 (ert-deftest anvil-offload-test-error-propagation ()
   "Remote errors settle the future into the `error' state."
   (anvil-offload-test--with-clean-repl
@@ -234,6 +250,25 @@ until the checkpoint arrives (non-settling), then kills the future."
         (should (eq 'c3    (plist-get cp :cursor))))
       (anvil-future-kill future))))
 
+(ert-deftest anvil-offload-test-checkpoint-survives-stdout-chatter ()
+  "Stdout chatter before a checkpoint does not poison the framed transport."
+  (anvil-offload-test--with-clean-repl
+    (let* ((form '(progn (princ ".")
+                         (anvil-preempt-checkpoint 'ok 'cursor)
+                         (sleep-for 30)))
+           (future (anvil-offload form)))
+      (let ((deadline (+ (float-time) 5)))
+        (while (and (null (anvil-future-checkpoint future))
+                    (eq 'pending (anvil-future-status future))
+                    (< (float-time) deadline))
+          (accept-process-output (anvil-future--process future) 0.05)))
+      (let ((cp (anvil-future-checkpoint future)))
+        (should cp)
+        (should (eq 'ok (plist-get cp :value)))
+        (should (eq 'cursor (plist-get cp :cursor))))
+      (anvil-future-kill future)
+      (should (eq 'killed (anvil-future-status future))))))
+
 (ert-deftest anvil-offload-test-load-path-extra ()
   "`:load-path' prepends directories so (require 'X) can find them."
   (anvil-offload-test--with-clean-repl
@@ -244,11 +279,35 @@ until the checkpoint arrives (non-settling), then kills the future."
       (unwind-protect
           (progn
             (with-temp-file stub-file
-              (insert (format ";;; %s.el\n" stub-feat))
+              (insert (format ";;; %s.el -*- lexical-binding: t; -*-\n"
+                              stub-feat))
               (insert (format "(defun %s-mul (x y) (* x y))\n" stub-feat))
               (insert (format "(provide '%s)\n" stub-feat)))
             (let ((future (anvil-offload
                            `(,(intern (format "%s-mul" stub-feat)) 6 7)
+                           :require stub-feat
+                           :load-path (list tmp))))
+              (should (anvil-future-await future 30))
+              (should (= 42 (anvil-future-value future)))))
+        (delete-directory tmp t)))))
+
+(ert-deftest anvil-offload-test-require-load-chatter-does-not-poison-reply ()
+  "Top-level stdout chatter during `require' does not break the protocol."
+  (anvil-offload-test--with-clean-repl
+    (let* ((tmp (make-temp-file "anvil-offload-noisy-" t))
+           (stub-feat (intern (format "anvil-offload-noisy-%s"
+                                      (format-time-string "%s%N"))))
+           (stub-file (expand-file-name (format "%s.el" stub-feat) tmp)))
+      (unwind-protect
+          (progn
+            (with-temp-file stub-file
+              (insert (format ";;; %s.el -*- lexical-binding: t; -*-\n"
+                              stub-feat))
+              (insert "(princ \".\")\n")
+              (insert (format "(defun %s-value () 42)\n" stub-feat))
+              (insert (format "(provide '%s)\n" stub-feat)))
+            (let ((future (anvil-offload
+                           `(,(intern (format "%s-value" stub-feat)))
                            :require stub-feat
                            :load-path (list tmp))))
               (should (anvil-future-await future 30))

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -1,0 +1,32 @@
+;;; anvil-org-test.el --- Tests for anvil-org -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Focused contract tests for org-mode MCP tool wrappers.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil-org)
+
+(ert-deftest anvil-org-test-tool-read-by-id-rejects-org-id-resource-uri ()
+  "The Layer-3 tool accepts org:// citations, not org-id:// resources."
+  (let ((err
+         (should-error
+          (anvil-org--tool-read-by-id
+           "org-id://550e8400-e29b-41d4-a716-446655440000")
+          :type 'anvil-server-tool-error)))
+    (should
+     (string-match-p
+      "Parameter uuid does not accept org-id:// resource URIs"
+      (cadr err)))
+    (should
+     (string-match-p
+      "Use the raw UUID"
+      (cadr err)))
+    (should
+     (string-match-p
+      "org://550e8400-e29b-41d4-a716-446655440000"
+      (cadr err)))))
+
+;;; anvil-org-test.el ends here

--- a/tests/anvil-py-test.el
+++ b/tests/anvil-py-test.el
@@ -618,6 +618,60 @@ not a create (use `py-add-import' for that)."
       (should-error (anvil-py-rename-import f '(:kind from :from "openpyxl"))
                     :type 'user-error))))
 
+;;;; --- MCP wrappers -------------------------------------------------------
+
+(ert-deftest anvil-py-test-tool-add-import-accepts-quoted-kind-string ()
+  "The MCP wrapper should accept the legacy quoted Lisp kind syntax."
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (anvil-py--tool-add-import
+       f "(:kind 'import :module \"subprocess\")" "t")
+      (let ((text (with-temp-buffer
+                    (insert-file-contents f) (buffer-string))))
+        (should (string-match-p "^import subprocess$" text))))))
+
+(ert-deftest anvil-py-test-tool-add-import-accepts-json-spec ()
+  "The MCP wrapper should accept JSON specs and coerce names arrays."
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (anvil-py--tool-add-import
+       f "{\"kind\":\"from\",\"from\":\"json\",\"names\":[\"loads\",\"dumps\"]}"
+       "t")
+      (let ((text (with-temp-buffer
+                    (insert-file-contents f) (buffer-string))))
+        (should (string-match-p "^from json import loads, dumps$" text))
+        (should (string-match-p "from typing import" text))))))
+
+(ert-deftest anvil-py-test-tool-add-import-invalid-kind-errors ()
+  "Invalid kinds should fail loudly instead of silently returning nil."
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (let ((err (should-error
+                  (anvil-py--tool-add-import
+                   f "(:kind bogus :module \"json\")" nil)
+                  :type 'anvil-server-tool-error)))
+        (should (string-match-p "unsupported :kind"
+                                (error-message-string err)))))))
+
+(ert-deftest anvil-py-test-tool-remove-import-accepts-quoted-kind-string ()
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (anvil-py--tool-remove-import
+       f "(:kind 'import :module \"os\")" "t")
+      (let ((text (with-temp-buffer
+                    (insert-file-contents f) (buffer-string))))
+        (should-not (string-match-p "^import os$" text))))))
+
+(ert-deftest anvil-py-test-tool-rename-import-accepts-quoted-kind-string ()
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (anvil-py--tool-rename-import
+       f "(:kind 'import :module \"sys\" :new-alias \"sy\")" "t")
+      (let ((text (with-temp-buffer
+                    (insert-file-contents f) (buffer-string))))
+        (should (string-match-p "^import sys as sy$" text))
+        (should-not (string-match-p "^import sys as system$" text))))))
+
 ;;;; --- wrap-expr (Phase 2c) -----------------------------------------------
 
 (ert-deftest anvil-py-test-wrap-expr-wraps-integer-literal ()

--- a/tests/anvil-sexp-test.el
+++ b/tests/anvil-sexp-test.el
@@ -315,6 +315,31 @@
       (let ((elc (concat tmp "c")))
         (when (file-exists-p elc) (delete-file elc))))))
 
+(ert-deftest anvil-sexp-test-verify-captures-byte-compile-errors ()
+  "A malformed file surfaces a byte-compile error diagnostic."
+  (let ((tmp (make-temp-file "anvil-sexp-bad-" nil ".el")))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (insert ";;; bad.el --- bad -*- lexical-binding: t; -*-\n"
+                    ";;; Commentary:\n;; bad.\n;;; Code:\n"
+                    "(defun anvil-sexp-test-broken (\n"
+                    "(provide 'bad)\n"
+                    ";;; bad.el ends here\n"))
+          (let ((r (anvil-sexp--tool-verify tmp nil "nil")))
+            (should-not (plist-get r :passed))
+            (should (cl-find-if
+                     (lambda (d)
+                       (and (eq (plist-get d :kind) 'error)
+                            (eq (plist-get d :source) 'byte-compile)
+                            (string-match-p
+                             "End of file during parsing"
+                             (plist-get d :message))))
+                     (plist-get r :diagnostics)))))
+      (when (file-exists-p tmp) (delete-file tmp))
+      (let ((elc (concat tmp "c")))
+        (when (file-exists-p elc) (delete-file elc))))))
+
 
 ;;;; --- ship criterion: stub + verify + restore round-trip ----------------
 

--- a/tests/anvil-test.el
+++ b/tests/anvil-test.el
@@ -158,6 +158,64 @@ MCP Parameters:
             (should (equal "ok-empty" text)))))
     (anvil-server-unregister-tool "anvil-test-underscore" "anvil-test")))
 
+(ert-deftest anvil-test-dispatch-converts-quit-to-tool-error ()
+  "A wrapped tool must turn `quit' into an MCP tool error result."
+  (defun anvil-test--tool-quit (_args)
+    "Signal quit through the helper wrapper.
+
+MCP Parameters:
+  (none)"
+    (anvil-server-with-error-handling
+      (signal 'quit '(minibuffer-quit))))
+  (unwind-protect
+      (progn
+        (anvil-server-register-tool
+         #'anvil-test--tool-quit
+         :id "anvil-test-tool-quit"
+         :description "test"
+         :server-id "anvil-test")
+          (let* ((params '((name . "anvil-test-tool-quit")
+                         (arguments . ())))
+               (resp (anvil-server--handle-tools-call
+                      "t-quit" params
+                      (make-anvil-server-metrics) "anvil-test"))
+               (decoded (json-read-from-string resp))
+               (result (alist-get 'result decoded))
+               (text (alist-get 'text
+                                (aref (alist-get 'content result) 0))))
+          (should (eq t (alist-get 'isError result)))
+          (should (string-match-p "Quit: .*minibuffer-quit" text))))
+    (anvil-server-unregister-tool "anvil-test-tool-quit" "anvil-test")))
+
+(ert-deftest anvil-test-process-jsonrpc-catches-raw-quit ()
+  "Top-level JSON-RPC dispatch must serialize uncaught `quit' as JSON."
+  (defun anvil-test--raw-quit (_args)
+    "Signal quit without wrapping.
+
+MCP Parameters:
+  (none)"
+    (signal 'quit '(minibuffer-quit)))
+  (unwind-protect
+      (progn
+        (anvil-server-register-tool
+         #'anvil-test--raw-quit
+         :id "anvil-test-raw-quit"
+         :description "test"
+         :server-id "anvil-test")
+        (let* ((anvil-server--running t)
+               (request
+                (anvil-server-create-tools-call-request
+                 "anvil-test-raw-quit" 77 nil))
+               (resp (anvil-server-process-jsonrpc request "anvil-test"))
+               (decoded (json-read-from-string resp))
+               (rpc-error (alist-get 'error decoded)))
+          (should rpc-error)
+          (should (= anvil-server-jsonrpc-error-internal
+                     (alist-get 'code rpc-error)))
+          (should (string-match-p "Quit"
+                                  (alist-get 'message rpc-error)))))
+    (anvil-server-unregister-tool "anvil-test-raw-quit" "anvil-test")))
+
 (ert-deftest anvil-test-schema-includes-real-params ()
   "JSON schema must still include non-underscore args."
   (defun anvil-test--tool-with-arg (task_id)


### PR DESCRIPTION
## Summary

This PR includes three related fixes:

- fix Python MCP import tools so `spec` values are normalized correctly
- fix `project_info` so it resolves the active project more reliably
- drop the internal `Package-Requires` header in `anvil-discovery.el`

## Notes

The `anvil-discovery.el` header cleanup is included intentionally for VC byte-compilation / dependency handling, otherwise it can conflict.