### PR TITLE
feat(org): org-watch module — TODO state-change signal channel

### DIFF
--- a/anvil-org-watch.el
+++ b/anvil-org-watch.el
@@ -1,0 +1,306 @@
+;;; anvil-org-watch.el --- Org TODO state-change signal channel -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Per-Emacs-session, in-memory broker that emits one NDJSON line per
+;; TODO state transition into a per-subscriber transport file under
+;; `anvil-org-watch-dir'.
+;;
+;; Subscribers register a UUID watch-set via the `org-watch-register'
+;; MCP tool and tail the returned transport file (e.g. with
+;; `tail -F -n +1 <path>') — no polling from the client side.  The
+;; hook fires for every writer path: this MCP server's own tools,
+;; interactive `C-c C-t', `org-agenda', and programmatic `org-todo'.
+;; The handler short-circuits when the buffer is not in
+;; `anvil-org-allowed-files', when the heading carries no `:ID:'
+;; property, or when no subscriber is watching that id, so filtering
+;; is server-side and unwatched transitions cost one hash lookup.
+;;
+;; Each event line is a JSON object with six fields:
+;;   uuid, file, headline, previous_state, new_state, timestamp (UTC).
+;;
+;; Intended use: a coordinating agent (or any external process) hands
+;; work items to humans or other agents as org TODOs and needs to
+;; react when their state changes, without polling the org files.
+;;
+;; Enable via `anvil-optional-modules':
+;;   (add-to-list 'anvil-optional-modules 'org-watch)
+;; or call `anvil-org-watch-enable' directly after `anvil-org'.
+
+;;; Code:
+
+(require 'json)
+(require 'url-util)
+(require 'org)
+(require 'org-id)
+(require 'anvil-org)
+(require 'anvil-server)
+
+(defcustom anvil-org-watch-dir
+  (expand-file-name "anvil-org-watch/" temporary-file-directory)
+  "Directory holding per-subscriber NDJSON transport files.
+Created lazily with mode 0700 on first use."
+  :type 'directory
+  :group 'anvil-org)
+
+(defvar anvil-org-watch--subscribers (make-hash-table :test 'equal)
+  "Subscriber table for the org-state-change signal channel.
+Maps subscriber-id (string) → plist with
+  :watch-set      hash-table of uuid (string) → t
+  :transport-path absolute path to per-subscriber NDJSON file")
+
+(defun anvil-org-watch--ensure-dir ()
+  "Create `anvil-org-watch-dir' with mode 0700 if absent."
+  (unless (file-directory-p anvil-org-watch-dir)
+    (make-directory anvil-org-watch-dir t)
+    (set-file-modes anvil-org-watch-dir #o700)))
+
+(defun anvil-org-watch--transport-path (subscriber-id)
+  "Return the transport file path for SUBSCRIBER-ID."
+  (expand-file-name
+   (concat (url-hexify-string subscriber-id) ".ndjson")
+   anvil-org-watch-dir))
+
+(defun anvil-org-watch--file-monitored-p (path)
+  "Return non-nil if PATH is currently open by any process.
+When lsof(1) is unavailable the file is conservatively treated as
+monitored, so stale subscribers are never reaped by mistake."
+  (and (file-exists-p path)
+       (if (executable-find "lsof")
+           (= 0 (call-process "lsof" nil nil nil "-t" path))
+         t)))
+
+(defun anvil-org-watch--reap-stale ()
+  "Drop subscribers whose transport file has no active monitor.
+Also deletes their transport files."
+  (let ((stale '()))
+    (maphash
+     (lambda (sid entry)
+       (let ((path (plist-get entry :transport-path)))
+         (unless (anvil-org-watch--file-monitored-p path)
+           (push sid stale))))
+     anvil-org-watch--subscribers)
+    (dolist (sid stale)
+      (let* ((entry (gethash sid anvil-org-watch--subscribers))
+             (path (and entry (plist-get entry :transport-path))))
+        (when (and path (file-exists-p path))
+          (ignore-errors (delete-file path)))
+        (remhash sid anvil-org-watch--subscribers)))))
+
+(defun anvil-org-watch--build-set (watch-uuids)
+  "Build a hash-set from WATCH-UUIDS (vector / list / nil)."
+  (let ((set (make-hash-table :test 'equal)))
+    (cond
+     ((null watch-uuids) nil)
+     ((vectorp watch-uuids)
+      (mapc (lambda (u) (puthash u t set)) (append watch-uuids nil)))
+     ((listp watch-uuids)
+      (mapc (lambda (u) (puthash u t set)) watch-uuids))
+     (t
+      (anvil-org--tool-validation-error
+       "Invalid watch_uuids format (expected array): %S" watch-uuids)))
+    (maphash
+     (lambda (u _v)
+       (unless (stringp u)
+         (anvil-org--tool-validation-error
+          "watch_uuids entries must be strings, got: %S" u)))
+     set)
+    set))
+
+(defun anvil-org-watch--iso8601-utc (&optional time)
+  "Return ISO-8601 UTC timestamp for TIME (or current time)."
+  (format-time-string "%Y-%m-%dT%H:%M:%SZ" (or time (current-time)) t))
+
+(defun anvil-org-watch--append-line (path line)
+  "Append LINE (with trailing newline) to PATH atomically.
+PATH's directory must exist."
+  (let ((coding-system-for-write 'utf-8-unix))
+    (write-region (concat line "\n") nil path 'append 'silent)))
+
+(defun anvil-org-watch--emit (payload-alist uuid)
+  "Append one JSON line per matching subscriber for the event on UUID.
+PAYLOAD-ALIST is the event payload."
+  (let ((line (json-encode payload-alist)))
+    (maphash
+     (lambda (_sid entry)
+       (let ((set (plist-get entry :watch-set))
+             (path (plist-get entry :transport-path)))
+         (when (and set path (gethash uuid set))
+           (condition-case _err
+               (anvil-org-watch--append-line path line)
+             (error nil)))))
+     anvil-org-watch--subscribers)))
+
+(defun anvil-org-watch--allowed-buffer-p ()
+  "Non-nil when the current buffer visits a file in the allowed list."
+  (when-let* ((path (buffer-file-name)))
+    (anvil-org--find-allowed-file path)))
+
+(defun anvil-org-watch--state-change-handler ()
+  "Hook function for `org-after-todo-state-change-hook'.
+Emits one NDJSON line per matching subscriber to its transport file.
+Short-circuits when the buffer is not in `anvil-org-allowed-files',
+when the heading carries no `:ID:' property, or when no subscriber
+is watching that id."
+  (condition-case _err
+      (when (anvil-org-watch--allowed-buffer-p)
+        (when-let* ((id (org-entry-get nil "ID")))
+          (let* ((headline (or (org-get-heading t t t t) ""))
+                 (previous (or (bound-and-true-p org-last-state) ""))
+                 (new (or (bound-and-true-p org-state) ""))
+                 (payload
+                  `((uuid . ,id)
+                    (file . ,(buffer-file-name))
+                    (headline . ,headline)
+                    (previous_state . ,(or previous ""))
+                    (new_state . ,(or new ""))
+                    (timestamp . ,(anvil-org-watch--iso8601-utc)))))
+            (anvil-org-watch--emit payload id))))
+    (error nil)))
+
+(defun anvil-org-watch--tool-register (subscriber_id watch_uuids)
+  "Register SUBSCRIBER_ID with WATCH_UUIDS watch-set.
+Idempotent: replaces any existing entry and truncates the transport file.
+
+MCP Parameters:
+  subscriber_id - Caller-generated UUID identifying this subscriber
+  watch_uuids - Array of heading UUIDs to watch (may be empty)"
+  (anvil-server-with-error-handling
+    (unless (and (stringp subscriber_id) (length> subscriber_id 0))
+      (anvil-org--tool-validation-error
+       "subscriber_id must be a non-empty string"))
+    (anvil-org-watch--ensure-dir)
+    (anvil-org-watch--reap-stale)
+    (let* ((set (anvil-org-watch--build-set watch_uuids))
+           (path (anvil-org-watch--transport-path subscriber_id)))
+      (when (file-exists-p path)
+        (delete-file path))
+      (anvil-org-watch--append-line path "")
+      ;; `write-region' with empty string + append leaves the file at
+      ;; exactly one newline; truncate it back to zero bytes.
+      (write-region "" nil path nil 'silent)
+      (puthash subscriber_id
+               (list :watch-set set
+                     :transport-path path)
+               anvil-org-watch--subscribers)
+      (json-encode
+       `((ok . t)
+         (subscriber_id . ,subscriber_id)
+         (watch_count . ,(if set (hash-table-count set) 0))
+         (transport_path . ,path))))))
+
+(defun anvil-org-watch--tool-unregister (subscriber_id)
+  "Unregister SUBSCRIBER_ID and delete its transport file.
+Idempotent: a second call returns ok without error.
+
+MCP Parameters:
+  subscriber_id - Caller-generated UUID identifying this subscriber"
+  (anvil-server-with-error-handling
+    (unless (and (stringp subscriber_id) (length> subscriber_id 0))
+      (anvil-org--tool-validation-error
+       "subscriber_id must be a non-empty string"))
+    (let* ((entry (gethash subscriber_id anvil-org-watch--subscribers))
+           (path (or (and entry (plist-get entry :transport-path))
+                     (anvil-org-watch--transport-path subscriber_id))))
+      (when (and path (file-exists-p path))
+        (ignore-errors (delete-file path)))
+      (remhash subscriber_id anvil-org-watch--subscribers)
+      (json-encode `((ok . t))))))
+
+;;;###autoload
+(defun anvil-org-watch-enable ()
+  "Install the org-state-change signal channel.
+Idempotent: hooks/tool registrations are added at most once."
+  (anvil-server-register-tool
+   #'anvil-org-watch--tool-register
+   :id "org-watch-register"
+   :intent '(org-watch)
+   :layer 'workflow
+   :description
+   "Register a subscriber on the org-state-change signal channel.
+
+The channel emits one NDJSON line per TODO state transition on any
+heading whose `:ID:' property matches the subscriber's watch-set, for
+any writer path (this MCP server, interactive `C-c C-t', `org-agenda',
+or programmatic `org-todo').  Filtering is server-side: nothing is
+written to the transport file for UUIDs the subscriber is not
+watching.
+
+Idempotent: re-registering the same `subscriber_id' replaces the
+watch-set and truncates the transport file (so a resuming subscriber
+starts from a clean cursor and never replays historical events).
+
+Parameters:
+  subscriber_id - Caller-generated UUID identifying this subscriber
+                  (string, required, non-empty).  Every call from the
+                  same logical client must reuse the same id.
+  watch_uuids - Array of heading UUIDs to watch (required; may be the
+                empty array).  Each entry must be a string.
+
+Returns JSON object:
+  ok - Always true on success (boolean)
+  subscriber_id - The id that was registered (string)
+  watch_count - Number of UUIDs in the watch-set (integer)
+  transport_path - Absolute path to the per-subscriber NDJSON file
+                   the caller should tail (e.g. with
+                   `tail -F -n +1 <path>')"
+   :read-only nil
+   :schema
+   '((type . "object")
+     (properties
+      . (("subscriber_id"
+          . ((type . "string")
+             (description
+              . "Caller-generated UUID identifying this subscriber (non-empty).  Every call from the same logical client must reuse the same id.")))
+         ("watch_uuids"
+          . ((type . "array")
+             (items . ((type . "string")))
+             (description
+              . "Array of heading UUIDs to watch (may be the empty array).  Each entry must be a string.")))))
+     (required . ["subscriber_id" "watch_uuids"]))
+   :server-id anvil-org--server-id)
+  (anvil-server-register-tool
+   #'anvil-org-watch--tool-unregister
+   :id "org-watch-unregister"
+   :intent '(org-watch)
+   :layer 'workflow
+   :description
+   "Unregister a subscriber from the org-state-change signal channel
+and delete its transport file.
+
+Idempotent: calling on an unknown `subscriber_id' returns ok without
+error.  Subscribers whose transport file has no active monitor are
+reaped lazily on the next registration.
+
+Parameters:
+  subscriber_id - The id passed to `org-watch-register' (string,
+                  required, non-empty).
+
+Returns JSON object:
+  ok - Always true on success (boolean)"
+   :read-only nil
+   :schema
+   '((type . "object")
+     (properties
+      . (("subscriber_id"
+          . ((type . "string")
+             (description
+              . "The id passed to `org-watch-register' (non-empty).")))))
+     (required . ["subscriber_id"]))
+   :server-id anvil-org--server-id)
+  (add-hook 'org-after-todo-state-change-hook
+            #'anvil-org-watch--state-change-handler))
+
+(defun anvil-org-watch-disable ()
+  "Tear down the org-state-change signal channel."
+  (remove-hook 'org-after-todo-state-change-hook
+               #'anvil-org-watch--state-change-handler)
+  (ignore-errors
+    (anvil-server-unregister-tool "org-watch-register"
+                                  anvil-org--server-id))
+  (ignore-errors
+    (anvil-server-unregister-tool "org-watch-unregister"
+                                  anvil-org--server-id)))
+
+(provide 'anvil-org-watch)
+;;; anvil-org-watch.el ends here

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -268,6 +268,11 @@ Hand-built to avoid `json-encode' cumulative degradation."
                 (push ":" parts)
                 (push (anvil-server--js-schema (cdr prop)) parts)))
             (push "}" parts))
+           ((and (consp val) (consp (car val)))
+            ;; Nested schema alist (e.g. an array's `items') — recurse.
+            ;; Provided :schema values reach here; the generator's own
+            ;; bounded shape never nests below `properties'.
+            (push (anvil-server--js-schema val) parts))
            (t
             ;; Fallback: stringify
             (push (anvil-server--js-string (format "%s" val)) parts)))))

--- a/tests/anvil-org-watch-test.el
+++ b/tests/anvil-org-watch-test.el
@@ -1,0 +1,525 @@
+;;; anvil-org-watch-test.el --- Org signal-channel ERTs -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+(require 'anvil)
+(require 'anvil-org)
+(require 'anvil-server)
+(require 'anvil-server-ert)
+(require 'anvil-org-watch)
+
+;;; --- Signal-channel fixture -----------------------------------------
+
+(defvar anvil-org-test--watch-fixture nil
+  "Plist holding the active signal-channel test fixture.
+Keys: :file (temp .org file path), :watch-dir (temp watch dir),
+:uuid-a, :uuid-b, :headline-a, :headline-b,
+:saved-allowed, :saved-watch-dir, :saved-server-id,
+:saved-subscribers, :saved-hook.")
+
+(defun anvil-org-test--watch-make-org-file ()
+  "Create a temp .org file with two TODO headings and return its path."
+  (let* ((path (make-temp-file "anvil-org-watch-" nil ".org"))
+         (uuid-a "11111111-1111-1111-1111-111111111111")
+         (uuid-b "22222222-2222-2222-2222-222222222222"))
+    (with-temp-file path
+      (insert "* TODO Heading A\n"
+              ":PROPERTIES:\n"
+              ":ID:       " uuid-a "\n"
+              ":END:\n"
+              "\n"
+              "* TODO Heading B\n"
+              ":PROPERTIES:\n"
+              ":ID:       " uuid-b "\n"
+              ":END:\n"))
+    path))
+
+(defun anvil-org-test--watch-setup ()
+  "Install the signal-channel test fixture."
+  (let* ((path (anvil-org-test--watch-make-org-file))
+         (watch-dir (make-temp-file "anvil-org-watch-dir-" t)))
+    (setq anvil-org-test--watch-fixture
+          (list :file path
+                :watch-dir watch-dir
+                :uuid-a "11111111-1111-1111-1111-111111111111"
+                :uuid-b "22222222-2222-2222-2222-222222222222"
+                :headline-a "Heading A"
+                :headline-b "Heading B"
+                :saved-allowed anvil-org-allowed-files
+                :saved-watch-dir anvil-org-watch-dir
+                :saved-server-id anvil-server-ert-server-id
+                :saved-subscribers (copy-hash-table
+                                    anvil-org-watch--subscribers)
+                :saved-hook (copy-sequence
+                             org-after-todo-state-change-hook)))
+    (setq anvil-org-allowed-files (list path))
+    (setq anvil-org-watch-dir (file-name-as-directory watch-dir))
+    (setq anvil-server-ert-server-id "emacs-eval")
+    (setq anvil-org-watch--subscribers (make-hash-table :test 'equal))
+    ;; Register the org + org-watch tools and install the hook
+    ;; (re-entrant: registration is ref-counted, add-hook idempotent).
+    (anvil-org-enable)
+    (anvil-org-watch-enable)))
+
+(defun anvil-org-test--watch-teardown ()
+  "Tear down the signal-channel test fixture.
+Restores the global hook and subscribers table snapshots so test
+runs are isolated from each other."
+  (let* ((fx anvil-org-test--watch-fixture)
+         (path (plist-get fx :file))
+         (watch-dir (plist-get fx :watch-dir)))
+    (when (and path (file-exists-p path))
+      (delete-file path))
+    (when (and watch-dir (file-directory-p watch-dir))
+      (delete-directory watch-dir t))
+    (setq anvil-org-allowed-files (plist-get fx :saved-allowed))
+    (setq anvil-org-watch-dir (plist-get fx :saved-watch-dir))
+    (setq anvil-server-ert-server-id (plist-get fx :saved-server-id))
+    (setq anvil-org-watch--subscribers
+          (or (plist-get fx :saved-subscribers)
+              (make-hash-table :test 'equal)))
+    (anvil-org-watch-disable)
+    (anvil-org-disable)
+    (setq org-after-todo-state-change-hook (plist-get fx :saved-hook))
+    (setq anvil-org-test--watch-fixture nil)))
+
+(defmacro anvil-org-test--with-watch-fixture (&rest body)
+  "Run BODY with the signal-channel fixture installed.
+Stubs `anvil-org-watch--file-monitored-p' to treat every existing
+transport file as monitored: batch test runs have no tailing process,
+and without the stub a second registration would reap the first
+subscriber."
+  (declare (indent 0) (debug t))
+  `(unwind-protect
+       (progn
+         (anvil-org-test--watch-setup)
+         (cl-letf (((symbol-function 'anvil-org-watch--file-monitored-p)
+                    #'file-exists-p))
+           ,@body))
+     (anvil-org-test--watch-teardown)))
+
+(defun anvil-org-test--read-ndjson (path)
+  "Return the list of decoded JSON objects from NDJSON file at PATH."
+  (when (file-exists-p path)
+    (with-temp-buffer
+      (insert-file-contents path)
+      (let ((lines (split-string (buffer-string) "\n" t))
+            (out '()))
+        (dolist (line lines)
+          (unless (string-empty-p (string-trim line))
+            (push (json-read-from-string line) out)))
+        (nreverse out)))))
+
+(defun anvil-org-test--toggle-todo-via-org-todo (uuid new-state)
+  "Open the fixture file and call `org-todo' on UUID to set NEW-STATE."
+  (let* ((fx anvil-org-test--watch-fixture)
+         (file (plist-get fx :file)))
+    (with-current-buffer (find-file-noselect file)
+      (revert-buffer t t)
+      (goto-char (point-min))
+      ;; org-id-goto needs a populated org-id DB; locate the property
+      ;; directly so batch runs need no org-id-locations state.
+      (goto-char (org-find-property "ID" uuid))
+      (org-back-to-heading t)
+      (let ((org-todo-log-states nil))
+        (org-todo new-state))
+      (save-buffer)
+      (kill-buffer (current-buffer)))))
+
+
+;;; --- Live-server signal-channel tests -------------------------------
+
+(ert-deftest anvil-org-test-watch-register-creates-empty-transport ()
+  "Register creates the NDJSON transport file as an empty file."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-empty-xform")
+             (raw
+              (anvil-server-ert-call-tool
+               "org-watch-register"
+               `(("subscriber_id" . ,sub)
+                 ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+             (decoded (json-read-from-string raw))
+             (path (cdr (assq 'transport_path decoded))))
+        (should (eq t (cdr (assq 'ok decoded))))
+        (should (equal sub (cdr (assq 'subscriber_id decoded))))
+        (should (equal 1 (cdr (assq 'watch_count decoded))))
+        (should (stringp path))
+        (should (file-exists-p path))
+        (should (= 0 (file-attribute-size (file-attributes path))))))))
+
+(ert-deftest anvil-org-test-watch-register-truncates-existing-file ()
+  "Re-registering truncates the transport file."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-trunc"))
+        (let* ((raw
+                (anvil-server-ert-call-tool
+                 "org-watch-register"
+                 `(("subscriber_id" . ,sub)
+                   ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+               (path (cdr (assq 'transport_path
+                                (json-read-from-string raw)))))
+          (with-temp-buffer
+            (insert "{\"stale\":true}\n")
+            (write-region (point-min) (point-max) path))
+          (should (> (file-attribute-size (file-attributes path)) 0))
+          (let ((raw2
+                 (anvil-server-ert-call-tool
+                  "org-watch-register"
+                  `(("subscriber_id" . ,sub)
+                    ("watch_uuids" . ,(vector (plist-get fx :uuid-a)))))))
+            (let ((path2 (cdr (assq 'transport_path
+                                    (json-read-from-string raw2)))))
+              (should (equal path path2))
+              (should (= 0 (file-attribute-size
+                            (file-attributes path2)))))))))))
+
+(ert-deftest anvil-org-test-watch-hook-fires-from-mcp-update ()
+  "MCP `org-update-todo-state' fires the hook and emits one event."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-mcp")
+             (raw
+              (anvil-server-ert-call-tool
+               "org-watch-register"
+               `(("subscriber_id" . ,sub)
+                 ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+             (path (cdr (assq 'transport_path
+                              (json-read-from-string raw)))))
+        (anvil-server-ert-call-tool
+         "org-update-todo-state"
+         `(("uri" . ,(concat "org-id://" (plist-get fx :uuid-a)))
+           ("current_state" . "TODO")
+           ("new_state" . "DONE")))
+        (let* ((events (anvil-org-test--read-ndjson path)))
+          (should (= 1 (length events)))
+          (let ((e (car events)))
+            (should (equal (plist-get fx :uuid-a)
+                           (cdr (assq 'uuid e))))
+            (should (equal (plist-get fx :file)
+                           (cdr (assq 'file e))))
+            (should (equal (plist-get fx :headline-a)
+                           (cdr (assq 'headline e))))
+            (should (equal "TODO" (cdr (assq 'previous_state e))))
+            (should (equal "DONE" (cdr (assq 'new_state e))))
+            (should (stringp (cdr (assq 'timestamp e))))
+            (should (string-match-p
+                     "\\`[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}T[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}Z\\'"
+                     (cdr (assq 'timestamp e))))))))))
+
+(ert-deftest anvil-org-test-watch-hook-fires-from-direct-org-todo ()
+  "Direct `org-todo' in a buffer (interactive path) also fires the hook."
+  (anvil-org-test--with-watch-fixture
+    (let* ((fx anvil-org-test--watch-fixture)
+           (sub "sub-direct"))
+      (anvil-server-ert-with-server :tools t :resources t
+        (let* ((raw
+                (anvil-server-ert-call-tool
+                 "org-watch-register"
+                 `(("subscriber_id" . ,sub)
+                   ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+               (path (cdr (assq 'transport_path
+                                (json-read-from-string raw)))))
+          (anvil-org-test--toggle-todo-via-org-todo
+           (plist-get fx :uuid-a) "DONE")
+          (let ((events (anvil-org-test--read-ndjson path)))
+            (should (= 1 (length events)))
+            (should (equal "DONE"
+                           (cdr (assq 'new_state (car events)))))))))))
+
+(ert-deftest anvil-org-test-watch-set-filtering ()
+  "An event for a non-watched UUID does not leak to the subscriber."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-filter")
+             (raw
+              (anvil-server-ert-call-tool
+               "org-watch-register"
+               `(("subscriber_id" . ,sub)
+                 ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+             (path (cdr (assq 'transport_path
+                              (json-read-from-string raw)))))
+        (anvil-server-ert-call-tool
+         "org-update-todo-state"
+         `(("uri" . ,(concat "org-id://" (plist-get fx :uuid-b)))
+           ("current_state" . "TODO")
+           ("new_state" . "DONE")))
+        (should (= 0 (length (anvil-org-test--read-ndjson path))))))))
+
+(ert-deftest anvil-org-test-watch-multi-subscriber-broadcast ()
+  "Two subscribers with overlapping watch-sets each receive one line."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub-1 "sub-1")
+             (sub-2 "sub-2")
+             (uuid-a (plist-get fx :uuid-a))
+             (uuid-b (plist-get fx :uuid-b))
+             (p1
+              (cdr (assq 'transport_path
+                         (json-read-from-string
+                          (anvil-server-ert-call-tool
+                           "org-watch-register"
+                           `(("subscriber_id" . ,sub-1)
+                             ("watch_uuids" . ,(vector uuid-a uuid-b))))))))
+             (p2
+              (cdr (assq 'transport_path
+                         (json-read-from-string
+                          (anvil-server-ert-call-tool
+                           "org-watch-register"
+                           `(("subscriber_id" . ,sub-2)
+                             ("watch_uuids" . ,(vector uuid-a)))))))))
+        (anvil-server-ert-call-tool
+         "org-update-todo-state"
+         `(("uri" . ,(concat "org-id://" uuid-a))
+           ("current_state" . "TODO")
+           ("new_state" . "DONE")))
+        (anvil-server-ert-call-tool
+         "org-update-todo-state"
+         `(("uri" . ,(concat "org-id://" uuid-b))
+           ("current_state" . "TODO")
+           ("new_state" . "DONE")))
+        (should (= 2 (length (anvil-org-test--read-ndjson p1))))
+        (let ((ev (anvil-org-test--read-ndjson p2)))
+          (should (= 1 (length ev)))
+          (should (equal uuid-a (cdr (assq 'uuid (car ev))))))))))
+
+(ert-deftest anvil-org-test-watch-unregister-removes-state ()
+  "Unregister deletes the transport file and the broker entry."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-unreg")
+             (raw
+              (anvil-server-ert-call-tool
+               "org-watch-register"
+               `(("subscriber_id" . ,sub)
+                 ("watch_uuids" . ,(vector (plist-get fx :uuid-a))))))
+             (path (cdr (assq 'transport_path
+                              (json-read-from-string raw)))))
+        (should (file-exists-p path))
+        (should (gethash sub anvil-org-watch--subscribers))
+        (let* ((raw2
+                (anvil-server-ert-call-tool
+                 "org-watch-unregister"
+                 `(("subscriber_id" . ,sub))))
+               (decoded (json-read-from-string raw2)))
+          (should (eq t (cdr (assq 'ok decoded)))))
+        (should-not (file-exists-p path))
+        (should-not (gethash sub anvil-org-watch--subscribers))
+        (let ((raw3
+               (anvil-server-ert-call-tool
+                "org-watch-unregister"
+                `(("subscriber_id" . ,sub)))))
+          (should (eq t (cdr (assq 'ok (json-read-from-string raw3))))))))))
+
+(ert-deftest anvil-org-test-watch-reregister-after-unregister ()
+  "Register after unregister works cleanly and starts from an empty file."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((fx anvil-org-test--watch-fixture)
+             (sub "sub-rereg")
+             (uuid-a (plist-get fx :uuid-a))
+             (raw1
+              (anvil-server-ert-call-tool
+               "org-watch-register"
+               `(("subscriber_id" . ,sub)
+                 ("watch_uuids" . ,(vector uuid-a)))))
+             (path1 (cdr (assq 'transport_path
+                               (json-read-from-string raw1)))))
+        (anvil-server-ert-call-tool
+         "org-update-todo-state"
+         `(("uri" . ,(concat "org-id://" uuid-a))
+           ("current_state" . "TODO")
+           ("new_state" . "DONE")))
+        (should (= 1 (length (anvil-org-test--read-ndjson path1))))
+        (anvil-server-ert-call-tool
+         "org-watch-unregister"
+         `(("subscriber_id" . ,sub)))
+        (let* ((raw2
+                (anvil-server-ert-call-tool
+                 "org-watch-register"
+                 `(("subscriber_id" . ,sub)
+                   ("watch_uuids" . ,(vector uuid-a)))))
+               (path2 (cdr (assq 'transport_path
+                                 (json-read-from-string raw2)))))
+          (should (file-exists-p path2))
+          (should (= 0 (length (anvil-org-test--read-ndjson path2)))))))))
+
+(ert-deftest anvil-org-test-watch-handler-tolerates-no-id ()
+  "Handler does not error when the heading has no `:ID:'."
+  (anvil-org-test--with-watch-fixture
+    (let* ((fx anvil-org-test--watch-fixture)
+           (file (plist-get fx :file)))
+      (with-temp-buffer
+        (insert "\n* TODO No-ID heading\n")
+        (write-region (point-min) (point-max) file 'append))
+      (with-current-buffer (find-file-noselect file)
+        (revert-buffer t t)
+        (goto-char (point-max))
+        (re-search-backward "No-ID heading")
+        (should-not (org-entry-get nil "ID"))
+        (let ((org-state "DONE")
+              (org-last-state "TODO"))
+          (anvil-org-watch--state-change-handler))
+        (kill-buffer (current-buffer))))))
+
+(ert-deftest anvil-org-test-watch-handler-tolerates-disallowed-buffer ()
+  "Handler does not error when the buffer is not in the allowed list."
+  (anvil-org-test--with-watch-fixture
+    (let ((stranger (make-temp-file "anvil-org-stranger-" nil ".org")))
+      (unwind-protect
+          (progn
+            (with-temp-file stranger
+              (insert "* TODO Stranger\n"
+                      ":PROPERTIES:\n"
+                      ":ID:       99999999-9999-9999-9999-999999999999\n"
+                      ":END:\n"))
+            (with-current-buffer (find-file-noselect stranger)
+              (revert-buffer t t)
+              (goto-char (point-min))
+              (let ((org-state "DONE")
+                    (org-last-state "TODO"))
+                (anvil-org-watch--state-change-handler))
+              (kill-buffer (current-buffer))))
+        (when (file-exists-p stranger)
+          (delete-file stranger))))))
+
+(ert-deftest anvil-org-test-watch-tools-listed ()
+  "Both new tools appear in tools/list from a fresh server."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((request
+              (anvil-server-create-tools-list-request))
+             (response
+              (anvil-server-process-jsonrpc-parsed
+               request anvil-server-ert-server-id))
+             (result (alist-get 'result response))
+             (tools (alist-get 'tools result))
+             (names (mapcar (lambda (t-alist)
+                              (alist-get 'name t-alist))
+                            (append tools nil))))
+        (should (member "org-watch-register" names))
+        (should (member "org-watch-unregister" names))))))
+
+(ert-deftest anvil-org-test-watch-register-input-schema-shape ()
+  "Advertised inputSchema for `org-watch-register' types `watch_uuids'
+as an array of strings (not a string), with non-empty descriptions on
+both required parameters.  Guards the MCP-path bug where the schema
+auto-generator would type every parameter as string and the live MCP
+client would reject array arguments before dispatch."
+  (anvil-org-test--with-watch-fixture
+    (anvil-server-ert-with-server :tools t :resources t
+      (let* ((request
+              (anvil-server-create-tools-list-request))
+             (response
+              (anvil-server-process-jsonrpc-parsed
+               request anvil-server-ert-server-id))
+             (result (alist-get 'result response))
+             (tools (append (alist-get 'tools result) nil))
+             (entry
+              (seq-find
+               (lambda (t-alist)
+                 (equal (alist-get 'name t-alist) "org-watch-register"))
+               tools))
+             (schema (alist-get 'inputSchema entry))
+             (properties (alist-get 'properties schema))
+             (required (alist-get 'required schema))
+             (sub (alist-get 'subscriber_id properties))
+             (wu (alist-get 'watch_uuids properties))
+             (wu-items (alist-get 'items wu)))
+        (should entry)
+        (should (equal (alist-get 'type schema) "object"))
+        (should (equal (alist-get 'type sub) "string"))
+        (should (stringp (alist-get 'description sub)))
+        (should (> (length (alist-get 'description sub)) 0))
+        (should (equal (alist-get 'type wu) "array"))
+        (should (equal (alist-get 'type wu-items) "string"))
+        (should (stringp (alist-get 'description wu)))
+        (should (> (length (alist-get 'description wu)) 0))
+        (let ((req-list (append required nil)))
+          (should (member "subscriber_id" req-list))
+          (should (member "watch_uuids" req-list)))))))
+
+
+;;; --- End-to-end integration (fixture-bypass) ------------------------
+
+(ert-deftest anvil-org-test-watch-end-to-end-emit-via-live-hook ()
+  "Register via MCP tools-call → real `org-todo' on a temp .org file
+added to `anvil-org-allowed-files' → tail the transport file → assert
+exactly one NDJSON line with all six fields and matching uuid.
+
+Owns its setup top-to-bottom (no shared fixture) so a fixture
+regression cannot mask it.  Confirms the live global hook actually
+delivers the emit when a real writer changes a TODO state."
+  (let* ((saved-allowed anvil-org-allowed-files)
+         (saved-watch-dir anvil-org-watch-dir)
+         (saved-subscribers (copy-hash-table anvil-org-watch--subscribers))
+         (saved-hook (copy-sequence org-after-todo-state-change-hook))
+         (saved-server-id anvil-server-ert-server-id)
+         (uuid "33333333-3333-3333-3333-333333333333")
+         (path (make-temp-file "anvil-org-e2e-" nil ".org"))
+         (watch-dir (make-temp-file "anvil-org-e2e-watch-" t)))
+    (unwind-protect
+        (progn
+          (with-temp-file path
+            (insert "* TODO E2E Heading\n"
+                    ":PROPERTIES:\n"
+                    ":ID:       " uuid "\n"
+                    ":END:\n"))
+          (setq anvil-org-allowed-files (list path))
+          (setq anvil-org-watch-dir (file-name-as-directory watch-dir))
+          (setq anvil-server-ert-server-id "emacs-eval")
+          (setq anvil-org-watch--subscribers (make-hash-table :test 'equal))
+          (anvil-org-enable)
+          (anvil-org-watch-enable)
+          (should (memq 'anvil-org-watch--state-change-handler
+                        org-after-todo-state-change-hook))
+          (anvil-server-ert-with-server :tools t :resources t
+            (let* ((sub "sub-e2e")
+                   (raw
+                    (anvil-server-ert-call-tool
+                     "org-watch-register"
+                     `(("subscriber_id" . ,sub)
+                       ("watch_uuids" . ,(vector uuid)))))
+                   (decoded (json-read-from-string raw))
+                   (transport (cdr (assq 'transport_path decoded))))
+              (should (eq t (cdr (assq 'ok decoded))))
+              (should (file-exists-p transport))
+              (with-current-buffer (find-file-noselect path)
+                (revert-buffer t t)
+                (goto-char (point-min))
+                (goto-char (org-find-property "ID" uuid))
+                (org-back-to-heading t)
+                (let ((org-todo-log-states nil))
+                  (org-todo "DONE"))
+                (save-buffer)
+                (kill-buffer (current-buffer)))
+              (let ((events (anvil-org-test--read-ndjson transport)))
+                (should (= 1 (length events)))
+                (let ((e (car events)))
+                  (should (equal uuid (cdr (assq 'uuid e))))
+                  (should (equal path (cdr (assq 'file e))))
+                  (should (equal "E2E Heading"
+                                 (cdr (assq 'headline e))))
+                  (should (equal "TODO" (cdr (assq 'previous_state e))))
+                  (should (equal "DONE" (cdr (assq 'new_state e))))
+                  (should (stringp (cdr (assq 'timestamp e)))))))))
+      (when (file-exists-p path) (delete-file path))
+      (when (file-directory-p watch-dir) (delete-directory watch-dir t))
+      (anvil-org-watch-disable)
+      (anvil-org-disable)
+      (setq anvil-org-allowed-files saved-allowed)
+      (setq anvil-org-watch-dir saved-watch-dir)
+      (setq anvil-server-ert-server-id saved-server-id)
+      (setq anvil-org-watch--subscribers saved-subscribers)
+      (setq org-after-todo-state-change-hook saved-hook))))
+
+(provide 'anvil-org-watch-test)
+;;; anvil-org-watch-test.el ends here


### PR DESCRIPTION
## What

A new optional module, `anvil-org-watch.el`: a per-Emacs-session broker that emits one NDJSON line per org TODO state transition into a per-subscriber transport file.

```
agent ──tools/call──▶ org-watch-register {subscriber_id, watch_uuids}
                      ◀── {ok, transport_path}
agent ──tail -F -n +1 transport_path   (no polling)

any writer (MCP tool / C-c C-t / org-agenda / org-todo)
  └─ org-after-todo-state-change-hook
       └─ matching subscribers get:
          {"uuid":…,"file":…,"headline":…,"previous_state":"TODO",
           "new_state":"DONE","timestamp":"2026-06-12T18:00:00Z"}
```

## Why

Agent workflows that hand work items to humans (or other agents) as org TODOs need to react when a state changes. Without a push channel the options are polling org files from outside (expensive, racy) or only noticing changes made through the MCP tools (misses `C-c C-t` and agenda edits). The hook-based channel sees **every** writer path; filtering is server-side (one hash lookup per transition, nothing written for unwatched UUIDs), and the handler short-circuits for buffers outside `anvil-org-allowed-files` or headings without an `:ID:`.

Design notes: registration is idempotent — re-registering the same `subscriber_id` replaces the watch-set and truncates the transport file, so a resuming subscriber starts from a clean cursor and never replays history. Subscribers whose transport file is no longer open by any process are reaped lazily on the next registration (conservatively skipped when `lsof` is unavailable). The transport dir is created `0700`.

Loads as an optional module — `(add-to-list 'anvil-optional-modules 'org-watch)` — or via `anvil-org-watch-enable` directly; nothing is installed by default.

## Supporting fix (first commit)

`anvil-server--js-schema` only handles the auto-generator's bounded shape, where nothing nests below `properties`. A provided `:schema` with an array parameter carries `(items . ((type . "string")))`, which fell through to the stringify fallback and emitted a Lisp-printed string into the `tools/list` JSON. First commit makes it recurse into nested alist values; the module's `watch_uuids` array schema is the first in-tree user.

## Tests

`tests/anvil-org-watch-test.el` — 13 ERTs: register/truncate/unregister contracts, watch-set filtering, multi-subscriber broadcast, no-ID and unwatched short-circuits, tools/list schema shape (exercising the nested `items` encoding), and an end-to-end test that registers through MCP `tools/call`, fires a real `org-todo`, and asserts the delivered NDJSON event.

```
Ran 13 tests, 13 results as expected, 0 unexpected
Ran 27 tests, 27 results as expected, 0 unexpected   (anvil-org-test + anvil-server-cons-fix-test)
```