### PR TITLE
fix(anvil-org): detect blocked TODO state transitions (Issue #31)

### DIFF
--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1016,8 +1016,23 @@ MCP Parameters:
            (or current_state "(no state)")
            (or actual-state "(no state)") "State")))
 
-      ;; Update the state
-      (org-todo new_state))))
+      ;; Update the state.  `org-todo' silently no-ops when the
+      ;; transition is blocked (e.g. `org-enforce-todo-dependencies'
+      ;; with unfinished children, or a custom `org-blocker-hook' that
+      ;; vetoes the change).  Re-read the state from the buffer to
+      ;; detect such a no-op and surface it as an error instead of
+      ;; lying about success.
+      (org-todo new_state)
+      (save-excursion
+        (beginning-of-line)
+        (let ((post-state (org-get-todo-state)))
+          (unless (equal post-state new_state)
+            (anvil-org--tool-validation-error
+             (concat "TODO state change blocked: expected '%s', "
+                     "headline is still '%s' "
+                     "(likely `org-enforce-todo-dependencies' or "
+                     "`org-blocker-hook' rejected the transition)")
+             new_state (or post-state "(no state)"))))))))
 
 ;; PHASE-C-IDE-SPLIT-CANDIDATE: inserts heading + ID + tags + body in real buffer
 (defun anvil-org--tool-add-todo

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -140,6 +140,31 @@
        (should (eq t (alist-get 'success response)))
        (should (string-match-p "^\\* TODO Plain" content))))))
 
+(ert-deftest anvil-org-test-update-todo-state-errors-when-blocked ()
+  "Blocked transitions (org-enforce-todo-dependencies) must surface as errors.
+
+A parent with an unfinished child TODO cannot be marked DONE while
+`org-enforce-todo-dependencies' is non-nil.  `org-todo' silently
+no-ops in that case; the tool must detect the no-op and throw."
+  (anvil-org-test--with-temp-org
+   "* TODO Parent\n** TODO Child\n"
+   (lambda (path)
+     (let* ((anvil-org-allowed-files (list path))
+            (anvil-org-allowed-files-enabled t)
+            (org-enforce-todo-dependencies t)
+            (uri (concat "org-headline://" path "#Parent"))
+            (err (should-error
+                  (anvil-org--tool-update-todo-state uri "TODO" "DONE")
+                  :type 'error))
+            (content (anvil-org-test--read path)))
+       ;; Error message names the blocked transition.
+       (should (string-match-p "blocked" (error-message-string err)))
+       (should (string-match-p "DONE" (error-message-string err)))
+       ;; Disk must still show the parent as TODO, not DONE.
+       (should (string-match-p "^\\* TODO Parent" content))
+       (should-not (string-match-p "^\\* DONE Parent" content))))))
+
+
 (ert-deftest anvil-org-test-add-todo-empty-tags-string ()
   "Empty `tags' string must mean no tags, not a single empty tag."
   (anvil-org-test--with-temp-org


### PR DESCRIPTION
## Summary

Closes #31.

`anvil-org--tool-update-todo-state` (and by extension the MCP `org-update-todo-state` tool) returned `{"success": true, "new_state": "DONE"}` even when the underlying `org-todo` call silently no-opped because `org-enforce-todo-dependencies` (or a custom `org-blocker-hook`) rejected the transition. The file was untouched but the caller was told the change had been applied.

This patch re-reads the headline's TODO state after `org-todo` runs. If it does not match the requested `new_state`, a `tool-validation-error` is thrown that names both the blocked transition and the most likely cause.

## Changes

- `anvil-org.el` — after `(org-todo new_state)`, `(org-get-todo-state)` post-check + `anvil-org--tool-validation-error` on mismatch.
- `tests/anvil-org-test.el` — `anvil-org-test-update-todo-state-errors-when-blocked` sets `org-enforce-todo-dependencies` t, attempts to mark a parent with an unfinished child as DONE, asserts the tool errors out and the file remains unchanged.

## Test plan

- [x] `anvil-org-test-update-todo-state-errors-when-blocked` passes
- [x] `anvil-org-test-update-todo-state-no-state-transition` still passes (success path unaffected)
- [x] Full `anvil-org-test.el` suite 17/17 green on this branch (rebased onto current master)
- [x] Bug reproducer (parent + unfinished child + `org-enforce-todo-dependencies` t) now surfaces a clear error instead of silent `success:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)