### PR TITLE
fix(server): echo the request id in fallback error responses

### DIFF
--- a/anvil-server.el
+++ b/anvil-server.el
@@ -1010,11 +1010,19 @@ normally while standalone silently no-ops."
   (declare (debug t))
   `(condition-case nil (cl-incf ,place) (error nil)))
 
+(defvar anvil-server--current-request-id nil
+  "Request id of the JSON-RPC message currently being dispatched.
+Bound by `anvil-server-process-jsonrpc' around request dispatch so
+that fallback error responses can carry the id of the request that
+failed.  JSON-RPC 2.0 requires error responses to echo the request
+id; a client cannot match an `id: null' error against its pending
+request and may wait forever.")
+
 (defun anvil-server--handle-error (err)
   "Handle error ERR in MCP process by logging and creating an error response.
 Returns a JSON-RPC error response string for internal errors."
   (anvil-server--jsonrpc-error
-   nil
+   anvil-server--current-request-id
    anvil-server-jsonrpc-error-internal
    (format "Internal error: %s" (error-message-string err))))
 
@@ -2026,14 +2034,16 @@ See also: `anvil-server-process-jsonrpc-parsed'"
       (let ((t0 (float-time)))
         (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
           (nelisp--write-stderr-line "[PJ] dispatch-start"))
-        (condition-case err
-            (setq response
-                  (anvil-server--validate-and-dispatch-request
-                   json-object server-id))
-          (quit
-           (setq response (anvil-server--handle-error err)))
-          (error
-           (setq response (anvil-server--handle-error err))))
+        (let ((anvil-server--current-request-id
+               (when json-object (cdr (assq 'id json-object)))))
+          (condition-case err
+              (setq response
+                    (anvil-server--validate-and-dispatch-request
+                     json-object server-id))
+            (quit
+             (setq response (anvil-server--handle-error err)))
+            (error
+             (setq response (anvil-server--handle-error err)))))
         (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
           (nelisp--write-stderr-line
            (format "[PJ] validate+dispatch %.4fs resp-len=%d"

--- a/tests/anvil-server-request-id-test.el
+++ b/tests/anvil-server-request-id-test.el
@@ -1,0 +1,56 @@
+;;; anvil-server-request-id-test.el --- ERT for error response request id -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; JSON-RPC 2.0 requires error responses to echo the id of the request
+;; they answer.  When request dispatch signals (an uncaught `error' or
+;; `quit' inside `anvil-server--validate-and-dispatch-request'), the
+;; fallback `anvil-server--handle-error' used to hard-code `id: null';
+;; an MCP client cannot match `id: null' against its pending numeric id
+;; and waits forever.
+;;
+;; These tests pin the fix: `anvil-server-process-jsonrpc' binds
+;; `anvil-server--current-request-id' from the parsed request before
+;; dispatching, and `anvil-server--handle-error' echoes it.
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'anvil)
+(require 'anvil-server)
+
+(defun anvil-server-request-id-test--dispatch-error (request)
+  "Process REQUEST with dispatch forced to signal; return parsed response."
+  (let ((anvil-server--running t))
+    (cl-letf (((symbol-function 'anvil-server--validate-and-dispatch-request)
+               (lambda (&rest _) (error "boom"))))
+      (json-read-from-string
+       (anvil-server-process-jsonrpc request "request-id-test")))))
+
+(ert-deftest anvil-server-request-id-test-error-echoes-numeric-id ()
+  "A dispatch error response carries the numeric request id."
+  (let ((resp (anvil-server-request-id-test--dispatch-error
+               "{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"tools/list\"}")))
+    (should (equal (alist-get 'id resp) 42))
+    (should (alist-get 'error resp))))
+
+(ert-deftest anvil-server-request-id-test-error-echoes-string-id ()
+  "A dispatch error response carries a string request id unchanged."
+  (let ((resp (anvil-server-request-id-test--dispatch-error
+               "{\"jsonrpc\":\"2.0\",\"id\":\"req-7\",\"method\":\"tools/list\"}")))
+    (should (equal (alist-get 'id resp) "req-7"))
+    (should (alist-get 'error resp))))
+
+(ert-deftest anvil-server-request-id-test-handle-error-defaults-nil ()
+  "Outside dispatch, `anvil-server--handle-error' still emits id null."
+  (let* ((anvil-server--current-request-id nil)
+         (resp (json-read-from-string
+                (anvil-server--handle-error (list 'error "boom")))))
+    ;; json.el reads JSON null as nil by default.
+    (should (null (alist-get 'id resp)))
+    (should (string-match-p "\"id\":null"
+                            (anvil-server--handle-error (list 'error "boom"))))))
+
+(provide 'anvil-server-request-id-test)
+;;; anvil-server-request-id-test.el ends here


### PR DESCRIPTION
## Problem

JSON-RPC 2.0 requires error responses to echo the `id` of the request they answer. When request dispatch signals — an uncaught `error` or `quit` inside `anvil-server--validate-and-dispatch-request` — the fallback `anvil-server--handle-error` hard-codes `id: null`:

```elisp
(anvil-server--jsonrpc-error
 nil   ; <- request id lost
 anvil-server-jsonrpc-error-internal
 ...)
```

An MCP client cannot match an `id: null` error against its pending numeric id, so from the client's perspective the request never completes and it waits forever (or until its own timeout).

## Fix

- New `anvil-server--current-request-id`, bound by `anvil-server-process-jsonrpc` from the parsed request object around the dispatch `condition-case`.
- `anvil-server--handle-error` echoes it instead of hard-coding `nil`.

Outside dispatch the variable is `nil`, so other callers keep the previous `id: null` shape.

## Tests

`tests/anvil-server-request-id-test.el`: numeric id echoed, string id echoed, and the out-of-dispatch default remains `id: null`.

```
Ran 3 tests, 3 results as expected, 0 unexpected
```