### PR TITLE
Fix/develop missing non ide fixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -534,10 +534,12 @@ refactor in one MCP call.
 
 For legacy data extraction and ETL, the usual flow is "read the
 whole file then assemble with regex." This tool replaces that
-with a single MCP call. =:block-start= matches each block opener,
+with a single MCP call. =:block-start= matches each block header,
 =:block-end= picks the closing strategy (=brace-balance= skips
 braces inside strings), =:fields= regexps capture per-field
 values; the result comes back as a list of plain-data records.
+For =brace-balance=, =:block-start= should stop before the opening
+={=; the matcher then finds that brace and balances from there.
 The file body itself is never sent back to the agent.
 
 Measured: extracted 347 item definitions from =func492.ts= in

--- a/anvil-compact.el
+++ b/anvil-compact.el
@@ -4,7 +4,7 @@
 
 ;; Author: zawatton
 ;; Keywords: tools, convenience
-;; Package-Requires: ((emacs "29.1") (anvil-server "0.1") (anvil-state "0.1"))
+;; Package-Requires: ((emacs "29.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/anvil-cron.el
+++ b/anvil-cron.el
@@ -153,6 +153,10 @@ ENABLED defaults to t."
     (when (and task (plist-get task :enabled))
       (plist-put task :last-run (current-time))
       (plist-put task :last-status 'running)
+      ;; Clear the previous run's result so a concurrent `--tool-status'
+      ;; landing in the running window cannot pair the stale value with
+      ;; the fresh `running' state.
+      (plist-put task :last-result nil)
       (let ((fn (plist-get task :fn))
             (expr (plist-get task :expression))
             (start (float-time)))

--- a/anvil-discovery.el
+++ b/anvil-discovery.el
@@ -2,6 +2,7 @@
 
 ;; Author: zawatton
 ;; Keywords: tools, mcp
+;; Package-Requires: ((emacs "29.1"))
 
 ;;; Commentary:
 

--- a/anvil-eval.el
+++ b/anvil-eval.el
@@ -113,7 +113,11 @@ Only available in Emacs with thread support.")
 ;;; Async eval tools
 
 (defvar anvil-eval--async-jobs (make-hash-table :test 'equal)
-  "Hash table mapping job-id to plist (:status :result :start-time).")
+  "Hash table mapping job-id to async job plists.
+Each job records :status, :result, :expression and :start-time.
+Once the timer starts evaluating the form, :run-start-time is set;
+completed jobs also carry :finish-time, :queue-wait-sec and
+:runtime-sec.")
 
 (defvar anvil-eval--async-counter 0
   "Counter for generating unique job IDs.")
@@ -125,9 +129,11 @@ event loop iteration, so Emacs remains responsive.
 Use emacs-eval-result to retrieve the result.
 
 MCP Parameters:
-  expression - Emacs Lisp expression to evaluate asynchronously (string, required)
+  expression - Emacs Lisp expression to evaluate asynchronously
+               (string, required)
                Example: \"(byte-compile-file \\\"~/.emacs.d/init.el\\\")\"
-               Use for long-running operations that would timeout with emacs-eval."
+               Use for long-running operations that would timeout with
+               emacs-eval."
   (anvil-server-with-error-handling
     (let* ((job-id (format "job-%d-%d"
                            (setq anvil-eval--async-counter
@@ -143,18 +149,46 @@ MCP Parameters:
       (run-with-timer 0 nil
         (lambda ()
           (let ((job (gethash job-id anvil-eval--async-jobs)))
-            (condition-case err
-                (let ((result (eval form t)))
-                  (plist-put job :status 'done)
-                  (plist-put job :result (format "%S" result)))
-              (error
-               (plist-put job :status 'error)
-               (plist-put job :result (format "Error: %S" err)))))))
+            (when job
+              (let ((run-start (current-time))
+                    status result)
+                (setq job (plist-put job :run-start-time run-start))
+                (condition-case err
+                    (setq result (format "%S" (eval form t))
+                          status 'done)
+                  (error
+                   (setq result (format "Error: %S" err)
+                         status 'error)))
+                (let ((finish (current-time)))
+                  (setq job (plist-put job :status status))
+                  (setq job (plist-put job :result result))
+                  (setq job (plist-put job :finish-time finish))
+                  (setq
+                   job
+                   (plist-put
+                    job :queue-wait-sec
+                    (float-time
+                     (time-subtract run-start
+                                    (plist-get job :start-time)))))
+                  (setq
+                   job
+                   (plist-put
+                    job :runtime-sec
+                    (float-time
+                     (time-subtract finish run-start))))
+                  (puthash job-id job anvil-eval--async-jobs)))))))
       (format "Job started: %s" job-id))))
+
+(defun anvil-eval--format-seconds (seconds)
+  "Format SECONDS as a compact duration string, or return \"N/A\"."
+  (if (numberp seconds)
+      (format "%.1fs" seconds)
+    "N/A"))
 
 (defun anvil-eval--result (job-id)
   "Get the result of an async job.
-Returns status and result.  Completed results auto-clean after 10 minutes.
+Returns status, age, queue wait, runtime and result.  Completed
+results auto-clean after 10 minutes.
 
 MCP Parameters:
   job-id - The job ID returned by emacs-eval-async (string, required)
@@ -165,14 +199,38 @@ MCP Parameters:
           (format "Job not found: %s (may have been cleaned up)" job-id)
         (let ((status (plist-get job :status))
               (result (plist-get job :result))
-              (elapsed (float-time
-                        (time-subtract (current-time)
-                                       (plist-get job :start-time)))))
+              (now (current-time)))
+          (let* ((start-time (plist-get job :start-time))
+                 (run-start (plist-get job :run-start-time))
+                 (finish (plist-get job :finish-time))
+                 (elapsed (float-time
+                           (time-subtract now start-time)))
+                 (queue-wait
+                  (or (plist-get job :queue-wait-sec)
+                      (and run-start
+                           (float-time
+                            (time-subtract run-start start-time)))
+                      elapsed))
+                 (runtime
+                  (or (plist-get job :runtime-sec)
+                      (and run-start
+                           (float-time
+                            (time-subtract (or finish now)
+                                           run-start))))))
           (when (and (not (eq status 'running))
                      (> elapsed 600))
             (remhash job-id anvil-eval--async-jobs))
-          (format "status: %s\nelapsed: %.1fs\nresult: %s"
-                  status elapsed (or result "N/A")))))))
+          (format
+           (concat "status: %s\n"
+                   "elapsed: %.1fs\n"
+                   "age: %.1fs\n"
+                   "queue-wait: %s\n"
+                   "runtime: %s\n"
+                   "result: %s")
+           status elapsed elapsed
+           (anvil-eval--format-seconds queue-wait)
+           (anvil-eval--format-seconds runtime)
+           (or result "N/A"))))))))
 
 (defun anvil-eval--jobs ()
   "List all async jobs and their statuses.
@@ -242,7 +300,7 @@ Retrieve result with emacs-eval-result tool using the returned job ID."
    :layer 'dev
    :description
    "Get the result of an async job started by emacs-eval-async.
-Returns status (running/done/error), elapsed time, and result.
+Returns status (running/done/error), age, queue wait, runtime, and result.
 Poll this until status is 'done' or 'error'."
    :server-id anvil-eval--server-id)
   (anvil-server-register-tool

--- a/anvil-file.el
+++ b/anvil-file.el
@@ -1595,8 +1595,11 @@ SPEC is a plist:
   :block-end      One of:
                     `next-block-start' (default) — block ends right before
                       the next `:block-start' match (or EOF).
-                    `brace-balance' — track `{}' depth from `:block-start';
-                      end at the matching closing `}'.  Strings are skipped.
+                    `brace-balance' — find the first `{` after the
+                      `:block-start' match, then track `{}' depth and end at
+                      the matching closing `}'.  Strings are skipped.
+                      `:block-start' should match the header before the
+                      opening brace and must not consume the brace itself.
                     REGEXP string — block ends at the start of the first
                       regexp match after `:block-start'.
   :fields         List of field plists.  Each plist:
@@ -2492,12 +2495,14 @@ descriptions and disclosure-help cover the full contract."
 For each match of `block-start' the tool finds the block's body via
 `block-end' (`next-block-start', `brace-balance', or a regexp), then
 runs each `fields' regexp inside the body and captures group 1 as the
-field's value.  Read-only — the file is never modified.  Returns plist
-with :matches (each :id :start-line :end-line :fields) :total :returned
-:skipped.  Targets legacy code migration / data extraction where reading
-the entire file would be wasteful.  Regexp values use Emacs regexp
-syntax, and `fields' must be a JSON array of {name, regexp, required?}
-objects.  Brace-balance skips strings."
+field's value.  In `brace-balance' mode, `block-start' should match the
+header before the opening `{` and must not consume the brace itself.
+Read-only — the file is never modified.  Returns plist with :matches
+(each :id :start-line :end-line :fields) :total :returned :skipped.
+Targets legacy code migration / data extraction where reading the entire
+file would be wasteful.  Regexp values use Emacs regexp syntax, and
+`fields' must be a JSON array of {name, regexp, required?} objects.
+Brace-balance skips strings."
    :read-only t
    :offload t
    :server-id anvil-file--server-id)

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -295,30 +295,34 @@ variables."
          ;; temporary file-visiting buffer.
          (set-buffer-modified-p nil)))))
 
-(defun anvil-org--find-allowed-file-with-id (id)
+(defun anvil-org--find-allowed-file-with-id
+    (id &optional not-found-fn file-access-fn)
   "Find an allowed file containing the Org ID.
 First looks up in the org-id database, then validates the file is in
 the allowed list.
 Returns the expanded file path if found and allowed.
-Throws a tool error if ID exists but file is not allowed, or if ID
-is not found."
-  (if-let* ((id-file (org-id-find-id-file id)))
-    ;; ID found in database, check if file is allowed
-    (if-let* ((allowed-file (anvil-org--find-allowed-file id-file)))
-      allowed-file
-      (anvil-org--tool-file-access-error id))
-    ;; ID not in database - might not exist or DB is stale
-    ;; Fall back to searching allowed files manually (only when restriction is on)
-    (if (not anvil-org-allowed-files-enabled)
-        (anvil-org--id-not-found-error id)
-      (let ((found-file nil))
-        (dolist (allowed-file anvil-org-allowed-files)
-          (unless found-file
-            (when (file-exists-p allowed-file)
-              (anvil-org--with-org-file allowed-file
-                (when (org-find-property "ID" id)
-                  (setq found-file (expand-file-name allowed-file)))))))
-        (or found-file (anvil-org--id-not-found-error id))))))
+NOT-FOUND-FN and FILE-ACCESS-FN customize the error shape for tool
+versus resource callers."
+  (let ((not-found-fn (or not-found-fn #'anvil-org--id-not-found-error))
+        (file-access-fn
+         (or file-access-fn #'anvil-org--tool-file-access-error)))
+    (if-let* ((id-file (org-id-find-id-file id)))
+      ;; ID found in database, check if file is allowed
+      (if-let* ((allowed-file (anvil-org--find-allowed-file id-file)))
+        allowed-file
+        (funcall file-access-fn id))
+      ;; ID not in database - might not exist or DB is stale
+      ;; Fall back to searching allowed files manually (only when restriction is on)
+      (if (not anvil-org-allowed-files-enabled)
+          (funcall not-found-fn id)
+        (let ((found-file nil))
+          (dolist (allowed-file anvil-org-allowed-files)
+            (unless found-file
+              (when (file-exists-p allowed-file)
+                (anvil-org--with-org-file allowed-file
+                  (when (org-find-property "ID" id)
+                    (setq found-file (expand-file-name allowed-file)))))))
+          (or found-file (funcall not-found-fn id)))))))
 
 (defmacro anvil-org--with-uri-prefix-dispatch
     (uri headline-body id-body)
@@ -1100,13 +1104,13 @@ The filename parameter includes both file and headline path."
   "Handler for org-id://{uuid} template.
 PARAMS is an alist containing the uuid parameter."
   (let* ((id (alist-get "uuid" params nil nil #'string=))
-         (file-path (org-id-find-id-file id)))
-    (unless file-path
-      (anvil-org--resource-not-found-error "ID" id))
-    (let ((allowed-file (anvil-org--find-allowed-file file-path)))
-      (unless allowed-file
-        (anvil-org--resource-file-access-error id))
-      (anvil-org--get-content-by-id allowed-file id))))
+         (allowed-file
+          (anvil-org--find-allowed-file-with-id
+           id
+           (lambda (missing-id)
+             (anvil-org--resource-not-found-error "ID" missing-id))
+           #'anvil-org--resource-file-access-error)))
+    (anvil-org--get-content-by-id allowed-file id)))
 
 ;; PHASE-C-IDE-SPLIT-CANDIDATE: writes via org-edit-headline in real buffer
 (defun anvil-org--tool-rename-headline (uri current_title new_title)
@@ -1185,83 +1189,89 @@ MCP Parameters:
          headline-path
          (string-prefix-p anvil-org--uri-id-prefix resource_uri))
 
-        (anvil-org--validate-body-no-headlines
-         new_body (org-current-level))
+        (let ((target-marker (point-marker)))
+          (unwind-protect
+              (progn
+                (anvil-org--validate-body-no-headlines
+                 new_body (org-current-level))
 
-        ;; Skip past headline and properties
-        (org-end-of-meta-data t)
+                ;; Skip past headline and properties
+                (org-end-of-meta-data t)
 
-        ;; Get body boundaries
-        (let ((body-begin (point))
-              (body-end nil)
-              (body-content nil)
-              (occurrence-count 0))
+                ;; Get body boundaries
+                (let ((body-begin (point))
+                      (body-end nil)
+                      (body-content nil)
+                      (occurrence-count 0))
 
-          ;; Find end of body (before next headline or end of subtree)
-          (save-excursion
-            (if (org-goto-first-child)
-                ;; Has children - body ends before first child
-                (setq body-end (point))
-              ;; No children - body extends to end of subtree
-              (org-end-of-subtree t)
-              (setq body-end (point))))
+                  ;; Find end of body (before next headline or end of subtree)
+                  (save-excursion
+                    (if (org-goto-first-child)
+                        ;; Has children - body ends before first child
+                        (setq body-end (point))
+                      ;; No children - body extends to end of subtree
+                      (org-end-of-subtree t)
+                      (setq body-end (point))))
 
-          ;; Extract body content
-          (setq body-content
-                (buffer-substring-no-properties body-begin body-end))
+                  ;; Extract body content
+                  (setq body-content
+                        (buffer-substring-no-properties body-begin body-end))
 
-          ;; Trim leading newline if present
-          ;; (`org-end-of-meta-data' includes it)
-          (when (and (> (length body-content) 0)
-                     (= (aref body-content 0) ?\n))
-            (setq body-content (substring body-content 1))
-            (setq body-begin (1+ body-begin)))
+                  ;; Trim leading newline if present
+                  ;; (`org-end-of-meta-data' includes it)
+                  (when (and (> (length body-content) 0)
+                             (= (aref body-content 0) ?\n))
+                    (setq body-content (substring body-content 1))
+                    (setq body-begin (1+ body-begin)))
 
-          ;; Check if body is empty
-          (when (string-match-p "\\`[[:space:]]*\\'" body-content)
-            ;; Empty oldBody + empty body -> add content
-            (if (string= old_body "")
-                ;; Treat as single replacement
-                (setq occurrence-count 1)
-              (anvil-org--tool-validation-error
-               "Node has no body content")))
+                  ;; Check if body is empty
+                  (when (string-match-p "\\`[[:space:]]*\\'" body-content)
+                    ;; Empty oldBody + empty body -> add content
+                    (if (string= old_body "")
+                        ;; Treat as single replacement
+                        (setq occurrence-count 1)
+                      (anvil-org--tool-validation-error
+                       "Node has no body content")))
 
-          ;; Count occurrences (unless already handled above)
-          (unless (= occurrence-count 1)
-            ;; Empty oldBody with non-empty body is an error
-            (if (and (string= old_body "")
-                     (not
-                      (string-match-p
-                       "\\`[[:space:]]*\\'" body-content)))
-                (anvil-org--tool-validation-error
-                 "Cannot use empty old_body with non-empty body")
-              ;; Normal occurrence counting
-              (let ((case-fold-search nil)
-                    (search-pos 0))
-                (while (string-match
-                        (regexp-quote old_body) body-content
-                        search-pos)
-                  (setq occurrence-count (1+ occurrence-count))
-                  (setq search-pos (match-end 0))))))
+                  ;; Count occurrences (unless already handled above)
+                  (unless (= occurrence-count 1)
+                    ;; Empty oldBody with non-empty body is an error
+                    (if (and (string= old_body "")
+                             (not
+                              (string-match-p
+                               "\\`[[:space:]]*\\'" body-content)))
+                        (anvil-org--tool-validation-error
+                         "Cannot use empty old_body with non-empty body")
+                      ;; Normal occurrence counting
+                      (let ((case-fold-search nil)
+                            (search-pos 0))
+                        (while (string-match
+                                (regexp-quote old_body) body-content
+                                search-pos)
+                          (setq occurrence-count (1+ occurrence-count))
+                          (setq search-pos (match-end 0))))))
 
-          ;; Validate occurrences
-          (cond
-           ((= occurrence-count 0)
-            (anvil-org--tool-validation-error "Body text not found: %s"
-                                            old_body))
-           ((and (> occurrence-count 1) (not replace_all))
-            (anvil-org--tool-validation-error
-             (concat "Text appears %d times (use replace_all)")
-             occurrence-count)))
+                  ;; Validate occurrences
+                  (cond
+                   ((= occurrence-count 0)
+                    (anvil-org--tool-validation-error
+                     "Body text not found: %s"
+                     old_body))
+                   ((and (> occurrence-count 1) (not replace_all))
+                    (anvil-org--tool-validation-error
+                     (concat "Text appears %d times (use replace_all)")
+                     occurrence-count)))
 
-          ;; Perform replacement
-          (anvil-org--replace-body-content
-           old_body
-           new_body
-           body-content
-           replace_all
-           body-begin
-           body-end))))))
+                  ;; Perform replacement
+                  (anvil-org--replace-body-content
+                   old_body
+                   new_body
+                   body-content
+                   replace_all
+                   body-begin
+                   body-end))
+                (goto-char target-marker))
+            (set-marker target-marker nil)))))))
 
 ;; Tools duplicating resource templates
 

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -689,6 +689,7 @@ Throws an MCP tool error if unbalanced blocks are found."
   "Normalize TAGS parameter to a list format.
 TAGS can be:
 - nil or empty list -> returns nil
+- empty / whitespace-only string -> returns nil (no tags)
 - vector (JSON array) -> converts to list
 - string -> wraps in list
 - list -> returns as-is
@@ -701,7 +702,11 @@ Throws error for invalid types."
    ((listp tags)
     tags) ; Already a list
    ((stringp tags)
-    (list tags)) ; Single tag string
+    (if (string-empty-p (string-trim tags))
+        nil ; "" / whitespace -> no tags (MCP schema declares tags
+            ; as a single required string, so callers need a way to
+            ; express "no tags" without inventing a sentinel value)
+      (list tags))) ; Single tag string
    (t
     (anvil-org--tool-validation-error "Invalid tags format: %s" tags))))
 
@@ -939,10 +944,18 @@ MCP Parameters:
       (anvil-org--goto-headline-from-uri
        headline-path (string-prefix-p anvil-org--uri-id-prefix uri))
 
-      ;; Check current state matches
+      ;; Check current state matches.  `org-get-todo-state' returns
+      ;; nil for headlines without a TODO keyword; treat nil and ""
+      ;; (the documented "no state" sentinel on the MCP wire) as the
+      ;; same value so callers can transition from no-state to a real
+      ;; state without inventing a magic string.
       (beginning-of-line)
-      (let ((actual-state (org-get-todo-state)))
-        (unless (string= actual-state current_state)
+      (let* ((actual-state (org-get-todo-state))
+             (expected (if (or (null current_state)
+                               (string-empty-p current_state))
+                           nil
+                         current_state)))
+        (unless (equal actual-state expected)
           (anvil-org--state-mismatch-error
            (or current_state "(no state)")
            (or actual-state "(no state)") "State")))

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -690,10 +690,15 @@ Throws an MCP tool error if unbalanced blocks are found."
 TAGS can be:
 - nil or empty list -> returns nil
 - empty / whitespace-only string -> returns nil (no tags)
-- vector (JSON array) -> converts to list
-- string -> wraps in list
+- vector (JSON array, decoded form) -> converts to list
+- string starting with `[' -> parsed as a JSON array of tag strings
+  (multi-tag form for MCP callers, since `anvil-server-register-tool'
+  types every parameter as \"string\" and structured values must arrive
+  JSON-encoded — same convention as `file-batch.operations',
+  `json-object-add.pairs-json', etc.)
+- other string -> wraps in single-element list (single-tag convenience)
 - list -> returns as-is
-Throws error for invalid types."
+Throws error for invalid types or malformed JSON."
   (cond
    ((null tags)
     nil) ; No tags (nil or empty list)
@@ -702,11 +707,26 @@ Throws error for invalid types."
    ((listp tags)
     tags) ; Already a list
    ((stringp tags)
-    (if (string-empty-p (string-trim tags))
-        nil ; "" / whitespace -> no tags (MCP schema declares tags
-            ; as a single required string, so callers need a way to
-            ; express "no tags" without inventing a sentinel value)
-      (list tags))) ; Single tag string
+    (let ((trimmed (string-trim tags)))
+      (cond
+       ((string-empty-p trimmed)
+        nil) ; "" / whitespace -> no tags (kept for MCP callers wanting
+             ; to express "no tags" without inventing a sentinel)
+       ((eq (aref trimmed 0) ?\[)
+        (condition-case err
+            (let ((parsed (json-parse-string trimmed
+                                             :array-type 'list
+                                             :null-object nil
+                                             :false-object nil)))
+              (unless (listp parsed)
+                (anvil-org--tool-validation-error
+                 "Tags JSON must encode an array, got: %s" tags))
+              parsed)
+          (json-error
+           (anvil-org--tool-validation-error
+            "Invalid tags JSON: %s" (error-message-string err)))))
+       (t
+        (list tags))))) ; Single tag string
    (t
     (anvil-org--tool-validation-error "Invalid tags format: %s" tags))))
 
@@ -970,7 +990,9 @@ MCP Parameters:
 Creates an Org ID for the new headline and returns its ID-based URI.
 TITLE is the headline text.
 TODO_STATE is the TODO state from `org-todo-keywords'.
-TAGS is a single tag string or list of tag strings.
+TAGS is a single tag string, a list/vector of tag strings, or a JSON
+array literal string (e.g. \"[\\\"a\\\",\\\"b\\\"]\") for the MCP wire form;
+empty string means no tags.
 BODY is optional body text.
 PARENT_URI is the URI of the parent item.
 AFTER_URI is optional URI of sibling to insert after.
@@ -978,7 +1000,7 @@ AFTER_URI is optional URI of sibling to insert after.
 MCP Parameters:
   title - The headline text
   todo_state - TODO state from `org-todo-keywords'
-  tags - Tags to add (single string or array of strings)
+  tags - Tags to add (single string, JSON array string, or empty for none)
   body - Optional body text content
   parent_uri - Parent item URI
                Formats:
@@ -1574,9 +1596,10 @@ Parameters:
           Cannot be empty or whitespace-only
           Cannot contain newlines
   todo_state - TODO keyword from org-todo-keywords (string, required)
-  tags - Tags for the headline (string or array, required)
+  tags - Tags for the headline (string, required)
          Single tag: \"urgent\"
-         Multiple tags: [\"work\", \"urgent\"]
+         Multiple tags: JSON array literal, e.g. \"[\\\"work\\\",\\\"urgent\\\"]\"
+         No tags: empty string \"\"
          Validated against org-tag-alist if configured
          Must follow Org tag rules (alphanumeric, _, @)
          Respects mutually exclusive tag groups

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -282,12 +282,18 @@ variables."
   `(progn
      (anvil-org--fail-if-modified ,file-path ,operation)
      (with-temp-buffer
-       (set-visited-file-name ,file-path t)
-       (insert-file-contents ,file-path)
-       (org-mode)
-       (goto-char (point-min))
-       ,@body
-       (anvil-org--complete-and-save ,file-path ,response-alist))))
+       (unwind-protect
+           (progn
+             (insert-file-contents ,file-path)
+             (set-visited-file-name ,file-path t)
+             (set-buffer-modified-p nil)
+             (org-mode)
+             (goto-char (point-min))
+             ,@body
+             (anvil-org--complete-and-save ,file-path ,response-alist))
+         ;; Do not let failed tool calls prompt about killing the
+         ;; temporary file-visiting buffer.
+         (set-buffer-modified-p nil)))))
 
 (defun anvil-org--find-allowed-file-with-id (id)
   "Find an allowed file containing the Org ID.

--- a/anvil-py.el
+++ b/anvil-py.el
@@ -1093,6 +1093,15 @@ MCP Parameters:
          (error nil))
        (user-error "anvil-py: could not parse spec string %S" spec)))))
 
+(defun anvil-py--coerce-name (name)
+  "Coerce a single import NAME element to a string.
+Accepts strings (returned unchanged) and symbols (rendered via
+`symbol-name'); anything else is rejected so render paths don't
+emit `(wrong-type-argument sequencep …)' on a list of symbols."
+  (cond ((stringp name) name)
+        ((and name (symbolp name)) (symbol-name name))
+        (t (user-error "anvil-py: invalid import name %S" name))))
+
 (defun anvil-py--coerce-spec (spec)
   "Normalize an MCP-bridge SPEC into the elisp plist shape.
 MCP tool calls can arrive as a plist, an alist / hash-table decoded
@@ -1126,6 +1135,19 @@ a plist whose values are ready for the elisp planners."
     (when (stringp names)
       (setq s (plist-put s :names
                          (split-string names "[ ,]+" t))))
+    ;; Identifier-shaped fields can arrive as symbols when SPEC was
+    ;; parsed from an elisp-style string like `(:name Dict)' — Emacs's
+    ;; reader produces symbols, but downstream rendering (`mapconcat',
+    ;; `format' into rewrite plans) expects strings.  Coerce the
+    ;; scalar `:name' and every element of `:names' so callers can
+    ;; pass either shape interchangeably.
+    (let ((name (plist-get s :name)))
+      (when (and name (symbolp name))
+        (setq s (plist-put s :name (symbol-name name)))))
+    (let ((ns (plist-get s :names)))
+      (when (consp ns)
+        (setq s (plist-put s :names
+                           (mapcar #'anvil-py--coerce-name ns)))))
     s))
 
 (defun anvil-py--tool-add-import (file spec apply)

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -692,6 +692,11 @@ METHOD-METRICS is used to track errors."
      (let ((code (car (cdr err)))
            (message (cadr (cdr err))))
        (anvil-server--jsonrpc-error id code message)))
+    (quit
+     (cl-incf (anvil-server-metrics-errors method-metrics))
+     (anvil-server--jsonrpc-error
+      id anvil-server-jsonrpc-error-internal
+      (format "Resource handler quit for %s: %S" uri err)))
     ;; Handle any other error from the handler
     (error
      (cl-incf (anvil-server-metrics-errors method-metrics))
@@ -1138,6 +1143,12 @@ virtual server-ids share the same handler pool."
                       (isError . t))))
                (anvil-server--respond-with-result
                 context formatted-error)))
+            (quit
+             (anvil-server-metrics--track-tool-call tool-name t)
+             (cl-incf (anvil-server-metrics-errors method-metrics))
+             (anvil-server--jsonrpc-error
+              id anvil-server-jsonrpc-error-internal
+              (format "Tool handler quit: %S" err)))
             ;; Keep existing handling for all other errors
             (error
              (anvil-server-metrics--track-tool-call tool-name t)
@@ -1263,6 +1274,8 @@ See also: `anvil-server-tool-throw'"
   `(condition-case err
        (progn
          ,@body)
+     (quit
+      (anvil-server-tool-throw (format "Quit: %S" err)))
      (error
       (anvil-server-tool-throw (format "Error: %S" err)))))
 
@@ -1312,6 +1325,8 @@ See also: `anvil-server-process-jsonrpc-parsed'"
           (setq response
                 (anvil-server--validate-and-dispatch-request
                  json-object server-id))
+        (quit
+         (setq response (anvil-server--handle-error err)))
         (error
          (setq response (anvil-server--handle-error err)))))
 

--- a/anvil-sexp.el
+++ b/anvil-sexp.el
@@ -1060,9 +1060,17 @@ leak in."
       (when (buffer-live-p log-buf) (kill-buffer log-buf)))))
 
 (defun anvil-sexp--run-checkdoc (file)
-  "Run `checkdoc-file' on FILE, return list of diagnostic plists."
+  "Run `checkdoc-file' on FILE, return list of diagnostic plists.
+`checkdoc-file' visits FILE via `find-file-noselect' and never
+kills the resulting buffer.  Subsequent apply-path writes go
+through `with-temp-buffer' + `write-region' (anvil-file's
+no-buffer-side-effects pattern) and would leave that visiting
+buffer stale, triggering `ask-user-about-supersession-threat'
+the next time the user touches it.  Track whether a visiting
+buffer existed before the call and kill the one we created."
   (require 'checkdoc)
-  (let ((warn-buf (get-buffer-create "*anvil-sexp-cd*"))
+  (let ((pre-buf (find-buffer-visiting file))
+        (warn-buf (get-buffer-create "*anvil-sexp-cd*"))
         (diags '()))
     (unwind-protect
         (progn
@@ -1091,7 +1099,13 @@ leak in."
                               :source 'checkdoc
                               :line line :message msg)
                         diags))))))
-      (when (buffer-live-p warn-buf) (kill-buffer warn-buf)))
+      (when (buffer-live-p warn-buf) (kill-buffer warn-buf))
+      (unless pre-buf
+        (let ((post-buf (find-buffer-visiting file)))
+          (when (buffer-live-p post-buf)
+            (with-current-buffer post-buf
+              (set-buffer-modified-p nil))
+            (kill-buffer post-buf)))))
     (nreverse diags)))
 
 (defun anvil-sexp--tool-verify (file &optional byte_compile checkdoc)

--- a/anvil-sexp.el
+++ b/anvil-sexp.el
@@ -29,7 +29,7 @@
 ;; Dynamic variables owned by `checkdoc'; declared so that the
 ;; byte compiler treats the `let' bindings in
 ;; `anvil-sexp--run-checkdoc' as dynamic (they are read by
-;; `checkdoc-file' internally).  The feature itself is loaded
+;; `checkdoc-current-buffer' internally).  The feature itself is loaded
 ;; lazily inside the function to avoid a top-level recursive
 ;; require when users load anvil-sexp during an active checkdoc
 ;; session.
@@ -37,6 +37,8 @@
 (defvar checkdoc-autofix-flag)
 (defvar checkdoc-spellcheck-documentation-flag)
 (defvar checkdoc-verb-check-experimental-flag)
+(defvar checkdoc--batch-flag)
+(defvar checkdoc-pending-errors)
 
 
 ;;;; --- group + constants ---------------------------------------------------
@@ -1060,14 +1062,18 @@ leak in."
       (when (buffer-live-p log-buf) (kill-buffer log-buf)))))
 
 (defun anvil-sexp--run-checkdoc (file)
-  "Run `checkdoc-file' on FILE, return list of diagnostic plists.
-`checkdoc-file' visits FILE via `find-file-noselect' and never
-kills the resulting buffer.  Subsequent apply-path writes go
-through `with-temp-buffer' + `write-region' (anvil-file's
-no-buffer-side-effects pattern) and would leave that visiting
-buffer stale, triggering `ask-user-about-supersession-threat'
-the next time the user touches it.  Track whether a visiting
-buffer existed before the call and kill the one we created."
+  "Run `checkdoc-current-buffer' on FILE, return diagnostic plists.
+`checkdoc-file' visits FILE via `find-file-noselect', overrides
+`checkdoc-diagnostic-buffer' with \"*warn*\", and may display
+diagnostic windows.  Drive `checkdoc-current-buffer' directly so
+the MCP tool can collect diagnostics in an internal buffer without
+touching the user's window layout.
+
+Track whether a visiting buffer existed before the call and kill
+only the buffer we create.  Otherwise subsequent apply-path writes
+that use `with-temp-buffer' + `write-region' can leave the visited
+buffer stale and trigger `ask-user-about-supersession-threat' on
+the next interactive edit."
   (require 'checkdoc)
   (let ((pre-buf (find-buffer-visiting file))
         (warn-buf (get-buffer-create "*anvil-sexp-cd*"))
@@ -1078,9 +1084,13 @@ buffer existed before the call and kill the one we created."
           (let ((checkdoc-diagnostic-buffer (buffer-name warn-buf))
                 (checkdoc-autofix-flag 'never)
                 (checkdoc-spellcheck-documentation-flag nil)
-                (checkdoc-verb-check-experimental-flag nil))
+                (checkdoc-verb-check-experimental-flag nil)
+                (checkdoc--batch-flag t)
+                (checkdoc-pending-errors nil))
             (condition-case err
-                (checkdoc-file file)
+                (save-window-excursion
+                  (with-current-buffer (find-file-noselect file)
+                    (checkdoc-current-buffer t)))
               (error
                (push (list :kind 'error :source 'checkdoc :line 0
                            :message (error-message-string err))

--- a/anvil-web.el
+++ b/anvil-web.el
@@ -4,7 +4,7 @@
 
 ;; Author: Anvil contributors
 ;; Keywords: http, twitter, reddit, tools
-;; Package-Requires: ((emacs "28.1") (anvil-http "0.1") (anvil-server "0.1"))
+;; Package-Requires: ((emacs "28.1"))
 ;; Version: 0.1.0
 
 ;;; Commentary:

--- a/tests/anvil-cron-test.el
+++ b/tests/anvil-cron-test.el
@@ -1,0 +1,37 @@
+;;; anvil-cron-test.el --- Tests for anvil-cron -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Focused contract tests for the cron scheduler's state machine.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil-cron)
+
+(ert-deftest anvil-cron-test-execute-clears-stale-result ()
+  "Transition to `running' must drop the previous run's result so that a
+concurrent status snapshot cannot pair stale output with the fresh
+`running' state.  The deferred lambda queued by `run-with-timer' does
+not fire while the test body holds control, which is exactly the
+running window we are asserting against."
+  (let ((id 'anvil-cron-test-stale))
+    (unwind-protect
+        (progn
+          (anvil-cron-register :id id
+                               :description "stale-result probe"
+                               :interval 3600
+                               :fn #'ignore)
+          (let ((task (gethash id anvil-cron--tasks)))
+            ;; Pretend a previous run left both fields populated.
+            (plist-put task :last-status 'error)
+            (plist-put task :last-result "prior result"))
+          (let ((anvil-cron-use-worker nil))
+            (anvil-cron--execute-task id))
+          (let ((task (gethash id anvil-cron--tasks)))
+            (should (eq (plist-get task :last-status) 'running))
+            (should-not (plist-get task :last-result))))
+      (anvil-cron-unregister id))))
+
+(provide 'anvil-cron-test)
+;;; anvil-cron-test.el ends here

--- a/tests/anvil-eval-test.el
+++ b/tests/anvil-eval-test.el
@@ -1,0 +1,98 @@
+;;; anvil-eval-test.el --- Tests for anvil eval helpers -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Tests for async eval result formatting.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil-eval)
+
+(defun anvil-eval-test--time-ago (seconds)
+  "Return a timestamp SECONDS before now."
+  (time-subtract (current-time) (seconds-to-time seconds)))
+
+(ert-deftest anvil-eval-test-result-reports-runtime-for-finished-job ()
+  "Finished async jobs report runtime separately from job age."
+  (let ((anvil-eval--async-jobs (make-hash-table :test 'equal)))
+    (puthash
+     "job-1"
+     (let* ((start (anvil-eval-test--time-ago 12))
+            (run-start (time-add start (seconds-to-time 10)))
+            (finish (time-add run-start (seconds-to-time 0.4))))
+       (list :status 'done
+             :result "\"ok\""
+             :expression "(progn \"ok\")"
+             :start-time start
+             :run-start-time run-start
+             :finish-time finish
+             :queue-wait-sec 10.0
+             :runtime-sec 0.4))
+     anvil-eval--async-jobs)
+    (let ((out (anvil-eval--result "job-1")))
+      (should (string-match-p "^status: done" out))
+      (should (string-match-p "^elapsed: [0-9.]+s" out))
+      (should (string-match-p "^age: [0-9.]+s" out))
+      (should (string-match-p "^queue-wait: 10.0s" out))
+      (should (string-match-p "^runtime: 0.4s" out))
+      (should (string-match-p "^result: \"ok\"" out)))))
+
+(ert-deftest anvil-eval-test-result-running-before-start-has-no-runtime ()
+  "Queued async jobs have age and queue wait, but no runtime."
+  (let ((anvil-eval--async-jobs (make-hash-table :test 'equal)))
+    (puthash
+     "job-1"
+     (list :status 'running
+           :result nil
+           :expression "(sleep-for 1)"
+           :start-time (anvil-eval-test--time-ago 3))
+     anvil-eval--async-jobs)
+    (let ((out (anvil-eval--result "job-1")))
+      (should (string-match-p "^status: running" out))
+      (should (string-match-p "^queue-wait: [0-9.]+s" out))
+      (should (string-match-p "^runtime: N/A" out))
+      (should (string-match-p "^result: N/A" out)))))
+
+(ert-deftest anvil-eval-test-result-running-after-start-reports-runtime ()
+  "Running async jobs report runtime since their run-start time."
+  (let ((anvil-eval--async-jobs (make-hash-table :test 'equal)))
+    (puthash
+     "job-1"
+     (let* ((start (anvil-eval-test--time-ago 4))
+            (run-start (time-add start (seconds-to-time 2))))
+       (list :status 'running
+             :result nil
+             :expression "(sleep-for 10)"
+             :start-time start
+             :run-start-time run-start))
+     anvil-eval--async-jobs)
+    (let ((out (anvil-eval--result "job-1")))
+      (should (string-match-p "^status: running" out))
+      (should (string-match-p "^queue-wait: 2.0s" out))
+      (should (string-match-p "^runtime: [0-9.]+s" out))
+      (should-not (string-match-p "^runtime: N/A" out)))))
+
+(ert-deftest anvil-eval-test-async-records-runtime-fields ()
+  "The async timer path records queue wait and runtime fields."
+  (let ((anvil-eval--async-jobs (make-hash-table :test 'equal))
+        (anvil-eval--async-counter 0))
+    (let* ((started (anvil-eval--async "(+ 1 2)"))
+           (job-id (replace-regexp-in-string "\\`Job started: " "" started))
+           (deadline (+ (float-time) 1.0)))
+      (while (and (< (float-time) deadline)
+                  (eq 'running
+                      (plist-get (gethash job-id anvil-eval--async-jobs)
+                                 :status)))
+        (accept-process-output nil 0.01))
+      (let ((job (gethash job-id anvil-eval--async-jobs)))
+        (should (eq 'done (plist-get job :status)))
+        (should (numberp (plist-get job :queue-wait-sec)))
+        (should (numberp (plist-get job :runtime-sec)))
+        (should (equal "3" (plist-get job :result))))
+      (let ((out (anvil-eval--result job-id)))
+        (should (string-match-p "^queue-wait: [0-9.]+s" out))
+        (should (string-match-p "^runtime: [0-9.]+s" out))))))
+
+(provide 'anvil-eval-test)
+;;; anvil-eval-test.el ends here

--- a/tests/anvil-file-test.el
+++ b/tests/anvil-file-test.el
@@ -710,6 +710,42 @@ Uses a fixture whose target line is already on disk so no write fires."
                       (alist-get "price" (plist-get (nth 1 matches) :fields)
                                  nil nil #'equal)))))))
 
+(ert-deftest anvil-code-extract-test-brace-balance-header-before-brace ()
+  "brace-balance expects :block-start to match the header before `{'."
+  (anvil-file-test--with-tmp-ts
+   (concat "if (id == 1) {\n"
+           "  count = 5;\n"
+           "}\n")
+   (lambda (path)
+     (let* ((res (anvil-code-extract-pattern
+                  path
+                  '(:block-start "if (id == \\([0-9]+\\))"
+                    :block-end brace-balance
+                    :fields ((:name "count"
+                              :regexp "count = \\([0-9]+\\)")))))
+            (matches (plist-get res :matches)))
+       (should (= 1 (plist-get res :returned)))
+       (should (equal "1" (plist-get (car matches) :id)))
+       (should (equal "5"
+                      (alist-get "count" (plist-get (car matches) :fields)
+                                 nil nil #'equal)))))))
+
+(ert-deftest anvil-code-extract-test-brace-balance-start-must-not-consume-brace ()
+  "Document current contract: :block-start must not consume the opening `{'."
+  (anvil-file-test--with-tmp-ts
+   (concat "if (id == 1) {\n"
+           "  count = 5;\n"
+           "}\n")
+   (lambda (path)
+     (let ((res (anvil-code-extract-pattern
+                 path
+                 '(:block-start "if (id == \\([0-9]+\\)) {"
+                   :block-end brace-balance
+                   :fields ((:name "count"
+                             :regexp "count = \\([0-9]+\\)"))))))
+       (should (= 1 (plist-get res :total)))
+       (should (= 0 (plist-get res :returned)))))))
+
 (ert-deftest anvil-code-extract-test-brace-balance-skips-string-braces ()
   "brace-balance ignores `{' / `}' that appear inside double-quoted strings."
   (anvil-file-test--with-tmp-ts

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -8,6 +8,7 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'json)
 (require 'anvil-org)
 
 (defun anvil-org-test--with-temp-org (content fn)
@@ -20,6 +21,13 @@
           (funcall fn path))
       (when (file-exists-p path)
         (delete-file path)))))
+
+(defun anvil-org-test--read (path)
+  "Return PATH's contents as a UTF-8 string."
+  (with-temp-buffer
+    (let ((coding-system-for-read 'utf-8))
+      (insert-file-contents path))
+    (buffer-string)))
 
 (ert-deftest anvil-org-test-modify-errors-do-not-prompt-on-kill ()
   "Failed modify tools must not ask to kill their temp file buffer."
@@ -59,6 +67,41 @@
                   (string= (file-truename buffer-file-name)
                            (file-truename path)))))
          (buffer-list)))))))
+
+(ert-deftest anvil-org-test-read-by-id-scans-allowed-files ()
+  "Read an ID property from allowed files when org-id has no DB entry."
+  (let ((id (concat "mcp-test-root-id-"
+                    (substring (md5 (number-to-string (float-time))) 0 8))))
+    (anvil-org-test--with-temp-org
+     (format "* TODO Root\n:PROPERTIES:\n:ID: %s\n:END:\nBody line.\n" id)
+     (lambda (path)
+       (let ((anvil-org-allowed-files (list path))
+             (anvil-org-allowed-files-enabled t)
+             (anvil-org-use-index nil))
+         (should-not (org-id-find-id-file id))
+         (let ((content (anvil-org--tool-read-by-id id)))
+           (should (string-match-p "\\* TODO Root" content))
+           (should (string-match-p "Body line." content))))))))
+
+(ert-deftest anvil-org-test-edit-body-returns-target-headline-id ()
+  "Editing parent body must return the parent URI, not a child URI."
+  (anvil-org-test--with-temp-org
+   "* TODO Root :test:\n:PROPERTIES:\n:ID: root-id-for-edit-body-test\n:END:\nBody line.\n** Child\nChild body.\n"
+   (lambda (path)
+     (let* ((anvil-org-allowed-files (list path))
+            (anvil-org-allowed-files-enabled t)
+            (root-uri (concat "org-headline://" path "#Root"))
+            (response
+             (json-parse-string
+              (anvil-org--tool-edit-body
+               root-uri "Body line." "Body line edited." nil)
+              :object-type 'alist))
+            (content (anvil-org-test--read path)))
+       (should
+        (equal "org-id://root-id-for-edit-body-test"
+               (alist-get 'uri response)))
+       (should (string-match-p "Body line edited." content))
+       (should-not (string-match-p "^\\*\\* Child\n:PROPERTIES:" content))))))
 
 (ert-deftest anvil-org-test-tool-read-by-id-rejects-org-id-resource-uri ()
   "The Layer-3 tool accepts org:// citations, not org-id:// resources."

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -123,4 +123,38 @@
       "org://550e8400-e29b-41d4-a716-446655440000"
       (cadr err)))))
 
+(ert-deftest anvil-org-test-update-todo-state-no-state-transition ()
+  "Empty `current_state' must match a headline that has no TODO keyword."
+  (anvil-org-test--with-temp-org
+   "* Plain :test:\nBody.\n"
+   (lambda (path)
+     (let* ((anvil-org-allowed-files (list path))
+            (anvil-org-allowed-files-enabled t)
+            (uri (concat "org-headline://" path "#Plain"))
+            (response
+             (json-parse-string
+              (anvil-org--tool-update-todo-state uri "" "TODO")
+              :object-type 'alist))
+            (content (anvil-org-test--read path)))
+       (should (eq t (alist-get 'success response)))
+       (should (string-match-p "^\\* TODO Plain" content))))))
+
+(ert-deftest anvil-org-test-add-todo-empty-tags-string ()
+  "Empty `tags' string must mean no tags, not a single empty tag."
+  (anvil-org-test--with-temp-org
+   "* Parent\nBody.\n"
+   (lambda (path)
+     (let* ((anvil-org-allowed-files (list path))
+            (anvil-org-allowed-files-enabled t)
+            (parent-uri (concat "org-headline://" path "#Parent"))
+            (response
+             (json-parse-string
+              (anvil-org--tool-add-todo
+               "Child" "TODO" "" "Child body." parent-uri)
+              :object-type 'alist))
+            (content (anvil-org-test--read path)))
+       (should (eq t (alist-get 'success response)))
+       (should (string-match-p "^\\*\\* TODO Child$" content))
+       (should-not (string-match-p "^\\*\\* TODO Child[ \t]+:" content))))))
+
 ;;; anvil-org-test.el ends here

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -7,7 +7,58 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'anvil-org)
+
+(defun anvil-org-test--with-temp-org (content fn)
+  "Write CONTENT to a temporary Org file and call FN with its path."
+  (let ((path (make-temp-file "anvil-org-test-" nil ".org")))
+    (unwind-protect
+        (progn
+          (let ((coding-system-for-write 'utf-8-unix))
+            (write-region content nil path nil 'silent))
+          (funcall fn path))
+      (when (file-exists-p path)
+        (delete-file path)))))
+
+(ert-deftest anvil-org-test-modify-errors-do-not-prompt-on-kill ()
+  "Failed modify tools must not ask to kill their temp file buffer."
+  (anvil-org-test--with-temp-org
+   "* TODO Root :test:\nBody line.\n** Child\nChild body.\n"
+   (lambda (path)
+     (let ((anvil-org-allowed-files (list path))
+           (anvil-org-allowed-files-enabled t)
+           (root-uri (concat "org-headline://" path "#Root"))
+           (child-uri (concat "org-headline://" path "#Root/Child")))
+       (dolist (case
+                `((update
+                   . ,(lambda ()
+                        (anvil-org--tool-update-todo-state
+                         child-uri "TODO" "DONE")))
+                  (rename
+                   . ,(lambda ()
+                        (anvil-org--tool-rename-headline
+                         root-uri "Wrong Root" "Root Renamed")))
+                  (edit-body
+                   . ,(lambda ()
+                        (anvil-org--tool-edit-body
+                         root-uri "missing body" "replacement" nil)))))
+         (let (prompts)
+           (cl-letf (((symbol-function 'read-multiple-choice)
+                      (lambda (prompt _choices &rest _args)
+                        (push prompt prompts)
+                        (list ?y "yes"))))
+             (should-error (funcall (cdr case))
+                           :type 'anvil-server-tool-error))
+           (should-not prompts)))
+       (should-not
+        (cl-some
+         (lambda (buf)
+           (with-current-buffer buf
+             (and buffer-file-name
+                  (string= (file-truename buffer-file-name)
+                           (file-truename path)))))
+         (buffer-list)))))))
 
 (ert-deftest anvil-org-test-tool-read-by-id-rejects-org-id-resource-uri ()
   "The Layer-3 tool accepts org:// citations, not org-id:// resources."

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -157,4 +157,48 @@
        (should (string-match-p "^\\*\\* TODO Child$" content))
        (should-not (string-match-p "^\\*\\* TODO Child[ \t]+:" content))))))
 
+(ert-deftest anvil-org-test-normalize-tags-json-array-string ()
+  "MCP callers must be able to send multiple tags as a JSON array string."
+  (should (equal '("work" "urgent")
+                 (anvil-org--normalize-tags-to-list
+                  "[\"work\",\"urgent\"]")))
+  (should (equal '("solo")
+                 (anvil-org--normalize-tags-to-list "[\"solo\"]")))
+  (should-not (anvil-org--normalize-tags-to-list "[]"))
+  (should-not (anvil-org--normalize-tags-to-list "  []  ")))
+
+(ert-deftest anvil-org-test-normalize-tags-json-malformed ()
+  "Malformed JSON array strings must surface a validation error."
+  (should-error (anvil-org--normalize-tags-to-list "[unterminated")
+                :type 'anvil-server-tool-error)
+  (should-error (anvil-org--normalize-tags-to-list "[\"a\",\"b\"")
+                :type 'anvil-server-tool-error))
+
+(ert-deftest anvil-org-test-normalize-tags-single-string-preserved ()
+  "Single-tag plain strings keep wrapping behavior unchanged."
+  (should (equal '("urgent")
+                 (anvil-org--normalize-tags-to-list "urgent")))
+  (should-not (anvil-org--normalize-tags-to-list ""))
+  (should-not (anvil-org--normalize-tags-to-list "   ")))
+
+(ert-deftest anvil-org-test-add-todo-json-array-tags ()
+  "Add-todo accepts a JSON array literal as the tags argument."
+  (anvil-org-test--with-temp-org
+   "* Parent\nBody.\n"
+   (lambda (path)
+     (let* ((anvil-org-allowed-files (list path))
+            (anvil-org-allowed-files-enabled t)
+            (parent-uri (concat "org-headline://" path "#Parent"))
+            (response
+             (json-parse-string
+              (anvil-org--tool-add-todo
+               "Child" "TODO" "[\"work\",\"urgent\"]"
+               "Child body." parent-uri)
+              :object-type 'alist))
+            (content (anvil-org-test--read path)))
+       (should (eq t (alist-get 'success response)))
+       (should (string-match-p
+                "^\\*\\* TODO Child[ \t]+:work:urgent:$"
+                content))))))
+
 ;;; anvil-org-test.el ends here

--- a/tests/anvil-py-test.el
+++ b/tests/anvil-py-test.el
@@ -654,6 +654,17 @@ not a create (use `py-add-import' for that)."
                     (insert-file-contents f) (buffer-string))))
         (should (string-match-p "^import subprocess$" text))))))
 
+(ert-deftest anvil-py-test-tool-add-import-accepts-symbol-names ()
+  "Names parsed as symbols (e.g. `(:names (Dict))') should still render as strings."
+  (anvil-py-test--requires-grammar
+    (anvil-py-test--with-edit-copy f
+      (anvil-py--tool-add-import
+       f "(:kind from :from typing :names (Mapping Set))" "t")
+      (let ((text (with-temp-buffer
+                    (insert-file-contents f) (buffer-string))))
+        (should (string-match-p "Mapping" text))
+        (should (string-match-p "Set" text))))))
+
 (ert-deftest anvil-py-test-tool-add-import-accepts-json-spec ()
   "The MCP wrapper should accept JSON specs and coerce names arrays."
   (anvil-py-test--requires-grammar

--- a/tests/anvil-sexp-test.el
+++ b/tests/anvil-sexp-test.el
@@ -340,6 +340,30 @@
       (let ((elc (concat tmp "c")))
         (when (file-exists-p elc) (delete-file elc))))))
 
+(ert-deftest anvil-sexp-test-verify-leaves-no-visiting-buffer ()
+  "verify must not leave a `checkdoc-file' visiting buffer behind.
+`checkdoc-file' uses `find-file-noselect' internally; the previous
+implementation never killed that buffer, which clashed with the
+apply path's `with-temp-buffer' + `write-region' writes and caused
+`ask-user-about-supersession-threat' on the next interactive edit."
+  (anvil-sexp-test--with-sample
+   (lambda (path)
+     (should-not (find-buffer-visiting path))
+     (anvil-sexp--tool-verify path "nil" t)
+     (should-not (find-buffer-visiting path)))))
+
+(ert-deftest anvil-sexp-test-verify-preserves-pre-existing-buffer ()
+  "verify must not kill a buffer the caller had already visited."
+  (anvil-sexp-test--with-sample
+   (lambda (path)
+     (let ((pre (find-file-noselect path)))
+       (unwind-protect
+           (progn
+             (anvil-sexp--tool-verify path "nil" t)
+             (should (buffer-live-p pre))
+             (should (eq pre (find-buffer-visiting path))))
+         (when (buffer-live-p pre) (kill-buffer pre)))))))
+
 
 ;;;; --- ship criterion: stub + verify + restore round-trip ----------------
 

--- a/tests/anvil-sexp-test.el
+++ b/tests/anvil-sexp-test.el
@@ -340,11 +340,79 @@
       (let ((elc (concat tmp "c")))
         (when (file-exists-p elc) (delete-file elc))))))
 
+(ert-deftest anvil-sexp-test-verify-captures-checkdoc-warnings ()
+  "A checkdoc-only issue surfaces as a checkdoc warning diagnostic."
+  (let ((tmp (make-temp-file "anvil-sexp-checkdoc-" nil ".el")))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (insert ";;; anvil-sexp-checkdoc.el --- bad -*- lexical-binding: t; -*-\n"
+                    "\n"
+                    "(defun anvil-sexp-test-undocumented (x)\n"
+                    "  (+ x 1))\n"
+                    "\n"
+                    "(provide 'wrong-feature)\n"
+                    ";;; wrong-footer.el ends here\n"))
+          (let ((r (anvil-sexp--tool-verify tmp "nil" t)))
+            (should (plist-get r :passed))
+            (should
+             (cl-find-if
+              (lambda (d)
+                (and (eq (plist-get d :source) 'checkdoc)
+                     (string-match-p
+                      "Commentary"
+                      (plist-get d :message))))
+              (plist-get r :diagnostics)))
+            (should
+             (cl-find-if
+              (lambda (d)
+                (and (eq (plist-get d :source) 'checkdoc)
+                     (string-match-p
+                      "documentation string"
+                      (plist-get d :message))))
+              (plist-get r :diagnostics)))))
+      (when (file-exists-p tmp) (delete-file tmp)))))
+
+(ert-deftest anvil-sexp-test-verify-checkdoc-does-not-display-windows ()
+  "checkdoc verification must not alter windows or warning buffers."
+  (let ((tmp (make-temp-file "anvil-sexp-checkdoc-ui-" nil ".el")))
+    (cl-labels ((buffer-text
+                 (name)
+                 (when (get-buffer name)
+                   (with-current-buffer name
+                     (buffer-substring-no-properties
+                      (point-min) (point-max))))))
+      (unwind-protect
+          (progn
+            (with-temp-file tmp
+              (insert ";;; anvil-sexp-checkdoc-ui.el --- bad -*- lexical-binding: t; -*-\n"
+                      "\n"
+                      "(defun anvil-sexp-test-ui-warning (x)\n"
+                      "  (+ x 1))\n"
+                      "\n"
+                      "(provide 'wrong-feature)\n"
+                      ";;; wrong-footer.el ends here\n"))
+            (let ((windows-before (mapcar (lambda (w)
+                                            (window-buffer w))
+                                          (window-list (selected-frame)
+                                                       'no-minibuf)))
+                  (warn-before (buffer-text "*warn*"))
+                  (warnings-before (buffer-text "*Warnings*")))
+              (anvil-sexp--tool-verify tmp "nil" t)
+              (should (equal (mapcar (lambda (w)
+                                       (window-buffer w))
+                                     (window-list (selected-frame)
+                                                  'no-minibuf))
+                             windows-before))
+              (should (equal (buffer-text "*warn*") warn-before))
+              (should (equal (buffer-text "*Warnings*") warnings-before))))
+        (when (file-exists-p tmp) (delete-file tmp))))))
+
 (ert-deftest anvil-sexp-test-verify-leaves-no-visiting-buffer ()
-  "verify must not leave a `checkdoc-file' visiting buffer behind.
-`checkdoc-file' uses `find-file-noselect' internally; the previous
-implementation never killed that buffer, which clashed with the
-apply path's `with-temp-buffer' + `write-region' writes and caused
+  "verify must not leave a checkdoc visiting buffer behind.
+Checkdoc verification opens FILE via `find-file-noselect'; keeping
+that buffer after verification would clash with the apply path's
+`with-temp-buffer' + `write-region' writes and cause
 `ask-user-about-supersession-threat' on the next interactive edit."
   (anvil-sexp-test--with-sample
    (lambda (path)

--- a/tests/anvil-test.el
+++ b/tests/anvil-test.el
@@ -158,6 +158,64 @@ MCP Parameters:
             (should (equal "ok-empty" text)))))
     (anvil-server-unregister-tool "anvil-test-underscore" "anvil-test")))
 
+(ert-deftest anvil-test-dispatch-converts-quit-to-tool-error ()
+  "A wrapped tool must turn `quit' into an MCP tool error result."
+  (defun anvil-test--tool-quit (_args)
+    "Signal quit through the helper wrapper.
+
+MCP Parameters:
+  (none)"
+    (anvil-server-with-error-handling
+      (signal 'quit '(minibuffer-quit))))
+  (unwind-protect
+      (progn
+        (anvil-server-register-tool
+         #'anvil-test--tool-quit
+         :id "anvil-test-tool-quit"
+         :description "test"
+         :server-id "anvil-test")
+          (let* ((params '((name . "anvil-test-tool-quit")
+                         (arguments . ())))
+               (resp (anvil-server--handle-tools-call
+                      "t-quit" params
+                      (make-anvil-server-metrics) "anvil-test"))
+               (decoded (json-read-from-string resp))
+               (result (alist-get 'result decoded))
+               (text (alist-get 'text
+                                (aref (alist-get 'content result) 0))))
+          (should (eq t (alist-get 'isError result)))
+          (should (string-match-p "Quit: .*minibuffer-quit" text))))
+    (anvil-server-unregister-tool "anvil-test-tool-quit" "anvil-test")))
+
+(ert-deftest anvil-test-process-jsonrpc-catches-raw-quit ()
+  "Top-level JSON-RPC dispatch must serialize uncaught `quit' as JSON."
+  (defun anvil-test--raw-quit (_args)
+    "Signal quit without wrapping.
+
+MCP Parameters:
+  (none)"
+    (signal 'quit '(minibuffer-quit)))
+  (unwind-protect
+      (progn
+        (anvil-server-register-tool
+         #'anvil-test--raw-quit
+         :id "anvil-test-raw-quit"
+         :description "test"
+         :server-id "anvil-test")
+        (let* ((anvil-server--running t)
+               (request
+                (anvil-server-create-tools-call-request
+                 "anvil-test-raw-quit" 77 nil))
+               (resp (anvil-server-process-jsonrpc request "anvil-test"))
+               (decoded (json-read-from-string resp))
+               (rpc-error (alist-get 'error decoded)))
+          (should rpc-error)
+          (should (= anvil-server-jsonrpc-error-internal
+                     (alist-get 'code rpc-error)))
+          (should (string-match-p "Quit"
+                                  (alist-get 'message rpc-error)))))
+    (anvil-server-unregister-tool "anvil-test-raw-quit" "anvil-test")))
+
 (ert-deftest anvil-test-schema-includes-real-params ()
   "JSON schema must still include non-underscore args."
   (defun anvil-test--tool-with-arg (task_id)


### PR DESCRIPTION

## Summary

- Restore missing non-IDE fixes from the fork branch onto `develop`
- Cover package metadata, org MCP boundary handling, sexp/elisp tooling, py import spec coercion, eval async
reporting, cron stale-result handling, and file tool contract docs
- Add server-side quit handling during MCP dispatch

## Testing

- Focused ERT suite: 183 passed, 0 unexpected
- Server quit handling tests: 31 passed, 0 unexpected
