### PR TITLE
fix(anvil-eval): use setq-local for delay-mode-hooks in org fast-mode (Emacs 30)

### DIFF
--- a/anvil-eval.el
+++ b/anvil-eval.el
@@ -76,7 +76,12 @@ Set automatically for the duration of each MCP tool call.")
 (defun anvil-eval--org-mode-fast-advice (orig-fn &rest args)
   "Make `org-mode' setup minimal when called inside an MCP tool."
   (if (and anvil-eval-org-fast-mode anvil-eval--in-org-fast-mode)
-      (let ((delay-mode-hooks t))
+      (progn
+        ;; setq-local, not let: Emacs 30's define-derived-mode calls
+        ;; (make-local-variable 'delay-mode-hooks) inside org-mode, which
+        ;; errors if the variable is already let-bound.  Making it
+        ;; buffer-local first turns that call into a harmless no-op.
+        (setq-local delay-mode-hooks t)
         (apply orig-fn args)
         (when (fboundp 'font-lock-mode)
           (font-lock-mode -1))


### PR DESCRIPTION
## Problem

`anvil-eval--org-mode-fast-advice` wraps every `org-mode` call inside an MCP
tool with `(let ((delay-mode-hooks t)) ...)`.  In Emacs 30, `define-derived-mode`
generates code that calls `(make-local-variable 'delay-mode-hooks)` inside the
derived mode function body.  Emacs 30 simultaneously introduced a safety check
that signals an error when `make-local-variable` is called on a variable that
is currently let-bound:

```
Debugger entered--Lisp error: "Making delay-mode-hooks buffer-local while locally let-bound!"
  make-local-variable(delay-mode-hooks)
  #<subr org-mode>()
  anvil-eval--org-mode-fast-advice(#<subr org-mode>)
```

This fires for any anvil org tool that calls `org-mode` inside a temp buffer
(i.e., everything that goes through `anvil-org--with-org-file` or
`anvil-org--modify-and-save`).

## Fix

Replace the `let`-binding with `(setq-local delay-mode-hooks t)` called
**before** `apply`.  The temp buffers anvil uses for org-mode operations are
always discarded after the tool call, so no cleanup is needed.  With the
variable already buffer-local when `org-mode` runs, the subsequent
`(make-local-variable 'delay-mode-hooks)` call inside the mode function is a
harmless no-op.

## Testing

Verified against Emacs 30.2.50 on macOS.  Any anvil org-write tool
(`org-update-todo-state`, `org-claim-task`, etc.) previously produced the
above error; all work correctly after this change.