### PR TITLE
Add anvil-modes-allow-buffer-modify to allow co-editing

### DIFF
--- a/README.ja.org
+++ b/README.ja.org
@@ -188,6 +188,7 @@ Anvil の default install は *約 40 個の MCP ツール* を提供します (
 | =anvil-worker= | 時間のかかる処理 (OCR、PDF 変換、ファイル一括走査など) を裏の別 Emacs に逃がす。対話中の Emacs はフリーズしない |
 | 大規模 org ファイルの編集 | 1.2 MB 以上の org も末尾欠損なく編集 (Windows ファイルマウント問題を回避) |
 | LLM クライアント非依存 | Claude Code / Claude Desktop / GPT / Ollama 経由のローカル LLM、すべて MCP で繋がる |
+| =anvil-modes-allow-buffer-modify= | Anvil ツールがファイルを訪れるのではなくライブバッファを直接変更するように major mode を設定。未保存の編集を保持します。 |
 
 数値の根拠と詳細なケーススタディは [[https://github.com/zawatton/anvil.el/blob/master/README.ja.org#効率性--anvil-が-ai-トークンを節約する理由][効率性 — Anvil が AI トークンを節約する理由]] にあります。
 全モジュール一覧は [[https://github.com/zawatton/anvil.el/blob/master/README.ja.org#モジュール][モジュール]] を参照。
@@ -622,6 +623,37 @@ user 向けです。
 ;; Anvil を起動
 (anvil-enable)
 (anvil-server-start)
+#+end_src
+
+** バッファ優先編集 — anvil-modes-allow-buffer-modify
+
+デフォルトでは、anvil の org 編集ツール (update-todo-state, add-todo,
+rename-headline, edit-body) は *ディスク優先* ポリシーを採用しています。
+ファイルをテンポラリバッファに読み込み、編集を適用し、結果をディスクに書き出し、
+訪問中のバッファがあればリフレッシュします。いずれかのバッファに未保存の変更がある
+場合は操作が拒否されます — anvil は人間が作業中の編集を上書きしないからです。
+
+=anvil-modes-allow-buffer-modify= に major mode のリストを設定すると、
+オープン中のバッファがその mode にマッチするファイルについて、anvil は
+*バッファ優先* ポリシーに切り替えます:
+
+1. ファイルを訪問している最初のバッファを見つけます
+   (indirect バッファは base バッファを辿ります)。
+2. バッファに既に未保存の変更があるか確認します。
+3. ライブバッファ内で直接編集を行います。
+4. 編集前にバッファがクリーンだった場合 *のみ* 保存します —
+   作業中の編集を保持するため、未保存の変更があった場合は保存しません。
+
+つまり、AI エージェントと人間が同じファイルで共同作業する際、
+エージェントが書きかけの編集を強制保存することはありません。
+
+#+begin_src emacs-lisp
+;; org ファイルのみバッファ優先編集を有効化
+(setq anvil-modes-allow-buffer-modify '(org-mode))
+
+;; または、全オープンバッファで有効化
+;; (fundamental-mode は特別扱いで、あらゆる major mode にマッチします)
+(setq anvil-modes-allow-buffer-modify '(fundamental-mode))
 #+end_src
 
 ** Browser モジュール（オプション）

--- a/README.org
+++ b/README.org
@@ -271,6 +271,7 @@ sister package).  Highlights:
 | =anvil-worker= | Dispatch long-running tasks (OCR, PDF conversion, batch file scans) to a separate background Emacs. The interactive Emacs never freezes |
 | Large org file editing | Edit org files of 1.2 MB or more without truncation (avoids the Windows file-mount issue) |
 | LLM client agnostic | Claude Code / Claude Desktop / GPT / local LLMs via Ollama — all speak through MCP |
+| =anvil-modes-allow-buffer-modify= | Configure major modes where Anvil tools modify live buffers directly rather than visiting files, preserving unsaved changes. |
 
 For numerical evidence and detailed case studies, see [[https://github.com/zawatton/anvil.el#efficiency--why-anvil-saves-ai-tokens][Efficiency — why Anvil saves AI tokens]].
 For the full module list, see [[https://github.com/zawatton/anvil.el#modules][Modules]].
@@ -676,6 +677,39 @@ budget goes to reasoning about your code, not re-reading it.
 ;; Start anvil
 (anvil-enable)
 (anvil-server-start)
+#+end_src
+
+** Buffer-first editing — anvil-modes-allow-buffer-modify
+
+By default, anvil's org-modifying tools (update-todo-state, add-todo,
+rename-headline, edit-body) use a *disk-first* policy: they read
+the file into a temporary buffer, apply the edit, write the result
+to disk, and refresh any visiting buffers.  If any buffer has unsaved
+modifications, the operation is refused — anvil will not clobber
+your in-progress edits.
+
+When =anvil-modes-allow-buffer-modify= is set to a list of major
+modes, anvil switches to a *buffer-first* policy for files whose
+open buffers match one of those modes:
+
+1. Locate the first buffer visiting the file (following indirect
+   buffers to their base buffer).
+2. Note whether the buffer already has unsaved modifications.
+3. Make the edit directly in the live buffer.
+4. Only save the buffer if it did *not* have unsaved modifications
+   before the edit — preserving any in-progress user work.
+
+This means an AI agent and a human can collaborate on the same
+file without the agent forcing a save that would commit half-finished
+edits.
+
+#+begin_src emacs-lisp
+;; Enable buffer-first editing for org files only
+(setq anvil-modes-allow-buffer-modify '(org-mode))
+
+;; Or enable it for every open buffer (fundamental-mode is a
+;; special case that matches any major mode)
+(setq anvil-modes-allow-buffer-modify '(fundamental-mode))
 #+end_src
 
 ** User config — Emacs vs NeLisp standalone

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -232,14 +232,18 @@ Check your Emacs hooks (`before-revert-hook', \
 `after-revert-hook', `revert-buffer-function')"
                 file-path (error-message-string err))))))))))
 
-(defun anvil-org--complete-and-save (file-path response-alist)
-  "Create ID if needed, save FILE-PATH, return JSON.
+(defun anvil-org--complete (file-path response-alist &optional no-save)
+  "Create ID if needed, maybe save FILE-PATH, return JSON.
 Creates or gets an Org ID for the current headline and returns it.
 FILE-PATH is the path to save the buffer contents to.
-RESPONSE-ALIST is an alist of response fields."
+RESPONSE-ALIST is an alist of response fields.
+When NO-SAVE is non-nil, the Org ID is created but the buffer is
+neither written to disk nor refreshed — the caller is responsible
+for managing the buffer's saved state."
   (let ((id (org-id-get-create)))
-    (write-region (point-min) (point-max) file-path)
-    (anvil-org--refresh-file-buffers file-path)
+    (unless no-save
+      (write-region (point-min) (point-max) file-path)
+      (anvil-org--refresh-file-buffers file-path))
     (json-encode
      (append
       `((success . t))
@@ -248,15 +252,20 @@ RESPONSE-ALIST is an alist of response fields."
 
 (defun anvil-org--fail-if-modified (file-path operation)
   "Check if FILE-PATH has unsaved change in any buffer.
-OPERATION is a string describing the operation for error messages."
-  (dolist (buf (buffer-list))
-    (with-current-buffer buf
-      (when (and (buffer-file-name)
-                 (string= (buffer-file-name) file-path)
-                 (buffer-modified-p))
-        (anvil-org--tool-validation-error
-         "Cannot %s: file has unsaved changes in buffer"
-         operation)))))
+OPERATION is a string describing the operation for error messages.
+
+When a live buffer's major mode is in `anvil-modes-allow-buffer-modify',
+unsaved changes are permitted — the edit will happen buffer-first and
+only be saved if the buffer was clean beforehand."
+  (unless (anvil--buffer-first-viable-p file-path)
+    (dolist (buf (buffer-list))
+      (with-current-buffer buf
+        (when (and (buffer-file-name)
+                   (string= (buffer-file-name) file-path)
+                   (buffer-modified-p))
+          (anvil-org--tool-validation-error
+           "Cannot %s: file has unsaved changes in buffer"
+           operation))))))
 
 (defmacro anvil-org--with-org-file (file-path &rest body)
   "Execute BODY in a temp Org buffer with file at FILE-PATH."
@@ -267,33 +276,60 @@ OPERATION is a string describing the operation for error messages."
      (goto-char (point-min))
      ,@body))
 
-(defmacro anvil-org--modify-and-save
+(defmacro anvil-org--modify
     (file-path operation response-alist &rest body)
   "Execute BODY to modify Org file at FILE-PATH, then save result.
+
 First validates that FILE-PATH has no unsaved changes (using
-OPERATION for error messages).  Then executes BODY in a temp buffer
-set up for the Org file.  After BODY executes, creates an Org ID if
-needed, saves the buffer, refreshes any visiting buffers, and
-returns the result of `anvil-org--complete-and-save' with FILE-PATH
-and RESPONSE-ALIST.
+OPERATION for error messages), unless the file's major mode
+appears in `anvil-modes-allow-buffer-modify'.
+
+Two execution paths:
+
+1. Buffer-first (when `anvil--buffer-first-viable-p' returns
+   non-nil): edits are made directly in the first live buffer
+   visiting FILE-PATH.  If the buffer had unsaved modifications
+   before the edit, the buffer is NOT saved — preserving any
+   in-progress user edits.  Otherwise the buffer is saved and
+   refreshed as normal.
+
+2. Disk-first (default): reads the file into a temp buffer,
+   executes BODY, then writes the result to disk and refreshes
+   all visiting buffers.  Unsaved changes in any buffer raise an
+   error before the edit proceeds.
+
 BODY can access FILE-PATH, OPERATION, and RESPONSE-ALIST as
 variables."
   (declare (indent 3) (debug (form form form body)))
-  `(progn
-     (anvil-org--fail-if-modified ,file-path ,operation)
-     (with-temp-buffer
-       (unwind-protect
-           (progn
-             (insert-file-contents ,file-path)
-             (set-visited-file-name ,file-path t)
-             (set-buffer-modified-p nil)
-             (org-mode)
-             (goto-char (point-min))
-             ,@body
-             (anvil-org--complete-and-save ,file-path ,response-alist))
-         ;; Do not let failed tool calls prompt about killing the
-         ;; temporary file-visiting buffer.
-         (set-buffer-modified-p nil)))))
+  `(if-let ((viable (anvil--buffer-first-viable-p ,file-path)))
+       ;; Buffer-first path
+       (let ((buf (car viable))
+             (was-modified (cdr viable)))
+         (with-current-buffer buf
+           (save-restriction
+             (widen)
+             (save-excursion
+               ,@body
+               ;; Complete — save only if the buffer was clean.
+               (anvil-org--complete
+                ,file-path ,response-alist was-modified)))))
+     ;; Disk-first path
+     (progn
+       (anvil-org--fail-if-modified ,file-path ,operation)
+       (with-temp-buffer
+         (unwind-protect
+             (progn
+               (insert-file-contents ,file-path)
+               (set-visited-file-name ,file-path t)
+               (set-buffer-modified-p nil)
+               (org-mode)
+               (goto-char (point-min))
+               ,@body
+               (anvil-org--complete
+                ,file-path ,response-alist))
+           ;; Do not let failed tool calls prompt about killing the
+           ;; temporary file-visiting buffer.
+           (set-buffer-modified-p nil))))))
 
 (defun anvil-org--find-allowed-file-with-id
     (id &optional not-found-fn file-access-fn)
@@ -307,10 +343,10 @@ versus resource callers."
         (file-access-fn
          (or file-access-fn #'anvil-org--tool-file-access-error)))
     (if-let* ((id-file (org-id-find-id-file id)))
-      ;; ID found in database, check if file is allowed
-      (if-let* ((allowed-file (anvil-org--find-allowed-file id-file)))
-        allowed-file
-        (funcall file-access-fn id))
+        ;; ID found in database, check if file is allowed
+        (if-let* ((allowed-file (anvil-org--find-allowed-file id-file)))
+            allowed-file
+          (funcall file-access-fn id))
       ;; ID not in database - might not exist or DB is stale
       ;; Fall back to searching allowed files manually (only when restriction is on)
       (if (not anvil-org-allowed-files-enabled)
@@ -338,11 +374,11 @@ Throws an error if neither prefix matches."
   `(if-let* ((id
               (anvil-org--extract-uri-suffix
                ,uri anvil-org--uri-id-prefix)))
-     ,id-body
+       ,id-body
      (if-let* ((headline
                 (anvil-org--extract-uri-suffix
                  ,uri anvil-org--uri-headline-prefix)))
-       ,headline-body
+         ,headline-body
        (anvil-org--tool-validation-error
         "Invalid resource URI format: %s"
         ,uri))))
@@ -353,7 +389,7 @@ FILENAME must be an absolute path.
 Returns the full path if allowed, signals an error otherwise."
   (unless (file-name-absolute-p filename)
     (anvil-org--resource-validation-error "Path must be absolute: %s"
-                                        filename))
+                                          filename))
   (let ((allowed-file (anvil-org--find-allowed-file filename)))
     (unless allowed-file
       (anvil-org--resource-file-access-error filename))
@@ -405,10 +441,10 @@ Returns (FILE . HEADLINE) where FILE is the decoded file path and
 HEADLINE is the part after the fragment separator.
 File paths with # characters should be encoded as %23."
   (if-let* ((hash-pos (string-match "#" path-after-protocol)))
-    (cons
-     (anvil-org--decode-file-path
-      (substring path-after-protocol 0 hash-pos))
-     (substring path-after-protocol (1+ hash-pos)))
+      (cons
+       (anvil-org--decode-file-path
+        (substring path-after-protocol 0 hash-pos))
+       (substring path-after-protocol (1+ hash-pos)))
     (cons (anvil-org--decode-file-path path-after-protocol) nil)))
 
 (defun anvil-org--parse-resource-uri (uri)
@@ -494,7 +530,7 @@ Otherwise, navigates using HEADLINE-PATH as title hierarchy."
   (if is-id
       ;; ID case - headline-path contains single ID
       (if-let* ((pos (org-find-property "ID" (car headline-path))))
-        (goto-char pos)
+          (goto-char pos)
         (anvil-org--id-not-found-error (car headline-path)))
     ;; Path case - headline-path contains title hierarchy
     (unless (anvil-org--navigate-to-headline headline-path)
@@ -711,7 +747,7 @@ Throws error for invalid types or malformed JSON."
       (cond
        ((string-empty-p trimmed)
         nil) ; "" / whitespace -> no tags (kept for MCP callers wanting
-             ; to express "no tags" without inventing a sentinel)
+                                        ; to express "no tags" without inventing a sentinel)
        ((eq (aref trimmed 0) ?\[)
         (condition-case err
             (let ((parsed (json-parse-string trimmed
@@ -956,11 +992,11 @@ MCP Parameters:
          (file-path (car parsed))
          (headline-path (cdr parsed)))
     (anvil-org--validate-todo-state new_state)
-    (anvil-org--modify-and-save file-path "update"
-                              `((previous_state
-                                 .
-                                 ,(or current_state ""))
-                                (new_state . ,new_state))
+    (anvil-org--modify file-path "update"
+                                `((previous_state
+                                   .
+                                   ,(or current_state ""))
+                                  (new_state . ,new_state))
       (anvil-org--goto-headline-from-uri
        headline-path (string-prefix-p anvil-org--uri-id-prefix uri))
 
@@ -1036,11 +1072,11 @@ MCP Parameters:
         (setq parent-id id)))
 
     ;; Add the TODO item
-    (anvil-org--modify-and-save file-path "add TODO"
-                              `((file
-                                 .
-                                 ,(file-name-nondirectory file-path))
-                                (title . ,title))
+    (anvil-org--modify file-path "add TODO"
+                                `((file
+                                   .
+                                   ,(file-name-nondirectory file-path))
+                                  (title . ,title))
       (let ((parent-level
              (anvil-org--navigate-to-parent-or-top
               parent-path parent-id)))
@@ -1168,9 +1204,9 @@ MCP Parameters:
          (headline-path (cdr parsed)))
 
     ;; Rename the headline in the file
-    (anvil-org--modify-and-save file-path "rename"
-                              `((previous_title . ,current_title)
-                                (new_title . ,new_title))
+    (anvil-org--modify file-path "rename"
+                                `((previous_title . ,current_title)
+                                  (new_title . ,new_title))
       ;; Navigate to the headline
       (anvil-org--goto-headline-from-uri
        headline-path (string-prefix-p anvil-org--uri-id-prefix uri))
@@ -1219,7 +1255,7 @@ MCP Parameters:
            (file-path (car parsed))
            (headline-path (cdr parsed)))
 
-      (anvil-org--modify-and-save file-path "edit body" nil
+      (anvil-org--modify file-path "edit body" nil
         (anvil-org--goto-headline-from-uri
          headline-path
          (string-prefix-p anvil-org--uri-id-prefix resource_uri))

--- a/anvil.el
+++ b/anvil.el
@@ -293,6 +293,25 @@ All anvil tools are registered under this server ID."
   :type 'string
   :group 'anvil)
 
+(defcustom anvil-modes-allow-buffer-modify nil
+  "List of major modes where anvil edits should modify the live buffer.
+
+When a file being edited has at least one open buffer whose major mode
+is derived from a mode in this list, anvil's org-modifying tools
+(such as `anvil-org--modify') will:
+
+1. Locate the first buffer visiting that file (following indirect
+   buffers to their base buffer).
+2. Note whether the buffer already has unsaved modifications.
+3. Make the edit directly in the live buffer.
+4. Only save the buffer if it did *not* have unsaved modifications
+   before the edit — preserving any in-progress user edits.
+
+Set this to \='(fundamental-mode) to enable buffer-first editing for
+every file open in Emacs, regardless of its major mode."
+  :type '(repeat symbol)
+  :group 'anvil)
+
 ;;; State
 
 (defvar anvil--enabled nil
@@ -376,6 +395,35 @@ Loads all modules listed in `anvil-modules' and `anvil-optional-modules'."
       (dolist (mod anvil-optional-modules)
         (princ (format "  - %s %s\n" mod
                        (if (memq mod anvil--loaded-modules) "[active]" "[not loaded]")))))))
+
+
+;;; Buffer-first modify helpers
+
+(defun anvil--buffer-first-viable-p (file-path)
+  "Return non-nil if FILE-PATH should be edited in a live buffer.
+
+Returns (BUF . WAS-MODIFIED) where BUF is the base buffer visiting
+FILE-PATH and WAS-MODIFIED is t when that buffer had unsaved edits
+before this check.  Returns nil when:
+- `anvil-modes-allow-buffer-modify' is nil, or
+- no buffer visits FILE-PATH, or
+- the visiting buffer's major mode does not derive from any mode
+  listed in `anvil-modes-allow-buffer-modify'.
+
+When the visiting buffer is an indirect buffer its base buffer is
+used instead.
+
+As a special case, `fundamental-mode' matches any mode — set the
+option to \='(fundamental-mode) for buffer-first editing everywhere."
+  (when anvil-modes-allow-buffer-modify
+    (when-let* ((buf (find-buffer-visiting (expand-file-name file-path))))
+      (let ((base (or (buffer-base-buffer buf) buf)))
+        (when (with-current-buffer base
+                (or (memq 'fundamental-mode anvil-modes-allow-buffer-modify)
+                    (cl-some (lambda (m)
+                               (provided-mode-derived-p major-mode m))
+                             anvil-modes-allow-buffer-modify)))
+          (cons base (buffer-modified-p base)))))))
 
 (provide 'anvil)
 ;;; anvil.el ends here

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -9,6 +9,7 @@
 (require 'ert)
 (require 'cl-lib)
 (require 'json)
+(require 'anvil)
 (require 'anvil-org)
 
 (defun anvil-org-test--with-temp-org (content fn)
@@ -198,7 +199,116 @@
             (content (anvil-org-test--read path)))
        (should (eq t (alist-get 'success response)))
        (should (string-match-p
-                "^\\*\\* TODO Child[ \t]+:work:urgent:$"
+                "^\\*\\* TODO Child[ \\t]+:work:urgent:$"
                 content))))))
+
+;;; Buffer-first modify tests
+
+(ert-deftest anvil-org-test-buffer-first-viable-returns-nil-by-default ()
+  "`anvil--buffer-first-viable-p' returns nil when the mode list is nil."
+  (anvil-org-test--with-temp-org "* Test\nBody."
+    (lambda (path)
+      (find-file-noselect path)
+      (unwind-protect
+          (should-not (anvil--buffer-first-viable-p path))
+        (kill-buffer (find-buffer-visiting path))))))
+
+(ert-deftest anvil-org-test-buffer-first-viable-returns-cons-when-matching ()
+  "`anvil--buffer-first-viable-p' returns a cons when the mode matches."
+  (let ((anvil-modes-allow-buffer-modify '(org-mode)))
+    (anvil-org-test--with-temp-org "* Test\nBody."
+      (lambda (path)
+        (find-file-noselect path)
+        (unwind-protect
+            (let ((result (anvil--buffer-first-viable-p path)))
+              (should result)
+              (should (bufferp (car result)))
+              (should-not (cdr result)))
+          (kill-buffer (find-buffer-visiting path)))))))
+
+(ert-deftest anvil-org-test-buffer-first-viable-detects-modified ()
+  "`anvil--buffer-first-viable-p' correctly reports modified state."
+  (let ((anvil-modes-allow-buffer-modify '(org-mode)))
+    (anvil-org-test--with-temp-org "* Test\nBody."
+      (lambda (path)
+        (let ((buf (find-file-noselect path)))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (insert "unsaved change")
+                  (let ((result (anvil--buffer-first-viable-p path)))
+                    (should result)
+                    (should (eq buf (car result)))
+                    (should (cdr result))))
+                (with-current-buffer buf
+                  (set-buffer-modified-p nil)))
+            (kill-buffer buf)))))))
+
+(ert-deftest anvil-org-test-buffer-first-preserves-unsaved-modifications ()
+  "Buffer-first editing does NOT save when the buffer was already modified."
+  (let ((anvil-modes-allow-buffer-modify '(org-mode)))
+    (anvil-org-test--with-temp-org
+     "* Before\nOriginal content.\n"
+     (lambda (path)
+       (let ((buf (find-file-noselect path)))
+         (unwind-protect
+             (let ((anvil-org-allowed-files (list path))
+                   (anvil-org-allowed-files-enabled t))
+               (with-current-buffer buf
+                 (goto-char (point-max))
+                 (insert "User's unsaved work."))
+               (anvil-org--modify path "update"
+                   '((previous_state . "") (new_state . "DONE"))
+                 (goto-char (point-min))
+                 (org-todo "DONE"))
+               (with-current-buffer buf
+                 (should (buffer-modified-p))
+                 (goto-char (point-min))
+                 (should (search-forward "User's unsaved work" nil t))
+                 (goto-char (point-min))
+                 (should (search-forward "DONE" nil t)))
+               (let ((disk-content (anvil-org-test--read path)))
+                 (should-not (string-match-p "DONE" disk-content))
+                 (should (string-match-p "Before" disk-content))))
+           (when (buffer-live-p buf)
+             (with-current-buffer buf
+               (set-buffer-modified-p nil))
+             (kill-buffer buf))))))))
+
+(ert-deftest anvil-org-test-buffer-first-saves-when-clean ()
+  "Buffer-first editing DOES save when the buffer was clean."
+  (let ((anvil-modes-allow-buffer-modify '(org-mode)))
+    (anvil-org-test--with-temp-org
+     "* Before\nOriginal content.\n"
+     (lambda (path)
+       (let ((buf (find-file-noselect path)))
+         (unwind-protect
+             (let ((anvil-org-allowed-files (list path))
+                   (anvil-org-allowed-files-enabled t))
+               (anvil-org--modify path "update"
+                   '((previous_state . "") (new_state . "DONE"))
+                 (goto-char (point-min))
+                 (org-todo "DONE"))
+               (with-current-buffer buf
+                 (should-not (buffer-modified-p)))
+               (let ((disk-content (anvil-org-test--read path)))
+                 (should (string-match-p "DONE" disk-content))
+                 (should (string-match-p "Before" disk-content))))
+           (when (buffer-live-p buf)
+             (with-current-buffer buf
+               (set-buffer-modified-p nil))
+             (kill-buffer buf))))))))
+
+(ert-deftest anvil-org-test-fundamental-mode-matches-everything ()
+  "`fundamental-mode' in the mode list matches org-mode buffers."
+  (let ((anvil-modes-allow-buffer-modify '(fundamental-mode)))
+    (anvil-org-test--with-temp-org "* Test\nBody."
+      (lambda (path)
+        (find-file-noselect path)
+        (unwind-protect
+            (let ((result (anvil--buffer-first-viable-p path)))
+              (should result)
+              (should (bufferp (car result))))
+          (kill-buffer (find-buffer-visiting path)))))))
 
 ;;; anvil-org-test.el ends here


### PR DESCRIPTION
This optionally enables anvil to modify buffers instead of files, which is
useful for when the user and the agent is modifying the same set of files.

When the mode is derived from a mode in `anvil-modes-allow-buffer-modify`, it
will modify the buffer and save it if the buffer was previously saved, otherwise
it will leave it unmodified.  This enables the agent to modify a buffer the user
was changing, and it won't save the in-progress user changes, or make changes
that would obsolete them.

See https://github.com/zawatton/anvil.el/issues/28