### PR TITLE
docs: fix anvil installer master keyword

### DIFF
--- a/README.org
+++ b/README.org
@@ -143,7 +143,7 @@ installed.
 ;; async-installer
 (async-installer-git-add "https://github.com/zawatton/anvil.el.git"
                          :tag "v1.1.1"
-                         :main "anvil.el")
+                         :master "anvil.el")
 
 ;; or straight.el
 (straight-use-package


### PR DESCRIPTION
## Summary
- update the README async-installer snippet for anvil.el to use :master instead of :main

## Verification
- git diff --check