### PR TITLE
fix(eval): skip org fast-mode for buffers that outlive the tool call

### DIFF
--- a/anvil-eval.el
+++ b/anvil-eval.el
@@ -83,7 +83,16 @@ Set automatically for the duration of each MCP tool call.")
 
 (defun anvil-eval--org-mode-fast-advice (orig-fn &rest args)
   "Make `org-mode' setup minimal when called inside an MCP tool."
-  (if (and anvil-eval-org-fast-mode anvil-eval--in-org-fast-mode)
+  (if (and anvil-eval-org-fast-mode anvil-eval--in-org-fast-mode
+           ;; Skip the fast path for user agenda files: those buffers
+           ;; outlive the MCP tool call, and `(font-lock-mode -1)' on
+           ;; them sets `font-lock-mode-set-explicitly' so
+           ;; `global-font-lock-mode' never re-enables fontification —
+           ;; the buffer stays uncoloured for the rest of the session.
+           (not (and buffer-file-name
+                     (member (expand-file-name buffer-file-name)
+                             (mapcar #'expand-file-name
+                                     (org-agenda-files t t))))))
       (progn
         ;; setq-local, not let: Emacs 30's define-derived-mode calls
         ;; (make-local-variable 'delay-mode-hooks) inside org-mode, which

--- a/tests/anvil-eval-fast-mode-test.el
+++ b/tests/anvil-eval-fast-mode-test.el
@@ -1,0 +1,62 @@
+;;; anvil-eval-fast-mode-test.el --- ERT for org fast-mode buffer scoping -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; The org fast-mode advice runs `(font-lock-mode -1)' after a minimal
+;; `org-mode' setup.  That is right for the throwaway temp buffers the
+;; org tools create, but wrong for buffers that outlive the tool call:
+;; an explicit `font-lock-mode' call sets
+;; `font-lock-mode-set-explicitly', after which
+;; `global-font-lock-mode' refuses to re-enable fontification — the
+;; user's buffer stays uncoloured for the rest of the session.
+;;
+;; User agenda files are exactly the org buffers a user keeps open
+;; while MCP tools operate on them, so the advice now skips the fast
+;; path for files in `org-agenda-files'.
+
+;;; Code:
+
+(require 'ert)
+(require 'org)
+(require 'anvil)
+(require 'anvil-eval)
+
+(defmacro anvil-eval-fast-mode-test--with-org-file (var &rest body)
+  "Bind VAR to a temp org file path around BODY."
+  (declare (indent 1))
+  `(let ((,var (make-temp-file "anvil-fast-mode-test" nil ".org"
+                               "* Heading\nBody.\n")))
+     (unwind-protect
+         (progn ,@body)
+       (when-let* ((buf (find-buffer-visiting ,var)))
+         (kill-buffer buf))
+       (delete-file ,var))))
+
+(ert-deftest anvil-eval-fast-mode-test-agenda-file-keeps-font-lock ()
+  "The fast path is skipped for buffers visiting agenda files."
+  (anvil-eval-fast-mode-test--with-org-file file
+    (let ((anvil-eval-org-fast-mode t)
+          (anvil-eval--in-org-fast-mode t)
+          (org-agenda-files (list file)))
+      (with-current-buffer (find-file-noselect file)
+        ;; find-file-noselect already ran org-mode through the advice;
+        ;; re-run explicitly to pin the decision under fast-mode flags.
+        (anvil-eval--org-mode-fast-advice #'org-mode)
+        (should-not delay-mode-hooks)
+        (should-not (and (boundp 'font-lock-mode-set-explicitly)
+                         font-lock-mode-set-explicitly))))))
+
+(ert-deftest anvil-eval-fast-mode-test-other-files-stay-fast ()
+  "Non-agenda buffers still get the minimal fast-path setup."
+  (anvil-eval-fast-mode-test--with-org-file file
+    (let ((anvil-eval-org-fast-mode t)
+          (anvil-eval--in-org-fast-mode t)
+          (org-agenda-files nil))
+      (with-current-buffer (find-file-noselect file)
+        (anvil-eval--org-mode-fast-advice #'org-mode)
+        (should delay-mode-hooks)
+        (when (boundp 'org-element-use-cache)
+          (should-not org-element-use-cache))))))
+
+(provide 'anvil-eval-fast-mode-test)
+;;; anvil-eval-fast-mode-test.el ends here


### PR DESCRIPTION
## Problem

`anvil-eval--org-mode-fast-advice` finishes its minimal `org-mode` setup with `(font-lock-mode -1)`. For the throwaway temp buffers the org tools create that's exactly right — but the advice fires for *every* `org-mode` call made while a tool is dispatching, including `find-file-noselect` on a user's own org file. Calling `font-lock-mode` explicitly sets `font-lock-mode-set-explicitly`, after which `global-font-lock-mode` permanently refuses to re-enable fontification for that buffer: the user's agenda file stays uncoloured for the rest of the session, with no obvious cause.

## Fix

Skip the fast path when the buffer visits a file in `(org-agenda-files t t)` — agenda files are precisely the org buffers users keep open while MCP tools operate on them. Temp buffers and non-agenda files keep the fast path unchanged.

## Tests

`tests/anvil-eval-fast-mode-test.el`: agenda-file buffer keeps font-lock (and doesn't get `delay-mode-hooks`); non-agenda buffer still gets the minimal fast-path setup.

```
Ran 2 tests, 2 results as expected, 0 unexpected
```