### PR TITLE
fix(eval): tear down emacsclient when server-execute exits abnormally

### DIFF
--- a/anvil-eval.el
+++ b/anvil-eval.el
@@ -388,6 +388,42 @@ MCP Parameters: (none)"
 (defvar anvil-eval--server-id "anvil"
   "Server ID used when registering eval tools.")
 
+(declare-function server-quote-arg "server")
+
+(defun anvil-eval--server-execute-cleanup-advice (orig-fn &rest args)
+  "Guarantee emacsclient teardown when `server-execute' exits abnormally.
+Without this, a non-local exit during the eval body — e.g.
+`(top-level)' selected in the debugger, or any unwound `throw' —
+skips the reply / `server-delete-client' step at the end of
+`server-execute'.  The emacsclient process is then blocked in
+`recvfrom' on a still-open server connection that will never
+receive its `-print' reply, hanging whatever owns it (for the MCP
+stdio transport, the anvil-stdio.sh bridge and its client).
+
+We wrap the call in an `unwind-protect': on abnormal unwind, if
+this looks like a wait-for-reply client (`dontkill' is nil and the
+connection is still open), synthesise an `-error' reply and tear
+the connection down so emacsclient can exit cleanly.  When
+`dontkill' is non-nil — `-window-system' / `-tty' / `-resume' /
+`-suspend' clients — we leave the connection alone, matching
+upstream `server-execute' behaviour."
+  (let ((proc (nth 0 args))
+        (dontkill (nth 4 args)))
+    (unwind-protect
+        (apply orig-fn args)
+      (when (and (null dontkill)
+                 (processp proc)
+                 (process-live-p proc)
+                 (eq (process-status proc) 'open))
+        (ignore-errors
+          (process-send-string
+           proc
+           (concat "-error "
+                   (server-quote-arg
+                    "anvil: server-execute aborted by non-local exit")
+                   "\n")))
+        (ignore-errors (delete-process proc))))))
+
 (defun anvil-eval-enable ()
   "Register eval tools and install advice."
   (setq anvil-eval--server-id
@@ -400,6 +436,8 @@ MCP Parameters: (none)"
   (advice-add 'org-mode :around #'anvil-eval--org-mode-fast-advice)
   (advice-add 'anvil-server-process-jsonrpc
               :around #'anvil-eval--request-mutex-advice)
+  (advice-add 'server-execute
+              :around #'anvil-eval--server-execute-cleanup-advice)
   ;; Register tools
   (anvil-server-register-tool
    #'anvil-eval--sync
@@ -474,7 +512,9 @@ NeLisp globals across calls, so it behaves as a practical MCP REPL."
                  #'anvil-eval--org-fast-mode-wrapper)
   (advice-remove 'org-mode #'anvil-eval--org-mode-fast-advice)
   (advice-remove 'anvil-server-process-jsonrpc
-                 #'anvil-eval--request-mutex-advice))
+                 #'anvil-eval--request-mutex-advice)
+  (advice-remove 'server-execute
+                 #'anvil-eval--server-execute-cleanup-advice))
 
 (provide 'anvil-eval)
 ;;; anvil-eval.el ends here

--- a/tests/anvil-eval-server-execute-test.el
+++ b/tests/anvil-eval-server-execute-test.el
@@ -1,0 +1,86 @@
+;;; anvil-eval-server-execute-test.el --- ERT for server-execute cleanup advice -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; A non-local exit during `server-execute' — `(top-level)' chosen in
+;; the debugger, or any `throw' unwinding past the eval body — skips
+;; the `-print' reply and `server-delete-client' teardown at the end
+;; of `server-execute'.  The emacsclient process then blocks in
+;; `recvfrom' forever on a connection that will never answer, hanging
+;; the stdio bridge that owns it.
+;;
+;; `anvil-eval--server-execute-cleanup-advice' wraps `server-execute'
+;; in `unwind-protect': on abnormal unwind of a wait-for-reply client
+;; (dontkill nil, connection still open) it sends an `-error' reply
+;; and deletes the connection.  These tests pin that contract using a
+;; real localhost socket pair so `process-status' is genuinely `open'.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'server)
+(require 'anvil)
+(require 'anvil-eval)
+
+(defmacro anvil-eval-server-execute-test--with-open-process (var &rest body)
+  "Bind VAR to a live network process with status `open' around BODY."
+  (declare (indent 1))
+  `(let* ((srv (make-network-process
+                :name "anvil-cleanup-test-srv" :server t
+                :host 'local :service t :family 'ipv4 :noquery t))
+          (,var (make-network-process
+                 :name "anvil-cleanup-test-cli"
+                 :host 'local :service (process-contact srv :service)
+                 :family 'ipv4 :noquery t)))
+     (unwind-protect
+         (progn ,@body)
+       (ignore-errors (delete-process ,var))
+       (ignore-errors (delete-process srv)))))
+
+(ert-deftest anvil-eval-server-execute-test-abnormal-exit-replies ()
+  "Abnormal unwind sends an -error reply and deletes the connection."
+  (anvil-eval-server-execute-test--with-open-process proc
+    (let (sent deleted)
+      (cl-letf (((symbol-function 'process-send-string)
+                 (lambda (_p s) (setq sent s)))
+                ((symbol-function 'delete-process)
+                 (lambda (p) (setq deleted p))))
+        (catch 'abort
+          (anvil-eval--server-execute-cleanup-advice
+           (lambda (&rest _) (throw 'abort nil))
+           proc nil nil nil nil nil nil)))
+      (should sent)
+      (should (string-prefix-p "-error " sent))
+      (should (eq deleted proc)))))
+
+(ert-deftest anvil-eval-server-execute-test-dontkill-left-alone ()
+  "Abnormal unwind of a dontkill client leaves the connection alone."
+  (anvil-eval-server-execute-test--with-open-process proc
+    (let (sent deleted)
+      (cl-letf (((symbol-function 'process-send-string)
+                 (lambda (_p s) (setq sent s)))
+                ((symbol-function 'delete-process)
+                 (lambda (p) (setq deleted p))))
+        (catch 'abort
+          (anvil-eval--server-execute-cleanup-advice
+           (lambda (&rest _) (throw 'abort nil))
+           proc nil nil nil t nil nil)))   ; dontkill = t
+      (should-not sent)
+      (should-not deleted))))
+
+(ert-deftest anvil-eval-server-execute-test-normal-exit-untouched ()
+  "When server-execute completes (and tears down itself), advice no-ops."
+  (anvil-eval-server-execute-test--with-open-process proc
+    (let (sent)
+      (cl-letf (((symbol-function 'process-send-string)
+                 (lambda (_p s) (setq sent s))))
+        ;; Real server-execute replies and deletes the client itself;
+        ;; simulate that teardown in the wrapped function.
+        (anvil-eval--server-execute-cleanup-advice
+         (lambda (&rest _) (delete-process proc) 'done)
+         proc nil nil nil nil nil nil))
+      (should-not sent))))
+
+(provide 'anvil-eval-server-execute-test)
+;;; anvil-eval-server-execute-test.el ends here


### PR DESCRIPTION
## Problem

When the form evaluated through emacsclient exits non-locally — the user picks `(top-level)` in the debugger, or any `throw` unwinds past the eval body — `server-execute` never reaches its `-print` reply / `server-delete-client` teardown. The emacsclient process stays blocked in `recvfrom` on a connection that will never answer.

For the MCP stdio transport this is fatal: `anvil-stdio.sh` owns that emacsclient in a command substitution, so one aborted eval wedges the whole bridge and the MCP client behind it. (It also bites any plain `emacsclient --eval` user the same way.)

## Fix

`:around` advice on `server-execute`, installed/removed by `anvil-eval-enable`/`-disable`, wrapping the call in `unwind-protect`. On abnormal unwind of a wait-for-reply client (`dontkill` nil, connection still `open`) it sends an `-error` reply and deletes the connection so emacsclient exits cleanly with a visible error. `dontkill` clients (`-window-system`/`-tty`/`-resume`/`-suspend`) are left untouched, matching upstream `server-execute` behaviour; normal completions are no-ops because `server-execute` has already torn the client down.

## Tests

`tests/anvil-eval-server-execute-test.el` uses a real localhost socket pair (so `process-status` is genuinely `open`) and pins: abnormal exit → `-error` sent + connection deleted; `dontkill` client → untouched; normal completion → no-op.

```
Ran 3 tests, 3 results as expected, 0 unexpected
```