### PR TITLE
fix(org): stop registering the disk-first temp buffer as a file visitor

### DIFF
--- a/anvil-org.el
+++ b/anvil-org.el
@@ -345,7 +345,14 @@ variables."
          (unwind-protect
              (progn
                (insert-file-contents ,file-path)
-               (set-visited-file-name ,file-path t)
+               ;; Associate the temp buffer with the file for org/id
+               ;; machinery without `set-visited-file-name', which
+               ;; renames the buffer to "<basename><2>" when the file
+               ;; is already visited and assigns an auto-save file
+               ;; name to a buffer that lives for one tool call.
+               (setq buffer-file-name ,file-path
+                     buffer-file-truename (file-truename ,file-path)
+                     default-directory (file-name-directory ,file-path))
                (set-buffer-modified-p nil)
                (org-mode)
                (goto-char (point-min))

--- a/tests/anvil-org-modify-temp-buffer-test.el
+++ b/tests/anvil-org-modify-temp-buffer-test.el
@@ -1,0 +1,50 @@
+;;; anvil-org-modify-temp-buffer-test.el --- ERT for disk-first temp buffer hygiene -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; The disk-first path of `anvil-org--modify' used
+;; `set-visited-file-name' to associate its temp buffer with the file.
+;; That call renames the buffer to the file's base name — yielding a
+;; "<basename><2>" buffer whenever the file is already visited — and
+;; assigns an auto-save file name to a buffer that only lives for one
+;; tool call.  Setting `buffer-file-name' / `buffer-file-truename' /
+;; `default-directory' directly gives org and org-id everything they
+;; need without registering the temp buffer as an interactive visitor.
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil)
+(require 'anvil-org)
+
+(ert-deftest anvil-org-modify-temp-buffer-test-no-visitor-side-effects ()
+  "The disk-first temp buffer is not renamed and gets no auto-save name."
+  (let* ((file (make-temp-file "anvil-modify-test" nil ".org"
+                               "* Heading\nBody.\n"))
+         (user-buf (find-file-noselect file))
+         (observed-name nil)
+         (observed-auto-save nil))
+    (unwind-protect
+        (progn
+          ;; Force disk-first even if buffer-first modes are configured.
+          (let ((anvil-modes-allow-buffer-modify nil))
+            (anvil-org--modify file "test edit" nil
+              (goto-char (point-min))
+              (setq observed-name (buffer-name)
+                    observed-auto-save buffer-auto-save-file-name)))
+          ;; Temp buffer keeps its temp name instead of "<basename><2>".
+          (should (string-prefix-p " *temp*" observed-name))
+          (should-not observed-auto-save)
+          ;; The user's buffer kept its name and the edit reached disk.
+          (should (equal (buffer-name user-buf)
+                         (file-name-nondirectory file)))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (string-match-p ":ID:" (buffer-string)))))
+      (when (buffer-live-p user-buf)
+        (with-current-buffer user-buf (set-buffer-modified-p nil))
+        (kill-buffer user-buf))
+      (delete-file file))))
+
+(provide 'anvil-org-modify-temp-buffer-test)
+;;; anvil-org-modify-temp-buffer-test.el ends here


### PR DESCRIPTION
## Problem

The disk-first path of `anvil-org--modify` associates its temp buffer with the file via `set-visited-file-name`. Two side effects for a buffer that only lives for the duration of one tool call:

- the buffer is renamed to the file's base name, so whenever the file is already visited (the common case — the user has the org file open while an agent edits it) a `<basename><2>` buffer appears in buffer lists, uniquify churn included;
- the buffer gets an auto-save file name, so a long-running body risks dropping `#basename#` auto-save artifacts next to the real file.

## Fix

Set `buffer-file-name`, `buffer-file-truename` and `default-directory` directly. org and org-id only need the buffer/file association for things like `org-id-get-create` and attachment path resolution — none of that requires the buffer to be registered as an interactive visitor.

## Tests

New `tests/anvil-org-modify-temp-buffer-test.el`: inside the macro body the buffer keeps its ` *temp*` name and has no auto-save file name; the user's visiting buffer keeps its name; the edit (including the created `:ID:` drawer) reaches disk.

Existing suite: `tests/anvil-org-test.el` — `Ran 20 tests, 20 results as expected`.