### PR TITLE
feat(server): infer JSON schema types from (TYPE) docstring prefixes

### DIFF
--- a/anvil-server.el
+++ b/anvil-server.el
@@ -828,7 +828,13 @@ Parameters prefixed with `_' (the Elisp unused-arg convention) are
 hidden from the client-facing schema — `anvil-server--handle-tools-call'
 fills them with nil at dispatch time.
 If ARGLIST is provided, reuse it instead of calling
-`help-function-arglist'."
+`help-function-arglist'.
+
+A description in the docstring's \"MCP Parameters:\" section may start
+with a \"(TYPE) \" prefix — one of (boolean), (integer), (number),
+(array), (object) — to set the parameter's JSON schema type.  The
+prefix is stripped from the client-facing description.  Without a
+recognised prefix the type defaults to \"string\"."
   (let ((arglist (or arglist (help-function-arglist func t))))
     (when (memq '&rest arglist)
       (error "MCP tool handlers do not support &rest parameters"))
@@ -851,9 +857,26 @@ If ARGLIST is provided, reuse it instead of calling
                     ;; Mark that we've seen &optional
                     (setq seen-optional t)
                   ;; Regular parameter - add to properties
-                  (let* ((description
+                  (let* ((raw-description
                           (cdr (assoc param-name param-descriptions)))
-                         (property-schema `((type . "string"))))
+                         ;; Infer the JSON type from a "(TYPE) ..." prefix
+                         ;; in the docstring description.  Recognised:
+                         ;; boolean integer number array object.  Absent
+                         ;; or unrecognised prefixes keep type "string".
+                         (type-match
+                          (and raw-description
+                               (string-match
+                                "\\`(\\(boolean\\|integer\\|number\\|array\\|object\\)) "
+                                raw-description)))
+                         (json-type
+                          (if type-match
+                              (match-string 1 raw-description)
+                            "string"))
+                         (description
+                          (if type-match
+                              (substring raw-description (match-end 0))
+                            raw-description))
+                         (property-schema `((type . ,json-type))))
                     ;; Add description if provided
                     (when description
                       (setq property-schema

--- a/tests/anvil-server-schema-types-test.el
+++ b/tests/anvil-server-schema-types-test.el
@@ -1,0 +1,78 @@
+;;; anvil-server-schema-types-test.el --- ERT for docstring-driven schema types -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `anvil-server--generate-schema-from-function' hard-coded every
+;; parameter's JSON schema type to "string".  Clients then send
+;; booleans as the strings "true"/"false" and arrays as ad-hoc
+;; encodings, and every handler grows its own normalisation shims.
+;; The `:schema' override exists but requires hand-writing the whole
+;; schema for one mistyped parameter.
+;;
+;; These tests pin the new inference: a description in the docstring's
+;; "MCP Parameters:" section may start with a "(TYPE) " prefix —
+;; (boolean) (integer) (number) (array) (object) — which sets the
+;; parameter's schema type and is stripped from the client-facing
+;; description.  No prefix, or an unrecognised one, keeps "string".
+
+;;; Code:
+
+(require 'ert)
+(require 'anvil)
+(require 'anvil-server)
+
+(defun anvil-server-schema-types-test--handler (name count enabled &optional tags)
+  "Test handler.
+
+MCP Parameters:
+  name - plain string parameter
+  count - (integer) how many items to return
+  enabled - (boolean) whether the feature is on
+  tags - (array) tags to attach"
+  (list name count enabled tags))
+
+(defun anvil-server-schema-types-test--unrecognised (value)
+  "Test handler with an unrecognised prefix.
+
+MCP Parameters:
+  value - (frob) a description that keeps its odd prefix"
+  value)
+
+(defun anvil-server-schema-types-test--prop (schema name key)
+  "Return KEY of parameter NAME in SCHEMA's properties."
+  (alist-get key (cdr (assoc name (alist-get 'properties schema)))))
+
+(ert-deftest anvil-server-schema-types-test-inferred-types ()
+  "Recognised (TYPE) prefixes set the schema type and are stripped."
+  (let ((schema (anvil-server--generate-schema-from-function
+                 #'anvil-server-schema-types-test--handler)))
+    (should (equal (anvil-server-schema-types-test--prop schema "name" 'type)
+                   "string"))
+    (should (equal (anvil-server-schema-types-test--prop schema "count" 'type)
+                   "integer"))
+    (should (equal (anvil-server-schema-types-test--prop schema "enabled" 'type)
+                   "boolean"))
+    (should (equal (anvil-server-schema-types-test--prop schema "tags" 'type)
+                   "array"))
+    ;; Prefix stripped from the client-facing description.
+    (should (equal (anvil-server-schema-types-test--prop
+                    schema "count" 'description)
+                   "how many items to return"))
+    (should (equal (anvil-server-schema-types-test--prop
+                    schema "enabled" 'description)
+                   "whether the feature is on"))
+    ;; Required/optional split unchanged.
+    (should (equal (alist-get 'required schema) ["name" "count" "enabled"]))))
+
+(ert-deftest anvil-server-schema-types-test-unrecognised-prefix-kept ()
+  "An unrecognised (foo) prefix keeps type string and full description."
+  (let ((schema (anvil-server--generate-schema-from-function
+                 #'anvil-server-schema-types-test--unrecognised)))
+    (should (equal (anvil-server-schema-types-test--prop schema "value" 'type)
+                   "string"))
+    (should (equal (anvil-server-schema-types-test--prop
+                    schema "value" 'description)
+                   "(frob) a description that keeps its odd prefix"))))
+
+(provide 'anvil-server-schema-types-test)
+;;; anvil-server-schema-types-test.el ends here


### PR DESCRIPTION
## Problem

`anvil-server--generate-schema-from-function` hard-codes every parameter's JSON schema type to `"string"`. LLM clients respect the advertised schema, so booleans arrive as the strings `"true"`/`"false"`, numbers as digit strings, arrays as ad-hoc encodings — and handlers accumulate per-tool normalisation shims (e.g. the `:false`/`"false"` handling in `anvil-org--tool-edit-body`).

The `:schema` override added in v1.2.0 solves this for hand-written schemas, but fixing one mistyped parameter means writing (and then maintaining) the entire schema by hand.

## Fix

The docstring `MCP Parameters:` section already drives per-parameter descriptions. Let a description start with a `(TYPE) ` prefix to set that parameter's schema type:

```elisp
"MCP Parameters:
  count - (integer) how many items to return
  enabled - (boolean) whether the feature is on
  tags - (array) tags to attach
  name - plain string parameter"
```

Recognised: `(boolean)`, `(integer)`, `(number)`, `(array)`, `(object)`. The prefix is stripped from the client-facing description. No prefix, or an unrecognised one, keeps `"string"` — existing tools are unaffected (no current docstring matches the pattern; verified by grep).

Interacts cleanly with the schema cache: the cache signature already keys on the generated schema's inputs, and cache misses re-run this generator.

## Tests

`tests/anvil-server-schema-types-test.el`: all five types inferred, prefixes stripped, required/optional split unchanged, unrecognised prefix kept verbatim with type string.

```
Ran 2 tests, 2 results as expected, 0 unexpected
```

Existing suites: `anvil-server-cons-fix-test` + `anvil-manifest-test` — `Ran 65 tests, 65 results as expected`.