### PR TITLE
feat(org): make add-todo tags/body optional; fix body spacing and ID target

### DIFF
--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1370,31 +1370,32 @@ MCP Parameters:
 
 ;; PHASE-C-IDE-SPLIT-CANDIDATE: inserts heading + ID + tags + body in real buffer
 (defun anvil-org--tool-add-todo
-    (title todo_state tags body parent_uri &optional after_uri)
+    (title todo_state parent_uri &optional body after_uri tags)
   "Add a new TODO item to an Org file.
 Creates an Org ID for the new headline and returns its ID-based URI.
 TITLE is the headline text.
 TODO_STATE is the TODO state from `org-todo-keywords'.
-TAGS is a single tag string, a list/vector of tag strings, or a JSON
-array literal string (e.g. \"[\\\"a\\\",\\\"b\\\"]\") for the MCP wire form;
-empty string means no tags.
-BODY is optional body text.
 PARENT_URI is the URI of the parent item.
+BODY is optional body text.
 AFTER_URI is optional URI of sibling to insert after.
+TAGS is optional: a single tag string, a list/vector of tag strings,
+a JSON array literal string (e.g. \"[\\\"a\\\",\\\"b\\\"]\") for the MCP
+wire form, or empty string for no tags.
 
 MCP Parameters:
   title - The headline text
   todo_state - TODO state from `org-todo-keywords'
-  tags - Tags to add (single string, JSON array string, or empty for none)
-  body - Optional body text content
   parent_uri - Parent item URI
                Formats:
                  - org-headline://{absolute-path}#{headline-path}
                  - org-id://{id}
+  body - Optional body text content
   after_uri - Sibling to insert after (optional)
               Formats:
                 - org-headline://{absolute-path}#{headline-path}
-                - org-id://{id}"
+                - org-id://{id}
+  tags - Tags to add (single string, JSON array string, or empty for
+         none; optional)"
   (anvil-org--validate-headline-title title)
   (anvil-org--validate-todo-state todo_state)
   (let* ((tag-list (anvil-org--validate-and-normalize-tags tags))
@@ -1464,18 +1465,33 @@ MCP Parameters:
         (if body
             (progn
               (end-of-line)
-              (insert "\n" body)
-              (unless (string-suffix-p "\n" body)
-                (insert "\n"))
-              ;; Move back to the heading for org-id-get-create
-              ;; org-id-get-create requires point to be on a heading
+              ;; Child headings have a trailing \n; top-level ones don't.
+              ;; Skip past it so the drawer (inserted at the heading line
+              ;; by org-id-get-create) ends up before our blank line.
+              (let* ((has-nl (looking-at "\n"))
+                     (before (if has-nl "\n" "\n\n")))
+                (when has-nl (forward-char 1))
+                ;; Remove any blank lines already at insertion point so
+                ;; existing spacing doesn't stack with ours.
+                (delete-region
+                 (point)
+                 (progn (skip-chars-forward "\n") (point)))
+                ;; Normalise body: strip boundary newlines, collapse
+                ;; internal runs of 3+ \n so the result never exceeds \n\n.
+                (let* ((trimmed (string-trim body "\n+" "\n+"))
+                       (clean (replace-regexp-in-string
+                               "\n\n\n+" "\n\n" trimmed)))
+                  (insert before clean "\n\n")))
+              ;; Step back inside the new entry: the insert can leave
+              ;; point at the beginning of the next heading, where
+              ;; org-back-to-heading stays put and org-id-get-create
+              ;; would return (or mint) the neighbouring heading's ID.
+              (skip-chars-backward "\n")
               (org-back-to-heading t))
           ;; No body - ensure newline after heading
           (end-of-line)
           (unless (looking-at "\n")
             (insert "\n")))))))
-
-;; Resource handlers
 
 (defun anvil-org--handle-outline-resource (params)
   "Handler for org://{filename}/outline template.

--- a/tests/anvil-org-add-todo-optional-test.el
+++ b/tests/anvil-org-add-todo-optional-test.el
@@ -1,0 +1,98 @@
+;;; anvil-org-add-todo-optional-test.el --- ERT for optional add-todo args -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Three pinned behaviors for `anvil-org--tool-add-todo':
+;;
+;; 1. `tags' and `body' are optional in the generated MCP schema.
+;;    Previously they sat before `&optional' in the arglist, so the
+;;    schema marked them required and clients had to send empty
+;;    placeholder values on every call.
+;;
+;; 2. Body spacing: exactly one blank line separates the generated
+;;    :PROPERTIES: drawer from the body, and one blank line follows,
+;;    instead of the body abutting the :END: line.
+;;
+;; 3. Point discipline: when the parent's subtree is not at the end of
+;;    the file, the body insert used to leave point at the beginning
+;;    of the *next* heading; `org-back-to-heading' stays put there and
+;;    the completion step's `org-id-get-create' returned (or minted)
+;;    the neighbouring heading's ID while the new task got no ID
+;;    drawer at all.
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'anvil)
+(require 'anvil-org)
+
+(defmacro anvil-org-add-todo-optional-test--with-org (content &rest body)
+  "Run BODY with PATH bound to a temp org file holding CONTENT."
+  (declare (indent 1))
+  `(let* ((path (make-temp-file "anvil-add-todo-test" nil ".org" ,content))
+          (anvil-org-allowed-files (list path))
+          (anvil-org-allowed-files-enabled t))
+     (unwind-protect
+         (progn ,@body)
+       (delete-file path))))
+
+(defun anvil-org-add-todo-optional-test--read (path)
+  "Return PATH's contents."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (buffer-string)))
+
+(ert-deftest anvil-org-add-todo-optional-test-schema-required-set ()
+  "Only title, todo_state and parent_uri are required in the schema."
+  (let ((schema (anvil-server--generate-schema-from-function
+                 #'anvil-org--tool-add-todo)))
+    (should (equal (alist-get 'required schema)
+                   ["title" "todo_state" "parent_uri"]))))
+
+(ert-deftest anvil-org-add-todo-optional-test-omitted-tags-and-body ()
+  "A call without tags and body succeeds and creates a clean headline."
+  (anvil-org-add-todo-optional-test--with-org "* Parent\nText.\n"
+    (let* ((response
+            (json-parse-string
+             (anvil-org--tool-add-todo
+              "Child" "TODO" (concat "org-headline://" path "#Parent"))
+             :object-type 'alist))
+           (content (anvil-org-add-todo-optional-test--read path)))
+      (should (eq t (alist-get 'success response)))
+      (should (string-match-p "^\\*\\* TODO Child$" content)))))
+
+(ert-deftest anvil-org-add-todo-optional-test-body-spacing ()
+  "One blank line separates the :END: drawer line from the body."
+  (anvil-org-add-todo-optional-test--with-org "* Parent\nText.\n"
+    (anvil-org--tool-add-todo
+     "Child" "TODO" (concat "org-headline://" path "#Parent")
+     "First line.\nSecond line.")
+    (let ((content (anvil-org-add-todo-optional-test--read path)))
+      (should (string-match-p ":END:\n\nFirst line\\.\nSecond line\\.\n"
+                              content))
+      (should-not (string-match-p ":END:\nFirst line\\." content)))))
+
+(ert-deftest anvil-org-add-todo-optional-test-id-on-new-heading ()
+  "With a following sibling heading, the new task gets its own fresh ID."
+  (anvil-org-add-todo-optional-test--with-org
+      "* Parent\n:PROPERTIES:\n:ID:       11111111-aaaa-bbbb-cccc-000000000001\n:END:\nText.\n* Next section\n:PROPERTIES:\n:ID:       22222222-aaaa-bbbb-cccc-000000000002\n:END:\nOther text.\n"
+    (let* ((response
+            (json-parse-string
+             (anvil-org--tool-add-todo
+              "Child" "TODO"
+              "org-id://11111111-aaaa-bbbb-cccc-000000000001"
+              "Body line.")
+             :object-type 'alist))
+           (uri (alist-get 'uri response))
+           (content (anvil-org-add-todo-optional-test--read path)))
+      (should (eq t (alist-get 'success response)))
+      ;; The returned URI is neither the parent's nor the sibling's ID.
+      (should-not (string-match-p "11111111-aaaa-bbbb-cccc-000000000001" uri))
+      (should-not (string-match-p "22222222-aaaa-bbbb-cccc-000000000002" uri))
+      ;; The new heading carries its own ID drawer.
+      (should (string-match-p
+               "\\*\\* TODO Child\n:PROPERTIES:\n:ID:" content)))))
+
+(provide 'anvil-org-add-todo-optional-test)
+;;; anvil-org-add-todo-optional-test.el ends here

--- a/tests/anvil-org-test.el
+++ b/tests/anvil-org-test.el
@@ -176,7 +176,7 @@ no-ops in that case; the tool must detect the no-op and throw."
             (response
              (json-parse-string
               (anvil-org--tool-add-todo
-               "Child" "TODO" "" "Child body." parent-uri)
+               "Child" "TODO" parent-uri "Child body." nil "")
               :object-type 'alist))
             (content (anvil-org-test--read path)))
        (should (eq t (alist-get 'success response)))
@@ -218,8 +218,8 @@ no-ops in that case; the tool must detect the no-op and throw."
             (response
              (json-parse-string
               (anvil-org--tool-add-todo
-               "Child" "TODO" "[\"work\",\"urgent\"]"
-               "Child body." parent-uri)
+               "Child" "TODO" parent-uri "Child body."
+               nil "[\"work\",\"urgent\"]")
               :object-type 'alist))
             (content (anvil-org-test--read path)))
        (should (eq t (alist-get 'success response)))


### PR DESCRIPTION
Three related changes to `anvil-org--tool-add-todo`:

## 1. `tags` and `body` become optional (schema-level)

They sat before `&optional` in the arglist, so the auto-generated MCP schema marked them **required** — clients had to send `""` placeholders on every call even though both are documented optional (and `""`-tags already means "no tags"). The arglist becomes:

```elisp
(title todo_state parent_uri &optional body after_uri tags)
```

⚠️ Breaking for positional **elisp** callers — the two call sites in `tests/anvil-org-test.el` are updated in this PR. MCP clients are unaffected (named JSON params) other than seeing a smaller required set.

## 2. Body spacing

Body text is inserted before `org-id-get-create` runs, so it ends up flush against the `:END:` line of the generated `:PROPERTIES:` drawer. Now exactly one blank line separates drawer from body and one follows; pre-existing blank runs are collapsed so spacing doesn't stack across repeated edits.

## 3. ID created on the right heading

With the spacing insert ending at the beginning of the **next** heading (whenever the parent's subtree isn't last in the file), `org-back-to-heading` stays put — it's already on a heading — and the completion step's `org-id-get-create` returns (or mints!) the *neighbouring* heading's ID while the new task gets no ID drawer at all. `skip-chars-backward` steps point back inside the new entry first.

## Tests

New `tests/anvil-org-add-todo-optional-test.el`: required set is `[title todo_state parent_uri]`; call with omitted tags/body succeeds; `:END:`→blank-line→body spacing; with a following sibling the returned URI is a fresh ID (not parent's, not sibling's) and the new heading carries its own drawer.

```
Ran 24 tests, 24 results as expected, 0 unexpected   (new + full anvil-org-test suite)
```