### PR TITLE
feat(server): opt-in dispatch timeout and autostart-on-request

### DIFF
--- a/anvil-server.el
+++ b/anvil-server.el
@@ -96,6 +96,29 @@ Defaults to `user-emacs-directory' but can be customized."
   :type 'file
   :group 'anvil-server)
 
+(defcustom anvil-server-autostart-on-request nil
+  "When non-nil, restart a stopped server instead of erroring.
+If `anvil-server-process-jsonrpc' is reached while
+`anvil-server--running' is nil (the server was stopped for any
+reason), call `anvil-server-start' transparently rather than
+signalling.  For stdio transports the signalled error surfaces as
+empty emacsclient output, which clients cannot match to their
+request — effectively a hang.  Nil preserves the historical
+behaviour of signalling an error."
+  :type 'boolean
+  :group 'anvil-server)
+
+(defcustom anvil-server-dispatch-timeout nil
+  "Seconds before an in-flight request is answered with a timeout error.
+When non-nil, request dispatch in `anvil-server-process-jsonrpc' is
+wrapped in `with-timeout': a handler that exceeds the limit yields a
+proper JSON-RPC internal error (carrying the request id) instead of
+blocking the transport indefinitely.  Note `with-timeout' only fires
+while the Emacs event loop is processing; it cannot interrupt a
+tight non-yielding loop.  Nil (default) imposes no limit."
+  :type '(choice (const :tag "No timeout" nil) number)
+  :group 'anvil-server)
+
 ;;; Public Constants
 
 (defconst anvil-server-name "anvil"
@@ -1939,8 +1962,10 @@ emacsclient -e \\='(anvil-server-process-jsonrpc
 
 See also: `anvil-server-process-jsonrpc-parsed'"
   (unless anvil-server--running
-    (error
-     "No active MCP server, start server with `anvil-server-start' first"))
+    (if anvil-server-autostart-on-request
+        (anvil-server-start)
+      (error
+       "No active MCP server, start server with `anvil-server-start' first")))
 
   (anvil-server--log-json-rpc "in" json-string server-id)
 
@@ -2026,14 +2051,27 @@ See also: `anvil-server-process-jsonrpc-parsed'"
       (let ((t0 (float-time)))
         (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
           (nelisp--write-stderr-line "[PJ] dispatch-start"))
-        (condition-case err
-            (setq response
-                  (anvil-server--validate-and-dispatch-request
-                   json-object server-id))
-          (quit
-           (setq response (anvil-server--handle-error err)))
-          (error
-           (setq response (anvil-server--handle-error err))))
+        (let ((dispatch
+               (lambda ()
+                 (condition-case err
+                     (setq response
+                           (anvil-server--validate-and-dispatch-request
+                            json-object server-id))
+                   (quit
+                    (setq response (anvil-server--handle-error err)))
+                   (error
+                    (setq response (anvil-server--handle-error err)))))))
+          (if anvil-server-dispatch-timeout
+              (with-timeout (anvil-server-dispatch-timeout
+                             (setq response
+                                   (anvil-server--jsonrpc-error
+                                    (when json-object
+                                      (cdr (assq 'id json-object)))
+                                    anvil-server-jsonrpc-error-internal
+                                    (format "Request timed out after %s seconds"
+                                            anvil-server-dispatch-timeout))))
+                (funcall dispatch))
+            (funcall dispatch)))
         (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
           (nelisp--write-stderr-line
            (format "[PJ] validate+dispatch %.4fs resp-len=%d"

--- a/tests/anvil-server-dispatch-guards-test.el
+++ b/tests/anvil-server-dispatch-guards-test.el
@@ -1,0 +1,83 @@
+;;; anvil-server-dispatch-guards-test.el --- ERT for dispatch guards -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Two opt-in guards for `anvil-server-process-jsonrpc', both nil by
+;; default (historical behaviour preserved):
+;;
+;; * `anvil-server-autostart-on-request' — restart a stopped server
+;;   instead of signalling.  For stdio transports the signalled error
+;;   surfaces as empty emacsclient output, which the client cannot
+;;   match to its request: an effective hang.
+;;
+;; * `anvil-server-dispatch-timeout' — answer an over-long request
+;;   with a JSON-RPC internal error carrying the request id instead
+;;   of blocking the transport indefinitely.
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'anvil)
+(require 'anvil-server)
+
+(ert-deftest anvil-server-dispatch-guards-test-stopped-server-errors ()
+  "Default: a stopped server still signals."
+  (let ((anvil-server--running nil)
+        (anvil-server-autostart-on-request nil))
+    (should-error
+     (anvil-server-process-jsonrpc
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"
+      "guards-test"))))
+
+(ert-deftest anvil-server-dispatch-guards-test-autostart ()
+  "With autostart enabled, a stopped server is started transparently."
+  (let ((anvil-server--running nil)
+        (anvil-server-autostart-on-request t)
+        (started nil))
+    (cl-letf (((symbol-function 'anvil-server-start)
+               (lambda (&rest _) (setq started t anvil-server--running t)))
+              ((symbol-function 'anvil-server--validate-and-dispatch-request)
+               (lambda (&rest _) "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}")))
+      (anvil-server-process-jsonrpc
+       "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"
+       "guards-test")
+      (should started))))
+
+(ert-deftest anvil-server-dispatch-guards-test-timeout-carries-id ()
+  "An over-long dispatch yields a timeout error with the request id."
+  (let ((anvil-server--running t)
+        (anvil-server-dispatch-timeout 0.05))
+    (cl-letf (((symbol-function 'anvil-server--validate-and-dispatch-request)
+               (lambda (&rest _)
+                 ;; sit-for yields to the event loop so with-timeout fires.
+                 (sit-for 1)
+                 "{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{}}")))
+      (let ((resp (json-read-from-string
+                   (anvil-server-process-jsonrpc
+                    "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/list\"}"
+                    "guards-test"))))
+        (should (equal (alist-get 'id resp) 7))
+        (should (string-match-p "timed out"
+                                (alist-get 'message
+                                           (alist-get 'error resp))))))))
+
+(ert-deftest anvil-server-dispatch-guards-test-no-timeout-by-default ()
+  "With the default nil timeout, dispatch is not wrapped."
+  (let ((anvil-server--running t)
+        (anvil-server-dispatch-timeout nil))
+    (cl-letf (((symbol-function 'anvil-server--validate-and-dispatch-request)
+               (lambda (&rest _)
+                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{}}")))
+      (let ((resp (json-read-from-string
+                   (anvil-server-process-jsonrpc
+                    "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/list\"}"
+                    "guards-test"))))
+        (should (equal (alist-get 'id resp) 3))
+        ;; json-read maps the empty result object to nil; presence of
+        ;; the key (and absence of error) is what matters.
+        (should (assq 'result resp))
+        (should-not (assq 'error resp))))))
+
+(provide 'anvil-server-dispatch-guards-test)
+;;; anvil-server-dispatch-guards-test.el ends here


### PR DESCRIPTION
Two opt-in robustness guards for `anvil-server-process-jsonrpc`, both **nil by default** — no behaviour change unless enabled.

## `anvil-server-autostart-on-request`

If a request arrives while `anvil-server--running` is nil (stopped by a test run, an error, a manual stop that was never undone), the function signals. Over a stdio transport that error surfaces as empty emacsclient output — the bridge has nothing to reply with and the MCP client cannot match anything to its pending request, so a stopped server degenerates into a silent hang on every subsequent call. With the option enabled, the server is restarted transparently via `anvil-server-start`.

## `anvil-server-dispatch-timeout`

When set to a number of seconds, dispatch is wrapped in `with-timeout`: a handler that exceeds the limit yields a JSON-RPC `-32603` error **carrying the request id**, instead of blocking the transport indefinitely. Documented caveat: `with-timeout` only fires while the event loop is processing, so a tight non-yielding loop still needs a transport-side cap (see #37 for the bridge-side counterpart — the two compose, transport cap slightly above dispatch cap so the richer daemon-side error wins).

## Tests

`tests/anvil-server-dispatch-guards-test.el`: default still signals on stopped server; autostart starts and serves; timeout answer carries the request id; nil timeout leaves dispatch unwrapped.

```
Ran 4 tests, 4 results as expected, 0 unexpected
```