### PR TITLE
feat(ert): reuse a running server in anvil-server-ert-with-server

### DIFF
--- a/anvil-server-ert.el
+++ b/anvil-server-ert.el
@@ -297,33 +297,40 @@ Starts the server, sends initialize request, then runs BODY.
 TOOLS and RESOURCES are booleans indicating expected capabilities.
 
 This macro:
-1. Starts the MCP server with `anvil-server-start'
+1. Starts the MCP server with `anvil-server-start' — unless one is
+   already running (`anvil-server-running-p'), in which case the
+   running server is reused and left running afterwards
 2. Sends and validates the initialize request
 3. Sends the initialized notification
 4. Executes BODY
-5. Stops the server with `anvil-server-stop'
+5. Stops the server with `anvil-server-stop' only when step 1
+   started it
 
 Arguments:
   TOOLS - If non-nil, expects server to have tools capability
   RESOURCES - If non-nil, expects server to have resources capability
   BODY - Forms to execute with server running"
  (declare (indent defun) (debug t))
- `(unwind-protect
-      (progn
-        (anvil-server-start)
-        (anvil-server-ert-assert-initialize-result
-         (anvil-server-ert--get-initialize-result)
-         ,tools
-         ,resources)
-        ;; Send initialized notification - should return nil
-        (should-not
-         (anvil-server-process-jsonrpc
-          (json-encode
-           '(("jsonrpc" . "2.0")
-             ("method" . "notifications/initialized")))
-          anvil-server-ert-server-id))
-        ,@body)
-    (anvil-server-stop)))
+ `(let ((anvil-server-ert--started-here-p
+         (not (anvil-server-running-p))))
+    (unwind-protect
+        (progn
+          (when anvil-server-ert--started-here-p
+            (anvil-server-start))
+          (anvil-server-ert-assert-initialize-result
+           (anvil-server-ert--get-initialize-result)
+           ,tools
+           ,resources)
+          ;; Send initialized notification - should return nil
+          (should-not
+           (anvil-server-process-jsonrpc
+            (json-encode
+             '(("jsonrpc" . "2.0")
+               ("method" . "notifications/initialized")))
+            anvil-server-ert-server-id))
+          ,@body)
+      (when anvil-server-ert--started-here-p
+        (anvil-server-stop)))))
 
 (defun anvil-server-ert-check-error-object
     (response expected-code expected-message)

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -158,6 +158,10 @@ definitions in the parser state machine.")
 (defvar anvil-server--running nil
   "Whether the MCP server is currently running.")
 
+(defun anvil-server-running-p ()
+  "Return non-nil if the Anvil MCP server is currently running."
+  (bound-and-true-p anvil-server--running))
+
 (defvar anvil-server--tools (make-hash-table :test 'equal)
   "Hash table of registered MCP tools by server.
 Keys are server-id strings, values are hash tables of tool-id to tool-data.")

--- a/tests/anvil-server-ert-reuse-test.el
+++ b/tests/anvil-server-ert-reuse-test.el
@@ -1,0 +1,109 @@
+;;; anvil-server-ert-reuse-test.el --- ERT for with-server reuse -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `anvil-server-ert-with-server' used to call `anvil-server-start'
+;; unconditionally, so the first ERT of any run errored with "MCP
+;; server is already running" whenever a live server was up — making
+;; the suites impossible to run from a session that actually uses the
+;; server.  The macro now consults `anvil-server-running-p': a running
+;; server is reused and left running; a cold start is torn down inside
+;; `unwind-protect' as before.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'anvil)
+(require 'anvil-server)
+(require 'anvil-server-commands)
+(require 'anvil-server-ert)
+
+(defun anvil-server-ert-reuse-test--sentinel-tool ()
+  "Sentinel handler used to advertise a tools capability during tests."
+  "ok")
+
+(defun anvil-server-ert-reuse-test--sentinel-resource ()
+  "Sentinel handler used to advertise a resources capability during tests."
+  "ok")
+
+(defmacro anvil-server-ert-reuse-test--with-clean-server (&rest body)
+  "Run BODY with a guaranteed-stopped server before and after.
+Registers a sentinel tool/resource so the :tools/:resources initialize
+asserts succeed in bare environments where no other module has
+registered anything."
+  (declare (indent 0) (debug t))
+  `(progn
+     (anvil-server-register-tool
+      #'anvil-server-ert-reuse-test--sentinel-tool
+      :id "ert-reuse-test-sentinel"
+      :description "Sentinel tool for ERT setup"
+      :server-id anvil-server-ert-server-id)
+     (anvil-server-register-resource
+      "ert-reuse-test://sentinel"
+      #'anvil-server-ert-reuse-test--sentinel-resource
+      :name "Sentinel"
+      :description "Sentinel resource for ERT setup"
+      :server-id anvil-server-ert-server-id)
+     (unwind-protect
+         (progn
+           (when (anvil-server-running-p) (anvil-server-stop))
+           ,@body)
+       (when (anvil-server-running-p) (anvil-server-stop)))))
+
+(ert-deftest anvil-server-ert-reuse-test-reuses-running-server ()
+  "Reuse path: pre-started server is reused; start/stop are not called."
+  (anvil-server-ert-reuse-test--with-clean-server
+    (anvil-server-start)
+    (should (anvil-server-running-p))
+    (let ((start-calls 0)
+          (stop-calls 0))
+      (cl-letf
+          (((symbol-function 'anvil-server-start)
+            (lambda (&rest _) (cl-incf start-calls)))
+           ((symbol-function 'anvil-server-stop)
+            (lambda (&rest _) (cl-incf stop-calls))))
+        (anvil-server-ert-with-server :tools t :resources t
+          (should (anvil-server-running-p))))
+      (should (= 0 start-calls))
+      (should (= 0 stop-calls)))
+    (should (anvil-server-running-p))))
+
+(ert-deftest anvil-server-ert-reuse-test-cold-path-starts-and-stops ()
+  "Cold path: no server running; macro starts then stops it."
+  (anvil-server-ert-reuse-test--with-clean-server
+    (should-not (anvil-server-running-p))
+    (let ((start-calls 0)
+          (stop-calls 0)
+          (real-start (symbol-function 'anvil-server-start))
+          (real-stop (symbol-function 'anvil-server-stop)))
+      (cl-letf
+          (((symbol-function 'anvil-server-start)
+            (lambda (&rest args)
+              (cl-incf start-calls)
+              (apply real-start args)))
+           ((symbol-function 'anvil-server-stop)
+            (lambda (&rest args)
+              (cl-incf stop-calls)
+              (apply real-stop args))))
+        (anvil-server-ert-with-server :tools t :resources t
+          (should (anvil-server-running-p))))
+      (should (= 1 start-calls))
+      (should (= 1 stop-calls)))
+    (should-not (anvil-server-running-p))))
+
+(ert-deftest anvil-server-ert-reuse-test-cold-path-signal-safety ()
+  "Cold path body signals: cleanup still stops the server."
+  (anvil-server-ert-reuse-test--with-clean-server
+    (should-not (anvil-server-running-p))
+    (let ((signalled nil))
+      (condition-case _err
+          (anvil-server-ert-with-server :tools t :resources t
+            (setq signalled t)
+            (error "boom"))
+        (error nil))
+      (should signalled))
+    (should-not (anvil-server-running-p))))
+
+(provide 'anvil-server-ert-reuse-test)
+;;; anvil-server-ert-reuse-test.el ends here


### PR DESCRIPTION
## Problem

`anvil-server-ert-with-server` calls `anvil-server-start` unconditionally, so the first ERT of any run errors with `MCP server is already running` whenever a live server is up. That makes the test suites impossible to run from the very session that uses anvil — you have to stop the server (breaking connected MCP clients) or spawn a separate Emacs just to run tests.

## Fix

- New public predicate `anvil-server-running-p` in `anvil-server.el` (next to the state variable, so `anvil-server-ert` gets it without extra requires).
- The macro binds `started-here-p` from it: a running server is **reused** and left running afterwards; a cold start is torn down in `unwind-protect` exactly as before, so a body that signals still leaves no orphan server. The reuse path's teardown is a no-op, so a body signal cannot stop a pre-existing server either.

## Tests

`tests/anvil-server-ert-reuse-test.el` (self-sufficient in `emacs -Q` via sentinel tool/resource registrations): reuse path calls neither start nor stop and leaves the server running; cold path starts and stops exactly once; cold path with a signalling body still stops the server.

```
Ran 3 tests, 3 results as expected, 0 unexpected
```