### PR TITLE
fix(server): add anvil-server-status command (closes #19)

### DIFF
--- a/anvil-server-commands.el
+++ b/anvil-server-commands.el
@@ -72,6 +72,17 @@ See also: `anvil-server-start'"
     (message "%s" (anvil-server-metrics-summary)))
   t)
 
+;;;###autoload
+(defun anvil-server-status ()
+  "Display the main MCP server's running state.
+Prints `Running' or `Stopped' via `message', mirroring
+`anvil-worker-status' for the worker pool.
+
+For full setup details (registered tools, resources, client config
+snippet), use `anvil-server-describe-setup'."
+  (interactive)
+  (message "MCP server: %s" (if anvil-server--running "Running" "Stopped")))
+
 (defun anvil-server--batch-emit-response (resp framing-p)
   "Emit RESP to stdout, framed if FRAMING-P is non-nil.
 

--- a/tests/anvil-test.el
+++ b/tests/anvil-test.el
@@ -10,6 +10,7 @@
 (require 'json)
 (require 'anvil)
 (require 'anvil-server)
+(require 'anvil-server-commands)
 (require 'anvil-server-metrics)
 ;; `anvil-offload-stub' provides tiny fixture handlers (pid / boom) so
 ;; the `:offload' dispatch tests can load them into the subprocess by
@@ -36,6 +37,21 @@
 (ert-deftest anvil-test-describe-setup-command ()
   "Verify describe-setup is callable."
   (should (fboundp 'anvil-describe-setup)))
+
+(ert-deftest anvil-test-server-status-command ()
+  "`anvil-server-status' is bound, interactive, and reports the
+running flag in the format the README documents (`Running' /
+`Stopped')."
+  (should (fboundp 'anvil-server-status))
+  (should (commandp 'anvil-server-status))
+  (let ((anvil-server--running t))
+    (should (string-match-p "Running"
+                            (let ((inhibit-message t))
+                              (anvil-server-status)))))
+  (let ((anvil-server--running nil))
+    (should (string-match-p "Stopped"
+                            (let ((inhibit-message t))
+                              (anvil-server-status))))))
 
 ;;;; --- MCP parameter validator ------------------------------------------
 


### PR DESCRIPTION
## Summary

Add the `anvil-server-status' interactive command — the README has
documented `(anvil-server-status)` as the way to check the main MCP
server state, but the function was never defined (issue #19).

The new command mirrors `anvil-worker-status' for the worker pool:
prints `\"Running\"` or `\"Stopped\"` via `message`. Full setup details
(registered tools, resources, client config snippet) remain on
`anvil-server-describe-setup'.

## Files changed

- `anvil-server-commands.el` — new `;;;###autoload` defun (11 lines)
- `tests/anvil-test.el` — focused ERT covering fboundp / commandp / message format for both states (16 lines, +1 require)

## Testing

- Focused: `tests/anvil-test.el` 32/32 pass (was 31/31, +1 new test)
- Full: `make test-all` — 1673/1732 pass, 0 failed, 22.4s (+1 vs develop, all from the new test)

Closes #19.