### PR TITLE
fix(mcp): respect optional fields and preserve window layout

### DIFF
--- a/anvil-file.el
+++ b/anvil-file.el
@@ -2170,7 +2170,7 @@ MCP Parameters:
                     (req  (or (alist-get 'required f)
                               (alist-get "required" f nil nil #'equal))))
                 (append (list :name name :regexp re)
-                        (when (and req (not (eq req :null)))
+                        (when (eq req t)
                           (list :required t)))))
             fields-raw))
           (max-blocks (funcall get "max-blocks"))

--- a/anvil-sexp.el
+++ b/anvil-sexp.el
@@ -1044,7 +1044,8 @@ leak in."
                 (byte-compile-dest-file-function (lambda (_) tmp-elc))
                 (byte-compile-verbose nil))
             (condition-case err
-                (setq ok (byte-compile-file file))
+                (save-window-excursion
+                  (setq ok (byte-compile-file file)))
               (error
                (with-current-buffer log-buf
                  (goto-char (point-max))

--- a/tests/anvil-file-test.el
+++ b/tests/anvil-file-test.el
@@ -820,6 +820,39 @@ Uses a fixture whose target line is already on disk so no write fires."
                           (plist-get res :matches))))
          (should (equal '("1" "3") ids)))))))
 
+(ert-deftest anvil-code-extract-test-tool-required-false-is-optional ()
+  "MCP JSON `required: false' must not mark a field as required."
+  (anvil-file-test--with-tmp-ts
+   "ITEM 1\n  name = \"A\"\n"
+   (lambda (path)
+     (let* ((spec-json
+             (json-serialize
+              '((block-start . "^ITEM \\([0-9]+\\)")
+                (fields . [((name . "missing")
+                             (regexp . "missing = \\([0-9]+\\)")
+                             (required . :false))]))
+              :false-object :false))
+            (res (read (anvil-file--tool-code-extract-pattern path spec-json))))
+       (should (= 1 (plist-get res :total)))
+       (should (= 1 (plist-get res :returned)))
+       (should (= 0 (plist-get res :skipped)))))))
+
+(ert-deftest anvil-code-extract-test-tool-required-true-skips ()
+  "MCP JSON `required: true' still skips blocks with missing fields."
+  (anvil-file-test--with-tmp-ts
+   "ITEM 1\n  name = \"A\"\n"
+   (lambda (path)
+     (let* ((spec-json
+             (json-serialize
+              '((block-start . "^ITEM \\([0-9]+\\)")
+                (fields . [((name . "missing")
+                             (regexp . "missing = \\([0-9]+\\)")
+                             (required . t))]))))
+            (res (read (anvil-file--tool-code-extract-pattern path spec-json))))
+       (should (= 1 (plist-get res :total)))
+       (should (= 0 (plist-get res :returned)))
+       (should (= 1 (plist-get res :skipped)))))))
+
 (ert-deftest anvil-code-extract-test-required-error ()
   "Missing :required field with :on-missing-required 'error aborts."
   (anvil-file-test--with-tmp-ts

--- a/tests/anvil-sexp-test.el
+++ b/tests/anvil-sexp-test.el
@@ -373,6 +373,33 @@
               (plist-get r :diagnostics)))))
       (when (file-exists-p tmp) (delete-file tmp)))))
 
+(ert-deftest anvil-sexp-test-verify-byte-compile-does-not-display-windows ()
+  "Byte-compile warnings must not alter the user's window layout."
+  (let ((tmp (make-temp-file "anvil-sexp-bytecomp-ui-" nil ".el"))
+        (window-config (current-window-configuration)))
+    (unwind-protect
+        (progn
+          (with-temp-file tmp
+            (insert ";;; anvil-sexp-bytecomp-ui.el --- missing cookie\n"
+                    ";;; Commentary:\n;; Warning fixture.\n;;; Code:\n"
+                    "(defun anvil-sexp-test-bytecomp-ui-warning () 1)\n"
+                    "(provide 'anvil-sexp-bytecomp-ui)\n"
+                    ";;; anvil-sexp-bytecomp-ui.el ends here\n"))
+          (let ((windows-before (mapcar (lambda (w)
+                                          (window-buffer w))
+                                        (window-list (selected-frame)
+                                                     'no-minibuf))))
+            (anvil-sexp--tool-verify tmp nil "nil")
+            (should (equal (mapcar (lambda (w)
+                                     (window-buffer w))
+                                   (window-list (selected-frame)
+                                                'no-minibuf))
+                           windows-before))))
+      (set-window-configuration window-config)
+      (when (file-exists-p tmp) (delete-file tmp))
+      (let ((elc (concat tmp "c")))
+        (when (file-exists-p elc) (delete-file elc))))))
+
 (ert-deftest anvil-sexp-test-verify-checkdoc-does-not-display-windows ()
   "checkdoc verification must not alter windows or warning buffers."
   (let ((tmp (make-temp-file "anvil-sexp-checkdoc-ui-" nil ".el")))


### PR DESCRIPTION
Treat only literal JSON true as required in code-extract-pattern so
JSON required: false is not interpreted as a required field.

Also wrap sexp byte compilation in save-window-excursion to prevent
byte-compiler warnings from altering the user's window layout.

Add regression tests for both MCP edge cases.