### PR TITLE
feat(anvil-file): add file-create MCP tool (1-step new file)

### DIFF
--- a/anvil-file.el
+++ b/anvil-file.el
@@ -1112,6 +1112,23 @@ MCP Parameters:
   (anvil-server-with-error-handling
     (format "%S" (anvil-file-append path content))))
 
+(defun anvil-file--tool-create (path content &optional overwrite)
+  "Create a new file at PATH with CONTENT.
+
+Errors if the file already exists unless OVERWRITE is a non-empty
+string (\"1\" / \"true\" / any truthy value).  Parent directory must
+exist; this tool will not create it.  Returns the absolute path and
+byte count.  Use this in place of `touch + file-append' for new
+file creation in a single MCP call.
+
+MCP Parameters:
+  path - Absolute path to the new file
+  content - Initial content of the file
+  overwrite - Optional. Non-empty string to overwrite an existing file (e.g. \"1\")"
+  (anvil-server-with-error-handling
+    (let ((ow (and overwrite (stringp overwrite) (not (string-empty-p overwrite)))))
+      (format "%S" (anvil-file-create path content ow)))))
+
 ;;;; --- batch operations ----------------------------------------------------
 ;;
 ;; Execute multiple file operations in a single MCP call.  This is the
@@ -2352,6 +2369,18 @@ read specific sections."
    :description
    "Append text to the end of a file.  A leading newline is added
 if the file does not end with one.  Safe for files over 1.2MB."
+   :server-id anvil-file--server-id)
+
+  (anvil-server-register-tool
+   #'anvil-file--tool-create
+   :id "file-create"
+   :intent '(file-edit)
+   :layer 'core
+   :description
+   "Create a new file with given content in a single call.  Replaces
+the `touch + file-append' two-step pattern.  Errors if the file
+exists unless an overwrite flag is passed.  Parent directory must
+exist; this tool will not create it.  Safe for files over 1.2MB."
    :server-id anvil-file--server-id)
 
   (anvil-server-register-tool

--- a/tests/anvil-file-test.el
+++ b/tests/anvil-file-test.el
@@ -846,4 +846,74 @@ Uses a fixture whose target line is already on disk so no write fires."
      (should-error
       (anvil-code-extract-pattern path '(:block-start "^A"))))))
 
+;;;; --- file-create ---------------------------------------------------------
+
+(defun anvil-file-test--with-tmp-dir (fn)
+  "Create a fresh temp directory, call FN with its path, then clean up."
+  (let ((dir (make-temp-file "anvil-file-create-" t)))
+    (unwind-protect
+        (funcall fn dir)
+      (when (file-directory-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest anvil-file-test-create-new-file ()
+  "anvil-file-create writes content to a fresh path."
+  (anvil-file-test--with-tmp-dir
+   (lambda (dir)
+     (let* ((path (expand-file-name "fresh.txt" dir))
+            (result (anvil-file-create path "hello\n")))
+       (should (equal (plist-get result :created) (expand-file-name path)))
+       (should (= (plist-get result :bytes) 6))
+       (should (file-exists-p path))
+       (should (equal (anvil-file-test--read path) "hello\n"))))))
+
+(ert-deftest anvil-file-test-create-existing-without-overwrite-errors ()
+  "anvil-file-create refuses to clobber an existing file by default."
+  (anvil-file-test--with-tmp
+   "old\n"
+   (lambda (path)
+     (should-error (anvil-file-create path "new\n"))
+     ;; Original content must be preserved.
+     (should (equal (anvil-file-test--read path) "old\n")))))
+
+(ert-deftest anvil-file-test-create-existing-with-overwrite-replaces ()
+  "anvil-file-create with OVERWRITE replaces existing content."
+  (anvil-file-test--with-tmp
+   "old\n"
+   (lambda (path)
+     (let ((result (anvil-file-create path "new\n" t)))
+       (should (= (plist-get result :bytes) 4))
+       (should (equal (anvil-file-test--read path) "new\n"))))))
+
+(ert-deftest anvil-file-test-create-missing-parent-dir-errors ()
+  "anvil-file-create errors when parent directory is absent."
+  (anvil-file-test--with-tmp-dir
+   (lambda (dir)
+     (let ((path (expand-file-name "no-such-subdir/file.txt" dir)))
+       (should-error (anvil-file-create path "x"))
+       (should-not (file-exists-p path))))))
+
+(ert-deftest anvil-file-test-tool-create-roundtrip ()
+  "MCP wrapper handles new file creation with string args."
+  (anvil-file-test--with-tmp-dir
+   (lambda (dir)
+     (let* ((path (expand-file-name "tool.txt" dir))
+            (out (anvil-file--tool-create path "via-tool\n")))
+       (should (stringp out))
+       (should (string-match-p ":bytes 9" out))
+       (should (equal (anvil-file-test--read path) "via-tool\n"))))))
+
+(ert-deftest anvil-file-test-tool-create-overwrite-flag ()
+  "MCP wrapper treats non-empty overwrite string as truthy."
+  (anvil-file-test--with-tmp
+   "first\n"
+   (lambda (path)
+     ;; Empty string -> still refuses.
+     (should-error (anvil-file--tool-create path "second\n" ""))
+     (should (equal (anvil-file-test--read path) "first\n"))
+     ;; Non-empty -> overwrites.
+     (let ((out (anvil-file--tool-create path "second\n" "1")))
+       (should (string-match-p ":bytes 7" out))
+       (should (equal (anvil-file-test--read path) "second\n"))))))
+
 ;;; anvil-file-test.el ends here


### PR DESCRIPTION
## Summary

- Adds `anvil-file--tool-create` MCP wrapper around the existing `anvil-file-create` internal helper (line 275) and registers it in `anvil-file-enable` as tool id `file-create`.
- Replaces the `touch + file-append` two-step pattern that Claude sessions had to use for new file creation.
- One JSON-RPC call now covers directory existence check + content write, errors cleanly if the file exists (unless `overwrite="1"`/`"true"`), and refuses to auto-create parent directories on purpose (callers should be explicit).
- Closes the dogfood gap noted in memory `feedback_anvil_mandatory_for_edits.md` (2026-04-29 update extending the anvil-mandatory rule to new file creation).

## Test plan

- [x] 6 new ERT cases — 4 cover the underlying `anvil-file-create` (had no tests before), 2 cover the new MCP wrapper including the `overwrite` flag string parsing.
- [x] `anvil-file-test.el` 48/48 → 54/54 OK.
- [x] `make test-all` = **1567/1622 pass, 0 failed** (no regressions).
- [x] Byte-compile clean (only pre-existing org-* function warnings unrelated to this change).
- [x] `anvil-dev-release-audit` clean (`missing-params: nil`, `arglist-strip: nil`, `clean-p: t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)