### PR TITLE
fix(org): compare buffer paths with anvil-org--paths-equal-p

### DIFF
--- a/anvil-org.el
+++ b/anvil-org.el
@@ -228,7 +228,7 @@ Preserves narrowing state across the refresh operation."
   (dolist (buf (buffer-list))
     (with-current-buffer buf
       (when-let* ((buf-file (buffer-file-name)))
-        (when (string= buf-file file-path)
+        (when (anvil-org--paths-equal-p buf-file file-path)
           (let ((was-narrowed (buffer-narrowed-p))
                 (narrow-start nil)
                 (narrow-end nil))
@@ -286,7 +286,7 @@ only be saved if the buffer was clean beforehand."
     (dolist (buf (buffer-list))
       (with-current-buffer buf
         (when (and (buffer-file-name)
-                   (string= (buffer-file-name) file-path)
+                   (anvil-org--paths-equal-p (buffer-file-name) file-path)
                    (buffer-modified-p))
           (anvil-org--tool-validation-error
            "Cannot %s: file has unsaved changes in buffer"

--- a/tests/anvil-org-symlink-paths-test.el
+++ b/tests/anvil-org-symlink-paths-test.el
@@ -1,0 +1,74 @@
+;;; anvil-org-symlink-paths-test.el --- ERT for symlink-alias path comparison -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `anvil-org--fail-if-modified' and `anvil-org--refresh-file-buffers'
+;; compared `buffer-file-name' against the tool's file path with
+;; `string='.  A buffer visiting the same file through a symlinked
+;; directory (or any path alias) never matches, so:
+;;
+;;   * the unsaved-changes guard is silently bypassed — a mutating
+;;     org tool proceeds disk-first while the aliased buffer holds
+;;     unsaved edits, which are then lost on the next revert;
+;;   * after a successful disk write the aliased buffer is never
+;;     refreshed and silently diverges from disk.
+;;
+;; The project already has `anvil-org--paths-equal-p' (truename-based)
+;; for exactly this; these tests pin its use at both call sites.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil)
+(require 'anvil-org)
+
+(defmacro anvil-org-symlink-paths-test--with-alias (&rest body)
+  "Run BODY with REAL-FILE and ALIAS-FILE bound to the same org file.
+ALIAS-FILE reaches the file through a symlinked directory."
+  `(let* ((dir (make-temp-file "anvil-symlink-test" t))
+          (real-dir (expand-file-name "real" dir))
+          (link-dir (expand-file-name "link" dir))
+          (real-file (progn (make-directory real-dir)
+                            (expand-file-name "tasks.org" real-dir)))
+          (alias-file (progn (make-symbolic-link real-dir link-dir)
+                             (expand-file-name "tasks.org" link-dir))))
+     (unwind-protect
+         (progn
+           (with-temp-file real-file
+             (insert "* Heading\nBody.\n"))
+           ,@body)
+       (when-let* ((buf (find-buffer-visiting real-file)))
+         (with-current-buffer buf (set-buffer-modified-p nil))
+         (kill-buffer buf))
+       (when-let* ((buf (find-buffer-visiting alias-file)))
+         (with-current-buffer buf (set-buffer-modified-p nil))
+         (kill-buffer buf))
+       (delete-directory dir t))))
+
+(ert-deftest anvil-org-symlink-paths-test-fail-if-modified-sees-alias ()
+  "Unsaved changes in a buffer visiting via a symlink block the edit."
+  (anvil-org-symlink-paths-test--with-alias
+   (let ((find-file-visit-truename nil))
+     (with-current-buffer (find-file-noselect alias-file)
+       (goto-char (point-max))
+       (insert "unsaved edit\n")
+       ;; Buffer records the aliased path, tool receives the real path.
+       (should-not (string= (buffer-file-name) real-file))
+       (should-error
+        (anvil-org--fail-if-modified real-file "test edit")
+        :type 'anvil-server-tool-error)))))
+
+(ert-deftest anvil-org-symlink-paths-test-refresh-sees-alias ()
+  "A clean buffer visiting via a symlink is refreshed after a disk write."
+  (anvil-org-symlink-paths-test--with-alias
+   (let ((find-file-visit-truename nil))
+     (with-current-buffer (find-file-noselect alias-file)
+       (should-not (string= (buffer-file-name) real-file))
+       (with-temp-file real-file
+         (insert "* Heading\nNew body from disk.\n"))
+       (anvil-org--refresh-file-buffers real-file)
+       (should (string-match-p "New body from disk"
+                               (buffer-string)))))))
+
+(provide 'anvil-org-symlink-paths-test)
+;;; anvil-org-symlink-paths-test.el ends here


### PR DESCRIPTION
## Problem

`anvil-org--fail-if-modified` and `anvil-org--refresh-file-buffers` compare `buffer-file-name` against the tool's file path with `string=`. A buffer that visits the same file through a symlinked directory (or any other path alias) never matches, so:

- the **unsaved-changes guard is silently bypassed** — a mutating org tool proceeds disk-first while the aliased buffer holds unsaved edits, which are then clobbered by the next refresh/revert (data loss);
- after a successful disk write the aliased buffer is **never refreshed** and silently diverges from disk.

The project already has `anvil-org--paths-equal-p` (truename-based comparison) for exactly this situation — it's used for the allowed-files check — but these two call sites still use raw `string=`.

## Fix

Use `anvil-org--paths-equal-p` at both call sites. Two-line change.

## Tests

`tests/anvil-org-symlink-paths-test.el` builds a real-dir/symlink-dir pair and pins both behaviors:

- modified buffer visiting via the symlink → `anvil-org--fail-if-modified` signals;
- clean buffer visiting via the symlink → refreshed after a disk write.

```
Ran 2 tests, 2 results as expected, 0 unexpected
```