### PR TITLE
feat(org): make edit-body replace_all optional

### DIFF
--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1571,7 +1571,7 @@ MCP Parameters:
 
 ;; PHASE-C-IDE-SPLIT-CANDIDATE: narrows body + org-end-of-meta-data + buffer mutation
 (defun anvil-org--tool-edit-body
-    (resource_uri old_body new_body replace_all)
+    (resource_uri old_body new_body &optional replace_all)
   "Edit body content of an Org node using partial string replacement.
 RESOURCE_URI is the URI of the node to edit.
 OLD_BODY is the substring to search for within the node's body.
@@ -1587,7 +1587,9 @@ MCP Parameters:
   old_body - Substring to replace within the body (must be unique
              unless replace_all).  Use \"\" to add to empty nodes
   new_body - Replacement text
-  replace_all - Replace all occurrences (optional, default false)"
+  replace_all - (boolean) Replace all occurrences; default false when
+                omitted.  When false, old_body must be unique in the
+                body."
   ;; Normalize JSON false to nil for proper boolean handling
   ;; JSON false can arrive as :false (keyword) or "false" (string)
   (let ((replace_all

--- a/tests/anvil-org-edit-body-optional-test.el
+++ b/tests/anvil-org-edit-body-optional-test.el
@@ -1,0 +1,46 @@
+;;; anvil-org-edit-body-optional-test.el --- ERT for optional replace_all -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `anvil-org--tool-edit-body' declared `replace_all' as a required
+;; positional parameter even though its docstring calls it optional,
+;; so the generated MCP schema forced clients to send a value on every
+;; call.  These tests pin the `&optional' arglist: the schema's
+;; required set excludes `replace_all', and a call omitting it behaves
+;; like `replace_all' false (single, unique replacement).
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'anvil)
+(require 'anvil-org)
+
+(ert-deftest anvil-org-edit-body-optional-test-schema-required-set ()
+  "replace_all is not in the schema's required parameters."
+  (let ((schema (anvil-server--generate-schema-from-function
+                 #'anvil-org--tool-edit-body)))
+    (should (equal (alist-get 'required schema)
+                   ["resource_uri" "old_body" "new_body"]))))
+
+(ert-deftest anvil-org-edit-body-optional-test-omitted-defaults-to-single ()
+  "Omitting replace_all performs a single unique replacement."
+  (let* ((path (make-temp-file "anvil-edit-body-test" nil ".org"
+                               "* Heading\nalpha beta gamma\n"))
+         (anvil-org-allowed-files (list path))
+         (anvil-org-allowed-files-enabled t))
+    (unwind-protect
+        (let ((response
+               (json-parse-string
+                (anvil-org--tool-edit-body
+                 (concat "org-headline://" path "#Heading")
+                 "beta" "BETA")
+                :object-type 'alist)))
+          (should (eq t (alist-get 'success response)))
+          (with-temp-buffer
+            (insert-file-contents path)
+            (should (string-match-p "alpha BETA gamma" (buffer-string)))))
+      (delete-file path))))
+
+(provide 'anvil-org-edit-body-optional-test)
+;;; anvil-org-edit-body-optional-test.el ends here


### PR DESCRIPTION
## Problem

`anvil-org--tool-edit-body` declares `replace_all` as a required positional parameter even though its own docstring says "(optional, default false)". The auto-generated MCP schema therefore marks it **required**, forcing clients to send a value on every call — and since the schema also types it as a string, they send `"false"`, which is why the `:false`/`"false"` normalisation shim exists in the handler.

## Fix

Move `replace_all` behind `&optional`. Elisp callers are unaffected (it's the trailing argument); MCP clients see it leave the required set. The docstring description gains a `(boolean)` prefix — with #40 (docstring-driven schema types) that types the parameter correctly; without it, the prefix is just visible documentation in the description. The existing wire-shape normalisation is kept either way for stale clients.

## Tests

`tests/anvil-org-edit-body-optional-test.el`: schema required set is `[resource_uri old_body new_body]`; omitting `replace_all` performs a single unique replacement.

```
Ran 22 tests, 22 results as expected, 0 unexpected   (new + full anvil-org-test suite)
```