### PR TITLE
fix(anvil-nelisp-shims): load real anvil-server before shim guards + regex test revert

### DIFF
--- a/anvil-nelisp-shims.el
+++ b/anvil-nelisp-shims.el
@@ -44,6 +44,18 @@ definitions below do NOT gate on this constant; they use per-symbol
 `unless (fboundp ...)' guards instead so they remain inert under
 regular Emacs but install unconditionally under NeLisp standalone.")
 
+;; Under regular Emacs, ensure the real `anvil-server' loads BEFORE the
+;; per-symbol `unless (fboundp ...)' guards below run, so the guards see
+;; the real functions and become inert.  Without this, transitive load
+;; paths that arrive here before anvil-server (e.g.
+;; `anvil-git' → `anvil-host' → `anvil-config' → this file) would install
+;; the standalone stubs and then `(provide 'anvil-server)' below would
+;; short-circuit the eventual `(require 'anvil-server)' in anvil-git,
+;; leaving `anvil-server--tools' unbound and tool registration broken.
+;; Under NeLisp standalone, anvil-server.el is not on load-path so the
+;; NOERROR require silently returns nil and the stubs install as designed.
+(require 'anvil-server nil t)
+
 (defvar anvil-nelisp-shims--collected-specs nil
   "Reverse-order alist of (SERVER-ID . SPEC-LIST) collected by the shim.
 Populated by every `anvil-server-register-tool[s]' call during module

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -224,7 +224,7 @@ no-ops in that case; the tool must detect the no-op and throw."
             (content (anvil-org-test--read path)))
        (should (eq t (alist-get 'success response)))
        (should (string-match-p
-                "^\\*\\* TODO Child[ \\t]+:work:urgent:$"
+                "^\\*\\* TODO Child[ \t]+:work:urgent:$"
                 content))))))
 
 ;;; Buffer-first modify tests


### PR DESCRIPTION
## Summary

Two follow-ups to the recent PR triage round:

1. **`anvil-nelisp-shims.el` load-order bug** — the per-symbol `(unless (fboundp ...))` guards assumed the real `anvil-server` was loaded by the time the shim file runs, but anvil-git's transitive require chain (`anvil-git → anvil-host → anvil-config → anvil-nelisp-shims`) actually hits the shim file *first*. The stubs installed, then `(provide 'anvil-server)` short-circuited the subsequent `(require 'anvil-server)` inside `anvil-git`, leaving `anvil-server--tools` unbound. Result: `anvil-git-test-enable-registers-tools` failed on master (only failing test in `make test-all`).

   Fix: `(require 'anvil-server nil t)` at the top of `anvil-nelisp-shims.el`, after the `defconst`. Under regular Emacs this loads the real file so the per-symbol guards become inert. Under NeLisp standalone `anvil-server.el` is not on load-path, the NOERROR require returns nil, and the stubs install as before.

2. **`anvil-org-test-add-todo-json-array-tags` regex revert** — PR #30 accidentally changed `[ \t]+` (space|tab character class) to `[ \\t]+` (space|backslash|'t' character class). The test still passed because the actual headline has spaces between title and tags, but the regex no longer covered the original tab case. One-character revert.

## Test plan

- [x] `anvil-git-test-enable-registers-tools` passes (was the only failure on master)
- [x] `make test-all`: 0 failed (previously 1 failed)
- [x] `anvil-org-test-add-todo-json-array-tags` still passes after the regex revert
- [x] No regression in other test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)