### PR TITLE
feat(server): make tool error messages actionable for LLM clients

### DIFF
--- a/anvil-server.el
+++ b/anvil-server.el
@@ -1661,8 +1661,15 @@ virtual server-ids share the same handler pool."
                           (signal
                            'anvil-server-invalid-params
                            (list
-                            (format "Missing required parameter: %s"
-                                    required)))))
+                            (format
+                             (concat
+                              "Missing required parameter: %s. "
+                              "Each parameter must be a separate field "
+                              "in the JSON input object — do not embed "
+                              "XML-style tags such as </%s> or "
+                              "<parameter name=\"%s\"> inside another "
+                              "parameter's string value.")
+                             required required required)))))
                       ;; Check for unexpected parameters.  `_'-prefixed
                       ;; names are silently accepted even when not in
                       ;; `expected-params' — a stale client that still has
@@ -1913,7 +1920,8 @@ See also: `anvil-server-tool-throw'"
        (progn
          ,@body)
      (quit
-      (anvil-server-tool-throw (format "Quit: %S" err)))
+      (anvil-server-tool-throw
+       "Interrupted (quit) — the user pressed C-g.  Avoid running code that blocks the Emacs UI."))
      (error
       (anvil-server--run-tool-error-hook
        err anvil-server--current-tool-name 'tool-body)

--- a/tests/anvil-server-llm-messages-test.el
+++ b/tests/anvil-server-llm-messages-test.el
@@ -1,0 +1,67 @@
+;;; anvil-server-llm-messages-test.el --- ERT for LLM-facing error messages -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Tool errors are read by LLM clients, which act on what the message
+;; tells them.  Two messages are made actionable:
+;;
+;; * Missing required parameter: LLM clients sometimes emit XML-style
+;;   tool-call syntax (</param>, <parameter name="...">) embedded
+;;   inside another parameter's JSON string value; the result parses
+;;   as JSON with a missing field and a corrupted sibling value.  The
+;;   bare "Missing required parameter: x" leads the model to resend
+;;   the same confabulated shape; naming the failure pattern breaks
+;;   the loop.
+;;
+;; * Quit: "Quit: (quit)" does not tell the model what happened or
+;;   what to change.  Saying the user interrupted with C-g (and to
+;;   avoid UI-blocking code) does.
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'anvil)
+(require 'anvil-server)
+(require 'anvil-server-metrics)
+
+(defun anvil-server-llm-messages-test--tool (alpha beta)
+  "Test tool.
+
+MCP Parameters:
+  alpha - first value
+  beta - second value"
+  (concat alpha beta))
+
+(ert-deftest anvil-server-llm-messages-test-missing-param-names-pattern ()
+  "The missing-parameter error names the XML-embedding failure mode."
+  (anvil-server-register-tool
+   #'anvil-server-llm-messages-test--tool
+   :id "llm-messages-test-tool"
+   :description "Test tool"
+   :server-id "llm-messages-test")
+  (unwind-protect
+      (let* ((resp (anvil-server--handle-tools-call
+                    9 '((name . "llm-messages-test-tool")
+                        (arguments . ((alpha . "a"))))
+                    (make-anvil-server-metrics)
+                    "llm-messages-test"))
+             (parsed (json-read-from-string resp))
+             (msg (alist-get 'message (alist-get 'error parsed))))
+        (should (string-match-p "Missing required parameter: beta" msg))
+        (should (string-match-p "do not embed" msg))
+        (should (string-match-p "<parameter name=\"beta\">" msg)))
+    (anvil-server-unregister-tool "llm-messages-test-tool"
+                                  "llm-messages-test")))
+
+(ert-deftest anvil-server-llm-messages-test-quit-message-actionable ()
+  "A quit inside a tool handler reports the C-g interruption."
+  (let ((err (should-error
+              (anvil-server-with-error-handling
+                (signal 'quit nil))
+              :type 'anvil-server-tool-error)))
+    (should (string-match-p "C-g" (cadr err)))
+    (should (string-match-p "Interrupted" (cadr err)))))
+
+(provide 'anvil-server-llm-messages-test)
+;;; anvil-server-llm-messages-test.el ends here


### PR DESCRIPTION
Tool error strings are consumed by LLM clients, which act on whatever the message tells them. Two high-frequency messages become instructions instead of diagnoses:

## Missing required parameter

LLM clients under load sometimes emit XML-style tool-call syntax embedded *inside* another parameter's JSON string value — e.g. a `new_body` value that ends with `</new_body><parameter name="replace_all">true`. The request still parses as JSON: one field is missing, a sibling value is silently corrupted. The bare `Missing required parameter: x` then causes the model to resend the same confabulated shape, looping until the call budget runs out. Naming the exact failure pattern in the error breaks the loop:

> Missing required parameter: %s. Each parameter must be a separate field in the JSON input object — do not embed XML-style tags such as `</%s>` or `<parameter name="%s">` inside another parameter's string value.

## Quit

`Quit: (quit)` doesn't tell the model what happened or what to change. New message:

> Interrupted (quit) — the user pressed C-g.  Avoid running code that blocks the Emacs UI.

## Tests

`tests/anvil-server-llm-messages-test.el`: missing-param error names the pattern with the concrete parameter; quit inside `anvil-server-with-error-handling` reports the interruption.

```
Ran 2 tests, 2 results as expected, 0 unexpected
```