### PR TITLE
feat(web): add anvil-web.el (tweet + reddit normalised fetches)

### DIFF
--- a/anvil-web.el
+++ b/anvil-web.el
@@ -1,0 +1,333 @@
+;;; anvil-web.el --- Web API wrappers (X/Twitter, Reddit) -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Anvil contributors
+
+;; Author: Anvil contributors
+;; Keywords: http, twitter, reddit, tools
+;; Package-Requires: ((emacs "28.1") (anvil-http "0.1") (anvil-server "0.1"))
+;; Version: 0.1.0
+
+;;; Commentary:
+
+;; Small, focused wrappers around a handful of public web endpoints that
+;; `anvil-http' alone does not normalise.  The goal is not "a generic web
+;; client" - it is to remove a class of recurring tool-use patterns that
+;; otherwise show up as curl + jq + parsing loops in agent transcripts.
+;;
+;; Currently provided:
+;;
+;;   * `anvil-web-tweet-fetch' - fetch a single tweet by numeric ID via the
+;;     public Twitter syndication endpoint (no auth, no token), and return a
+;;     normalised plist.  Works for tweets that X WebFetch can't reach.
+;;
+;;   * `anvil-web-reddit-thread' - fetch a Reddit thread (title + OP body +
+;;     top-N comments) from either a canonical `/comments/<id>/...' URL or a
+;;     short `/r/<sub>/s/<hash>' share URL, which requires a redirect-resolve
+;;     step before appending `.json'.
+;;
+;; Both tools go through `anvil-http-get' so caching, retry/backoff and the
+;; scheme allow-list come for free.  A browser-ish User-Agent is attached by
+;; default since Reddit and a few others return 403 to bare
+;; `Mozilla-only' / libcurl-style UAs.
+
+;;; Code:
+
+(require 'anvil-http)
+(require 'anvil-server)
+(require 'cl-lib)
+(require 'json)
+
+(defgroup anvil-web nil
+  "Normalised wrappers around a few public web endpoints."
+  :group 'anvil
+  :prefix "anvil-web-")
+
+(defcustom anvil-web-default-user-agent
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+  "Default User-Agent for `anvil-web' requests.
+Reddit and various CDN-fronted endpoints respond 403 to libcurl or
+empty UAs, so we present as a generic desktop browser by default.
+Callers can override with the :user-agent argument."
+  :type 'string
+  :group 'anvil-web)
+
+(defcustom anvil-web-default-timeout-sec 15
+  "Default per-request timeout (seconds) for `anvil-web' tools."
+  :type 'integer
+  :group 'anvil-web)
+
+(defcustom anvil-web-reddit-default-top-n 10
+  "Default number of top-level comments returned by `anvil-web-reddit-thread'."
+  :type 'integer
+  :group 'anvil-web)
+
+(defconst anvil-web--server-id "emacs-eval"
+  "MCP server id under which `anvil-web' tools register.
+Matches the id used by `anvil-http', `anvil-file', etc. so that all
+anvil MCP tools end up on the same transport.")
+
+;;;; --- internal HTTP + JSON helpers --------------------------------------
+
+(defun anvil-web--merge-ua (headers user-agent)
+  "Return HEADERS alist with a User-Agent entry guaranteed.
+USER-AGENT (nil → default) wins over any UA already in HEADERS."
+  (let* ((ua (or user-agent anvil-web-default-user-agent))
+         (stripped (cl-remove-if
+                    (lambda (h)
+                      (and (consp h) (stringp (car h))
+                           (string-equal-ignore-case (car h) "User-Agent")))
+                    headers)))
+    (cons (cons "User-Agent" ua) stripped)))
+
+(cl-defun anvil-web--http-json (url &key headers user-agent
+                                    (timeout-sec anvil-web-default-timeout-sec)
+                                    (no-cache t)
+                                    accept)
+  "GET URL through `anvil-http-get' and return its body parsed as JSON.
+Signals a user-error for non-2xx status or invalid JSON payloads.
+Returns whatever `json-parse-string' produces (plists + vectors)."
+  (let* ((merged (anvil-web--merge-ua headers user-agent))
+         (resp (anvil-http-get url
+                               :headers merged
+                               :accept (or accept "application/json")
+                               :timeout-sec timeout-sec
+                               :no-cache no-cache))
+         (status (plist-get resp :status))
+         (body (plist-get resp :body)))
+    (unless (and (integerp status) (>= status 200) (< status 300))
+      (user-error "anvil-web: HTTP %s for %s" status url))
+    (unless (and (stringp body) (not (string-empty-p body)))
+      (user-error "anvil-web: empty body from %s" url))
+    (condition-case err
+        (json-parse-string body
+                           :object-type 'plist
+                           :null-object nil
+                           :false-object nil)
+      (error
+       (user-error "anvil-web: JSON parse failed for %s: %s"
+                   url (error-message-string err))))))
+
+(defun anvil-web--resolve-redirect (url &optional user-agent)
+  "GET URL via `anvil-http-get' and return `:final-url' after redirects.
+Used for Reddit `/s/<hash>' share links that only resolve via redirect.
+Returns URL unchanged if the server didn't redirect."
+  (let* ((resp (anvil-http-get url
+                               :headers (anvil-web--merge-ua nil user-agent)
+                               :accept "text/html"
+                               :timeout-sec anvil-web-default-timeout-sec
+                               :no-cache t))
+         (final (plist-get resp :final-url)))
+    (or (and (stringp final) (not (string-empty-p final)) final)
+        url)))
+
+;;;; --- tweet -------------------------------------------------------------
+
+(defconst anvil-web--tweet-syndication-url
+  "https://cdn.syndication.twimg.com/tweet-result?id=%s&token=x"
+  "Public syndication endpoint for tweet-by-id retrieval.
+Requires no OAuth; the `token' query parameter is a deliberate
+placeholder the endpoint accepts.  Returns a single-tweet JSON
+document (no thread traversal).")
+
+(defun anvil-web--tweet-normalise (json tweet-id)
+  "Flatten the syndication response JSON into a stable plist.
+Fields that the caller is likely to want are exposed at the top level;
+the raw response is returned under `:raw' for anything else."
+  (let* ((user (plist-get json :user))
+         (quoted (plist-get json :quoted_tweet))
+         (quoted-user (and quoted (plist-get quoted :user)))
+         (article (plist-get json :article))
+         (entities (plist-get json :entities))
+         (url-entries (and entities (plist-get entities :urls)))
+         (screen (and user (plist-get user :screen_name))))
+    (list
+     :id tweet-id
+     :url (format "https://x.com/%s/status/%s" (or screen "i") tweet-id)
+     :text (plist-get json :text)
+     :lang (plist-get json :lang)
+     :created-at (plist-get json :created_at)
+     :favorite-count (plist-get json :favorite_count)
+     :conversation-count (plist-get json :conversation_count)
+     :possibly-sensitive (plist-get json :possibly_sensitive)
+     :user-name (and user (plist-get user :name))
+     :screen-name screen
+     :is-blue-verified (and user (plist-get user :is_blue_verified))
+     :quoted-screen-name (and quoted-user (plist-get quoted-user :screen_name))
+     :quoted-text (and quoted (plist-get quoted :text))
+     :article-id (and article (plist-get article :rest_id))
+     :article-title (and article (plist-get article :title))
+     :article-preview-text (and article (plist-get article :preview_text))
+     :expanded-urls
+     (cl-loop for u across (or url-entries [])
+              for expanded = (plist-get u :expanded_url)
+              when expanded collect expanded)
+     :raw json)))
+
+(defun anvil-web-tweet-fetch (tweet_id)
+  "Fetch a tweet by TWEET_ID and return a normalised plist.
+Uses the public syndication API: no authentication, no rate-limit
+headers, no thread traversal.  The response is a single tweet - for
+thread continuations, call the tool once per reply id.
+
+MCP Parameters:
+  tweet_id - Numeric Twitter/X status id as a string of digits,
+             e.g. \"2046898117241635240\".
+
+Returns a plist with at least:
+  :id :url :text :lang :created-at :user-name :screen-name
+  :favorite-count :quoted-text :quoted-screen-name :article-title
+  :article-preview-text :expanded-urls :raw
+
+The tool bypasses the `anvil-http' cache (syndication is cheap and
+near-realtime accuracy is preferred for social-media content)."
+  (anvil-server-with-error-handling
+   (let ((id (cond ((and (stringp tweet_id)
+                         (string-match-p "\\`[0-9]+\\'" tweet_id))
+                    tweet_id)
+                   ((integerp tweet_id) (number-to-string tweet_id))
+                   (t (user-error
+                       "anvil-web-tweet-fetch: tweet_id must be digit string, got %S"
+                       tweet_id)))))
+     (let* ((url (format anvil-web--tweet-syndication-url id))
+            (json (anvil-web--http-json url)))
+       (anvil-web--tweet-normalise json id)))))
+
+;;;; --- reddit ------------------------------------------------------------
+
+(defun anvil-web--reddit-canonicalize (url)
+  "Return a canonical `/r/<sub>/comments/<id>/slug/' URL for URL.
+Resolves the `/r/<sub>/s/<hash>' share-link form via one redirect
+fetch.  If URL is already canonical (or any other reddit URL with a
+`/comments/' segment), it is returned stripped of query parameters."
+  (unless (stringp url)
+    (user-error "anvil-web-reddit: url must be a string, got %S" url))
+  (let* ((base url))
+    (when (string-match "\\b\\(reddit\\.com\\)/r/[^/]+/s/" url)
+      (setq base (anvil-web--resolve-redirect url)))
+    (let* ((no-query (replace-regexp-in-string "[?#].*\\'" "" base)))
+      (unless (string-match-p "/comments/[^/]+/" no-query)
+        (user-error
+         "anvil-web-reddit: could not resolve canonical comments URL from %s"
+         url))
+      no-query)))
+
+(defun anvil-web--reddit-normalise-comments (com-children top-n)
+  "Turn Reddit's `t1' children vector into a list of plists, capped at TOP-N.
+Comments with nil :body (deleted / mod-removed / MoreComments sentinels)
+are skipped.  Scores appear as reported by the API (may be fuzzed)."
+  (let (out)
+    (cl-loop for c across (or com-children [])
+             for d = (plist-get c :data)
+             for body = (and d (plist-get d :body))
+             when (and (stringp body) (not (string-empty-p body)))
+             do (push (list :author (plist-get d :author)
+                            :score (plist-get d :score)
+                            :body body
+                            :created-utc (plist-get d :created_utc))
+                      out))
+    (setq out (nreverse out))
+    (if (and (integerp top-n) (>= top-n 0))
+        (seq-take out top-n)
+      out)))
+
+(defun anvil-web-reddit-thread (url &optional top_n)
+  "Fetch a Reddit thread (OP + top comments) and return a normalised plist.
+URL may be either a canonical `/r/<sub>/comments/<id>/...' permalink
+or a `/r/<sub>/s/<hash>' share-link (the latter is resolved via one
+extra redirect fetch).
+
+MCP Parameters:
+  url   - Reddit thread URL (canonical or `/s/<hash>' share link).
+  top_n - Optional maximum number of top-level comments to include.
+          Integer or digit-string; default `anvil-web-reddit-default-top-n'.
+
+Returns a plist:
+  :title :author :subreddit :selftext :url :permalink :score
+  :created-utc :num-comments :comments
+
+where :comments is a list of (:author :score :body :created-utc)
+plists for up to top_n entries."
+  (anvil-server-with-error-handling
+   (let* ((n (cond ((null top_n) anvil-web-reddit-default-top-n)
+                   ((integerp top_n) top_n)
+                   ((and (stringp top_n)
+                         (string-match-p "\\`[0-9]+\\'" top_n))
+                    (string-to-number top_n))
+                   (t anvil-web-reddit-default-top-n)))
+          (canonical (anvil-web--reddit-canonicalize url))
+          (json-url (concat (string-trim-right canonical "/") ".json"))
+          (arr (anvil-web--http-json json-url)))
+     (unless (and (vectorp arr) (>= (length arr) 2))
+       (user-error "anvil-web-reddit: unexpected response shape for %s"
+                   json-url))
+     (let* ((post-listing (aref arr 0))
+            (com-listing (aref arr 1))
+            (post-children (plist-get (plist-get post-listing :data) :children))
+            (com-children (plist-get (plist-get com-listing :data) :children)))
+       (unless (and (vectorp post-children) (> (length post-children) 0))
+         (user-error "anvil-web-reddit: no post found in %s" json-url))
+       (let ((post-data (plist-get (aref post-children 0) :data)))
+         (list
+          :title (plist-get post-data :title)
+          :author (plist-get post-data :author)
+          :subreddit (plist-get post-data :subreddit)
+          :selftext (plist-get post-data :selftext)
+          :url (plist-get post-data :url)
+          :permalink (plist-get post-data :permalink)
+          :score (plist-get post-data :score)
+          :created-utc (plist-get post-data :created_utc)
+          :num-comments (plist-get post-data :num_comments)
+          :comments (anvil-web--reddit-normalise-comments com-children n)))))))
+
+;;;; --- module lifecycle --------------------------------------------------
+
+(defun anvil-web--register-tools ()
+  "Register web-* MCP tools under `anvil-web--server-id'."
+  (anvil-server-register-tool
+   #'anvil-web-tweet-fetch
+   :id "web-tweet-fetch"
+   :intent '(web http twitter)
+   :layer 'io
+   :server-id anvil-web--server-id
+   :description
+   "Fetch a single tweet by numeric ID through the public X/Twitter
+syndication endpoint.  No auth required, no thread traversal (single
+tweet only).  Returns a normalised plist with body text, author,
+created-at, quoted-tweet text and X-native article preview fields when
+the tweet wraps an x.com/i/article/<id>.  Bypasses the HTTP cache."
+   :read-only t)
+
+  (anvil-server-register-tool
+   #'anvil-web-reddit-thread
+   :id "web-reddit-thread"
+   :intent '(web http reddit)
+   :layer 'io
+   :server-id anvil-web--server-id
+   :description
+   "Fetch a Reddit thread (title + OP selftext + top-N comments) from
+either a canonical `/r/<sub>/comments/<id>/slug/' URL or a
+`/r/<sub>/s/<hash>' share link (redirects are resolved automatically).
+Top-level comments only; `MoreComments' sentinels and removed bodies
+are skipped.  Bypasses the HTTP cache."
+   :read-only t))
+
+(defun anvil-web--unregister-tools ()
+  "Remove every web-* MCP tool from the shared server."
+  (dolist (id '("web-tweet-fetch" "web-reddit-thread"))
+    (anvil-server-unregister-tool id anvil-web--server-id)))
+
+;;;###autoload
+(defun anvil-web-enable ()
+  "Register the `anvil-web' MCP tools."
+  (interactive)
+  (anvil-web--register-tools))
+
+;;;###autoload
+(defun anvil-web-disable ()
+  "Unregister the `anvil-web' MCP tools."
+  (interactive)
+  (anvil-web--unregister-tools))
+
+(provide 'anvil-web)
+
+;;; anvil-web.el ends here

--- a/tests/anvil-web-test.el
+++ b/tests/anvil-web-test.el
@@ -1,0 +1,408 @@
+;;; anvil-web-test.el --- Tests for anvil-web -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Unit tests for `anvil-web'.  The transport layer (`anvil-http--request')
+;; is stubbed with a response queue; no live network traffic happens unless
+;; the optional smoke test at the bottom is enabled with ANVIL_ALLOW_LIVE=1.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+(require 'anvil-http)
+(require 'anvil-state)
+(require 'anvil-web)
+
+;;;; --- fixtures -----------------------------------------------------------
+
+(defvar anvil-web-test--calls nil
+  "List of `(:method :url :headers :timeout)' recorded by the stub.")
+
+(defvar anvil-web-test--responses nil
+  "Queue of fake response plists to hand back.")
+
+(defun anvil-web-test--pop-response ()
+  (or (pop anvil-web-test--responses)
+      (error "anvil-web-test: response queue exhausted")))
+
+(defun anvil-web-test--response (status &optional headers body final-url)
+  (list :status status
+        :headers headers
+        :body (or body "")
+        :final-url (or final-url "https://example.com/")))
+
+(defmacro anvil-web-test--with-stub (responses &rest body)
+  "Run BODY with `anvil-http--request' returning successive RESPONSES."
+  (declare (indent 1))
+  `(let ((anvil-web-test--calls nil)
+         (anvil-web-test--responses (copy-sequence ,responses))
+         (anvil-state-db-path (make-temp-file "anvil-web-st-" nil ".db"))
+         (anvil-state--db nil)
+         (anvil-http--metrics
+          (list :requests 0 :cache-fresh 0 :cache-revalidated 0
+                :network-200 0 :errors 0 :log nil)))
+     (unwind-protect
+         (progn
+           (anvil-state-enable)
+           (cl-letf (((symbol-function 'anvil-http--request)
+                      (lambda (method url headers timeout)
+                        (push (list :method method :url url
+                                    :headers headers :timeout timeout)
+                              anvil-web-test--calls)
+                        (anvil-web-test--pop-response)))
+                     ((symbol-function 'sleep-for)
+                      (lambda (&rest _) nil)))
+             ,@body))
+       (anvil-state-disable)
+       (ignore-errors (delete-file anvil-state-db-path)))))
+
+(defun anvil-web-test--json (obj)
+  "Serialize OBJ (plist or vector) to JSON text.
+`t' → true, `:false' → false, `:null' → null."
+  (json-serialize obj :null-object :null :false-object :false))
+
+(defun anvil-web-test--tb (b)
+  "Map a test bool B (t or nil) to a JSON-serializable token."
+  (if b t :false))
+
+(defun anvil-web-test--tweet-fixture (&optional overrides)
+  "Return a minimal syndication tweet response JSON object (plist).
+OVERRIDES, if non-nil, is merged onto the defaults."
+  (let ((base
+         (list :__typename "Tweet"
+               :id_str "2046898117241635240"
+               :text "hello world"
+               :lang "en"
+               :created_at "2026-04-22T10:25:15.000Z"
+               :favorite_count 42
+               :conversation_count 3
+               :possibly_sensitive :false
+               :user (list :name "Hasan Toor"
+                           :screen_name "hasantoxr"
+                           :is_blue_verified t)
+               :entities (list :urls
+                               (vector
+                                (list :expanded_url
+                                      "https://example.com/article"
+                                      :display_url "example.com/article"))))))
+    (if overrides
+        (let ((merged (copy-sequence base)))
+          (cl-loop for (k v) on overrides by #'cddr
+                   do (setq merged (plist-put merged k v)))
+          merged)
+      base)))
+
+(defun anvil-web-test--reddit-post-fixture ()
+  (list :kind "t3"
+        :data (list :title "Emacs is My Web Browser"
+                    :author "joshuablais"
+                    :subreddit "emacs"
+                    :selftext "Seed body."
+                    :url "https://joshblais.com/blog/emacs-as-my-browser/"
+                    :permalink "/r/emacs/comments/1sry0vi/emacs_is_my_web_browser/"
+                    :score 77
+                    :num_comments 10
+                    :created_utc 1776799646.0)))
+
+(defun anvil-web-test--reddit-comment (author score body)
+  (list :kind "t1"
+        :data (list :author author
+                    :score score
+                    :body body
+                    :created_utc 1776800000.0)))
+
+(defun anvil-web-test--reddit-fixture (&optional comments)
+  "Return an ARRAY (vector) of two Listings (post + comments).
+COMMENTS is a list of plists from `anvil-web-test--reddit-comment';
+if nil a small default list is used."
+  (let ((com-list
+         (or comments
+             (list (anvil-web-test--reddit-comment "alice" 15 "first!")
+                   (anvil-web-test--reddit-comment "bob" 8 "second.")
+                   ;; MoreComments-like sentinel with nil body
+                   (list :kind "more" :data (list :author nil :score nil
+                                                  :body nil))))))
+    (vector
+     (list :kind "Listing"
+           :data (list :children
+                       (vector (anvil-web-test--reddit-post-fixture))))
+     (list :kind "Listing"
+           :data (list :children (apply #'vector com-list))))))
+
+;;;; --- merge-ua ----------------------------------------------------------
+
+(ert-deftest anvil-web-test-merge-ua-adds-default ()
+  (let ((merged (anvil-web--merge-ua nil nil)))
+    (should (equal (cdr (assoc "User-Agent" merged))
+                   anvil-web-default-user-agent))))
+
+(ert-deftest anvil-web-test-merge-ua-overrides-caller ()
+  "An explicit USER-AGENT wins over any UA already in HEADERS."
+  (let* ((headers '(("User-Agent" . "libcurl/7.88")
+                    ("X-Test" . "1")))
+         (merged (anvil-web--merge-ua headers "custom-ua/1.0")))
+    (should (equal "custom-ua/1.0" (cdr (assoc "User-Agent" merged))))
+    (should (equal "1" (cdr (assoc "X-Test" merged))))
+    ;; The libcurl UA must have been removed (case-insensitive).
+    (should (= 1 (cl-count-if
+                  (lambda (h)
+                    (and (stringp (car h))
+                         (string-equal-ignore-case (car h) "User-Agent")))
+                  merged)))))
+
+(ert-deftest anvil-web-test-merge-ua-strips-case-insensitive ()
+  "UA with lowercased key is stripped before adding the default."
+  (let* ((headers '(("user-agent" . "bad/1"))) ; lowercase key
+         (merged (anvil-web--merge-ua headers nil)))
+    (should (equal anvil-web-default-user-agent
+                   (cdr (assoc "User-Agent" merged))))
+    (should (= 1 (length merged)))))
+
+;;;; --- http-json --------------------------------------------------------
+
+(ert-deftest anvil-web-test-http-json-200 ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (list :ok t :n 1))
+             "https://api.example.com/"))
+    (let ((obj (anvil-web--http-json "https://api.example.com/")))
+      (should (eq t (plist-get obj :ok)))
+      (should (= 1 (plist-get obj :n))))))
+
+(ert-deftest anvil-web-test-http-json-non2xx-errors ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response 404 nil "not found"
+                                      "https://api.example.com/"))
+    (should-error (anvil-web--http-json "https://api.example.com/")
+                  :type 'user-error)))
+
+(ert-deftest anvil-web-test-http-json-empty-body-errors ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response 200 nil ""
+                                      "https://api.example.com/"))
+    (should-error (anvil-web--http-json "https://api.example.com/")
+                  :type 'user-error)))
+
+(ert-deftest anvil-web-test-http-json-invalid-json-errors ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response 200 nil "not-json-at-all"
+                                      "https://api.example.com/"))
+    (should-error (anvil-web--http-json "https://api.example.com/")
+                  :type 'user-error)))
+
+(ert-deftest anvil-web-test-http-json-sends-ua ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response 200 nil
+                                      (anvil-web-test--json (list :ok t))
+                                      "https://api.example.com/"))
+    (anvil-web--http-json "https://api.example.com/")
+    (let* ((call (car anvil-web-test--calls))
+           (headers (plist-get call :headers)))
+      (should (assoc "User-Agent" headers))
+      (should (equal anvil-web-default-user-agent
+                     (cdr (assoc "User-Agent" headers)))))))
+
+;;;; --- tweet-fetch ------------------------------------------------------
+
+(ert-deftest anvil-web-test-tweet-fetch-happy-path ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (anvil-web-test--tweet-fixture))
+             "https://cdn.syndication.twimg.com/"))
+    (let ((out (anvil-web-tweet-fetch "2046898117241635240")))
+      (should (equal "2046898117241635240" (plist-get out :id)))
+      (should (equal "hello world" (plist-get out :text)))
+      (should (equal "hasantoxr" (plist-get out :screen-name)))
+      (should (equal "Hasan Toor" (plist-get out :user-name)))
+      (should (equal "en" (plist-get out :lang)))
+      (should (equal 42 (plist-get out :favorite-count)))
+      (should (equal "https://x.com/hasantoxr/status/2046898117241635240"
+                     (plist-get out :url)))
+      (should (equal '("https://example.com/article")
+                     (plist-get out :expanded-urls)))
+      (should-not (plist-get out :quoted-text))
+      (should-not (plist-get out :article-title)))))
+
+(ert-deftest anvil-web-test-tweet-fetch-accepts-integer-id ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (anvil-web-test--tweet-fixture))
+             "https://cdn.syndication.twimg.com/"))
+    (let ((out (anvil-web-tweet-fetch 2046898117241635240)))
+      (should (equal "2046898117241635240" (plist-get out :id))))))
+
+(ert-deftest anvil-web-test-tweet-fetch-rejects-bad-id ()
+  (should-error (anvil-web-tweet-fetch "not-a-number") :type 'user-error)
+  (should-error (anvil-web-tweet-fetch "") :type 'user-error)
+  (should-error (anvil-web-tweet-fetch nil) :type 'user-error))
+
+(ert-deftest anvil-web-test-tweet-fetch-quoted-and-article ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json
+              (anvil-web-test--tweet-fixture
+               (list :quoted_tweet
+                     (list :text "original thought"
+                           :user (list :screen_name "orig_user"))
+                     :article
+                     (list :rest_id "99999"
+                           :title "Top 30 MCP"
+                           :preview_text "preview body here"))))
+             "https://cdn.syndication.twimg.com/"))
+    (let ((out (anvil-web-tweet-fetch "2046898117241635240")))
+      (should (equal "original thought" (plist-get out :quoted-text)))
+      (should (equal "orig_user" (plist-get out :quoted-screen-name)))
+      (should (equal "99999" (plist-get out :article-id)))
+      (should (equal "Top 30 MCP" (plist-get out :article-title)))
+      (should (equal "preview body here"
+                     (plist-get out :article-preview-text))))))
+
+(ert-deftest anvil-web-test-tweet-fetch-hits-syndication-url ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (anvil-web-test--tweet-fixture))
+             "https://cdn.syndication.twimg.com/"))
+    (anvil-web-tweet-fetch "12345")
+    (let* ((call (car anvil-web-test--calls))
+           (url (plist-get call :url)))
+      (should (string-match-p
+               "\\`https://cdn\\.syndication\\.twimg\\.com/tweet-result\\?id=12345"
+               url)))))
+
+;;;; --- reddit thread ----------------------------------------------------
+
+(ert-deftest anvil-web-test-reddit-thread-canonical ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (anvil-web-test--reddit-fixture))
+             "https://www.reddit.com/"))
+    (let ((out (anvil-web-reddit-thread
+                "https://www.reddit.com/r/emacs/comments/1sry0vi/emacs_is_my_web_browser/")))
+      (should (equal "Emacs is My Web Browser" (plist-get out :title)))
+      (should (equal "joshuablais" (plist-get out :author)))
+      (should (equal "emacs" (plist-get out :subreddit)))
+      (should (equal "https://joshblais.com/blog/emacs-as-my-browser/"
+                     (plist-get out :url)))
+      ;; default top-n = 10, deleted comment skipped
+      (let ((comments (plist-get out :comments)))
+        (should (= 2 (length comments)))
+        (should (equal "alice" (plist-get (nth 0 comments) :author)))
+        (should (equal "first!" (plist-get (nth 0 comments) :body)))))))
+
+(ert-deftest anvil-web-test-reddit-thread-shortlink-resolves-redirect ()
+  (anvil-web-test--with-stub
+      (list
+       ;; First call: redirect resolve (HEAD-ish GET)
+       (anvil-web-test--response
+        200 nil "<html>ignored</html>"
+        "https://www.reddit.com/r/emacs/comments/1sry0vi/emacs_is_my_web_browser/?share_id=abc")
+       ;; Second call: the .json fetch
+       (anvil-web-test--response
+        200 nil
+        (anvil-web-test--json (anvil-web-test--reddit-fixture))
+        "https://www.reddit.com/"))
+    (let ((out (anvil-web-reddit-thread
+                "https://www.reddit.com/r/emacs/s/lVNi77sfno")))
+      (should (equal "Emacs is My Web Browser" (plist-get out :title))))
+    ;; Verify the JSON call URL ends with `.json' and has no query string.
+    (let* ((json-call (car anvil-web-test--calls))
+           (url (plist-get json-call :url)))
+      (should (string-suffix-p ".json" url))
+      (should-not (string-match-p "\\?" url)))))
+
+(ert-deftest anvil-web-test-reddit-thread-top-n-limits ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json
+              (anvil-web-test--reddit-fixture
+               (list (anvil-web-test--reddit-comment "a" 5 "one")
+                     (anvil-web-test--reddit-comment "b" 4 "two")
+                     (anvil-web-test--reddit-comment "c" 3 "three"))))
+             "https://www.reddit.com/"))
+    (let ((out (anvil-web-reddit-thread
+                "https://www.reddit.com/r/emacs/comments/abc/x/"
+                2)))
+      (should (= 2 (length (plist-get out :comments)))))))
+
+(ert-deftest anvil-web-test-reddit-thread-top-n-string ()
+  "top_n accepts digit-strings (MCP transport coerces int→str)."
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json
+              (anvil-web-test--reddit-fixture
+               (list (anvil-web-test--reddit-comment "a" 5 "one")
+                     (anvil-web-test--reddit-comment "b" 4 "two")
+                     (anvil-web-test--reddit-comment "c" 3 "three"))))
+             "https://www.reddit.com/"))
+    (let ((out (anvil-web-reddit-thread
+                "https://www.reddit.com/r/emacs/comments/abc/x/" "1")))
+      (should (= 1 (length (plist-get out :comments)))))))
+
+(ert-deftest anvil-web-test-reddit-thread-rejects-non-comment-url ()
+  (should-error
+   (anvil-web-reddit-thread "https://www.reddit.com/r/emacs/")
+   :type 'user-error))
+
+(ert-deftest anvil-web-test-reddit-thread-strips-query-string ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             (anvil-web-test--json (anvil-web-test--reddit-fixture))
+             "https://www.reddit.com/"))
+    (anvil-web-reddit-thread
+     "https://www.reddit.com/r/emacs/comments/abc/x/?utm_source=share")
+    (let* ((call (car anvil-web-test--calls))
+           (url (plist-get call :url)))
+      (should (string-suffix-p "/comments/abc/x.json" url))
+      (should-not (string-match-p "utm_source" url)))))
+
+(ert-deftest anvil-web-test-reddit-thread-bad-response-shape ()
+  (anvil-web-test--with-stub
+      (list (anvil-web-test--response
+             200 nil
+             ;; Only one listing instead of [post, comments]
+             (anvil-web-test--json (vector (list :kind "Listing")))
+             "https://www.reddit.com/"))
+    (should-error
+     (anvil-web-reddit-thread
+      "https://www.reddit.com/r/emacs/comments/abc/x/")
+     :type 'user-error)))
+
+;;;; --- module lifecycle -------------------------------------------------
+
+(ert-deftest anvil-web-test-enable-registers-tools ()
+  "enable adds both tools, disable removes them."
+  (anvil-web-enable)
+  (unwind-protect
+      (let ((tools (anvil-server--get-server-tools anvil-web--server-id)))
+        (should (gethash "web-tweet-fetch" tools))
+        (should (gethash "web-reddit-thread" tools)))
+    (anvil-web-disable))
+  (let ((tools (anvil-server--get-server-tools anvil-web--server-id)))
+    (should-not (gethash "web-tweet-fetch" tools))
+    (should-not (gethash "web-reddit-thread" tools))))
+
+;;;; --- live smoke (opt-in via ANVIL_ALLOW_LIVE=1) -----------------------
+
+(ert-deftest anvil-web-test-live-tweet-fetch ()
+  "Exercises the real syndication endpoint.  Skipped unless
+ANVIL_ALLOW_LIVE=1 is set."
+  (skip-unless (equal "1" (getenv "ANVIL_ALLOW_LIVE")))
+  ;; Jack Dorsey's \"just setting up my twttr\" - stable public tweet.
+  (let ((out (anvil-web-tweet-fetch "20")))
+    (should (stringp (plist-get out :text)))
+    (should (equal "jack" (plist-get out :screen-name)))))
+
+(provide 'anvil-web-test)
+
+;;; anvil-web-test.el ends here


### PR DESCRIPTION
## Summary

Adds `anvil-web.el` with two focused MCP tools on the existing `emacs-eval` transport:

- **`web-tweet-fetch`** — single-tweet fetch via the public X/Twitter syndication endpoint (no OAuth). Returns a normalised plist including article preview and quoted-tweet fields.
- **`web-reddit-thread`** — Reddit thread (title + OP + top-N comments) from either a canonical `/comments/<id>/` URL or a `/s/<hash>` share link (redirect auto-resolved).

Both go through `anvil-http-get`, so scheme allow-list, retry/backoff and header handling are reused. Default User-Agent is a generic desktop browser (Reddit returns 403 to bare libcurl UAs); callers can override.

### Motivation

Real task: summarising 18 user-shared URLs (11 X, 1 Reddit, 6 SmartNews) in one session. `WebFetch` got `402` on X and `403` on Reddit, so the session devolved into `curl | jq` loops. These two endpoints cover ~60% of that class of task; the remaining SmartNews short-link handling is personal enough to stay in the user's `init.org`.

## Test plan

- [x] `make test-all` — **1219/1225 pass, 0 failed** (21 new anvil-web tests pass, 1 live smoke gated on `ANVIL_ALLOW_LIVE=1`)
- [x] `anvil-dev-release-audit` → `clean-p=t` (MCP Parameters / arglist / plist-return all OK)
- [x] `emacs -Q --batch -f batch-byte-compile anvil-web.el` → no warnings
- [ ] Opt-in live smoke: `ANVIL_ALLOW_LIVE=1 make test-all` (fetches @jack's first tweet)

## Next (out of scope)

- SmartNews short-link resolver → personal `init.org` helper (not generic enough for anvil.el).

🤖 Generated with [Claude Code](https://claude.com/claude-code)