### PR TITLE
feat(org): bounded-depth org-read-by-id with child-headline footer

### DIFF
--- a/anvil-org-index.el
+++ b/anvil-org-index.el
@@ -1098,17 +1098,106 @@ a full parse rather than pick the wrong entry."
     (unless failed current)))
 
 ;;;###autoload
-(defun anvil-org-index-read-by-id (org-id)
-  "Return the text of the entire subtree whose :ID: property is ORG-ID.
-Uses the index to locate (file, line-range) in one SELECT, then
-reads only that line range of the file.  Signals `user-error' if
-ORG-ID is not in the index."
+(defun anvil-org-index--lookup-id-bounded (db org-id max-depth)
+  "Return (path line-start line-end level hid) for ORG-ID, bounded by MAX-DEPTH.
+MAX-DEPTH is a positive integer: 1 keeps just the target heading and
+its body, 2 adds immediate children, and so on.  A nil or non-positive
+MAX-DEPTH returns the full subtree range."
+  (let* ((row (car (anvil-org-index--select
+                    db
+                    "SELECT h.id, h.level, f.id, f.path, h.line_start
+                       FROM headline h JOIN file f ON f.id = h.file_id
+                      WHERE h.org_id = ? LIMIT 1"
+                    (list org-id)))))
+    (when row
+      (let* ((hid     (nth 0 row))
+             (level   (nth 1 row))
+             (file-id (nth 2 row))
+             (path    (nth 3 row))
+             (start   (nth 4 row))
+             (sibling-row (car (anvil-org-index--select
+                                db
+                                "SELECT MIN(line_start) FROM headline
+                                  WHERE file_id = ? AND line_start > ?
+                                    AND level <= ?"
+                                (list file-id start level))))
+             (sibling-start (car sibling-row))
+             (full-end (if (and sibling-start (numberp sibling-start))
+                           (1- sibling-start)
+                         0))
+             (cap-level (and max-depth
+                             (integerp max-depth)
+                             (> max-depth 0)
+                             (+ level (1- max-depth))))
+             (bounded-end
+              (if (not cap-level)
+                  full-end
+                (let* ((deeper-row
+                        (car (anvil-org-index--select
+                              db
+                              "SELECT MIN(line_start) FROM headline
+                                WHERE file_id = ? AND line_start > ?
+                                  AND level > ?
+                                  AND (? = 0 OR line_start <= ?)"
+                              (list file-id start cap-level
+                                    full-end full-end))))
+                       (deeper-start (car deeper-row)))
+                  (if (and deeper-start (numberp deeper-start))
+                      (1- deeper-start)
+                    full-end)))))
+        (list path start bounded-end level hid)))))
+
+(defun anvil-org-index--immediate-children-titles (db parent-hid)
+  "Return list of titles for headlines whose parent_id is PARENT-HID."
+  (mapcar #'car
+          (anvil-org-index--select
+           db
+           "SELECT title FROM headline
+             WHERE parent_id = ? ORDER BY position"
+           (list parent-hid))))
+
+(defun anvil-org-index-read-by-id (org-id &optional max-depth)
+  "Return the text of the subtree whose :ID: property is ORG-ID.
+Uses the index to locate (file, line-range) in one SELECT, then reads
+only that line range of the file.  MAX-DEPTH, when a positive integer,
+caps the depth of included headings (MAX-DEPTH=1 means the heading and
+its body only, no child subtrees).  nil or non-positive MAX-DEPTH
+returns the full subtree (backwards-compatible default).  Signals
+`user-error' if ORG-ID is not in the index."
   (unless anvil-org-index--db (anvil-org-index-enable))
-  (let ((loc (anvil-org-index--lookup-id-subtree
-              anvil-org-index--db org-id)))
+  (let ((loc (if (and max-depth (integerp max-depth) (> max-depth 0))
+                 (anvil-org-index--lookup-id-bounded
+                  anvil-org-index--db org-id max-depth)
+               (anvil-org-index--lookup-id-subtree
+                anvil-org-index--db org-id))))
     (unless loc
       (user-error "anvil-org-index: ID %s not found in index" org-id))
-    (apply #'anvil-org-index--read-file-region loc)))
+    (apply #'anvil-org-index--read-file-region (seq-take loc 3))))
+
+(defun anvil-org-index-read-by-id-with-children (org-id &optional max-depth)
+  "Return a plist describing ORG-ID's bounded subtree plus its child titles.
+Keys: :body (bounded subtree text), :children (immediate child
+headline titles, in order), :level (target heading level), :truncated
+(non-nil when MAX-DEPTH cut content off the full subtree)."
+  (unless anvil-org-index--db (anvil-org-index-enable))
+  (let ((loc (anvil-org-index--lookup-id-bounded
+              anvil-org-index--db org-id max-depth)))
+    (unless loc
+      (user-error "anvil-org-index: ID %s not found in index" org-id))
+    (pcase-let* ((`(,path ,line-start ,bounded-end ,level ,hid) loc)
+                 (full-loc (anvil-org-index--lookup-id-subtree
+                            anvil-org-index--db org-id))
+                 (full-end (and full-loc (nth 2 full-loc)))
+                 (children (anvil-org-index--immediate-children-titles
+                            anvil-org-index--db hid)))
+      (list :body (anvil-org-index--read-file-region
+                   path line-start bounded-end)
+            :children children
+            :level level
+            :truncated (and max-depth (integerp max-depth)
+                            (> max-depth 0)
+                            full-end
+                            (< bounded-end full-end))))))
 
 ;;;###autoload
 (defun anvil-org-index-read-headline (file headline-path)

--- a/anvil-org.el
+++ b/anvil-org.el
@@ -1742,16 +1742,17 @@ the specific delegate they intend to call before invoking it."
        (boundp 'anvil-org-index--db)
        anvil-org-index--db))
 
-(defun anvil-org--try-index-read-by-id (uuid)
+(defun anvil-org--try-index-read-by-id (uuid &optional max-depth)
   "Try `anvil-org-index-read-by-id' for UUID; return the body or nil.
-A nil return means fall back to the org-element handler.
+A nil return means fall back to the org-element handler.  MAX-DEPTH,
+when a positive integer, caps the depth of included headings.
 
 Doc 38 Phase B4: :headline-only delegate — the index resolves
 ID→(file, line-range) without ever parsing the org tree."
   (when (and (anvil-org--index-available-p)
              (fboundp 'anvil-org-index-read-by-id))
     (condition-case _err
-        (anvil-org-index-read-by-id uuid)
+        (anvil-org-index-read-by-id uuid max-depth)
       (error nil))))
 
 (defun anvil-org--try-index-read-headline (file headline-path)
@@ -1806,15 +1807,106 @@ org-read-file tool to read entire files"))
       (let ((full-path (concat file "#" headline_path)))
         (anvil-org--handle-headline-resource `(("filename" . ,full-path))))))
 
-(defun anvil-org--tool-read-by-id (uuid)
+(defun anvil-org--try-index-read-by-id-with-children (uuid &optional max-depth)
+  "Try the with-children index variant; return a plist or nil on failure."
+  (when (and (anvil-org--index-available-p)
+             (fboundp 'anvil-org-index-read-by-id-with-children))
+    (condition-case _err
+        (anvil-org-index-read-by-id-with-children uuid max-depth)
+      (error nil))))
+
+
+(defun anvil-org--parse-max-depth (max_depth default)
+  "Parse a string MAX_DEPTH into an integer, falling back to DEFAULT.
+Returns nil (meaning: full subtree) for zero or negative values."
+  (let* ((s (and (stringp max_depth) (string-trim max_depth)))
+         (n (cond
+             ((null max_depth) default)
+             ((and s (string-empty-p s)) default)
+             ((stringp max_depth) (string-to-number max_depth))
+             ((integerp max_depth) max_depth)
+             (t default))))
+    (when (and (integerp n) (> n 0)) n)))
+
+
+(defun anvil-org--bounded-subtree-from-text (full-text max-depth)
+  "Truncate FULL-TEXT to the first MAX-DEPTH heading levels.
+Returns (BOUNDED-TEXT . CHILDREN-TITLES).  CHILDREN-TITLES are the
+titles of the target heading's immediate children, with trailing tag
+strings stripped."
+  (let ((children nil)
+        (target-level nil)
+        (cap-level (and max-depth (integerp max-depth) (> max-depth 0)
+                        max-depth)))
+    (with-temp-buffer
+      (insert full-text)
+      (goto-char (point-min))
+      (when (looking-at "^\\(\\*+\\) ")
+        (setq target-level (length (match-string 1))))
+      (forward-line 1)
+      (let ((cut-point nil))
+        (while (not (eobp))
+          (when (looking-at "^\\(\\*+\\) +\\(.*\\)$")
+            (let ((lv (length (match-string 1)))
+                  (title (match-string 2)))
+              (when (and target-level (= lv (1+ target-level)))
+                (push (replace-regexp-in-string
+                       "[ \t]+:[[:alnum:]_@:]+:[ \t]*$" "" title)
+                      children))
+              (when (and (not cut-point) cap-level target-level
+                         (> lv (+ target-level (1- cap-level))))
+                (setq cut-point (line-beginning-position)))))
+          (forward-line 1))
+        (cons (if cut-point
+                  (buffer-substring-no-properties (point-min) cut-point)
+                full-text)
+              (nreverse children))))))
+
+
+(defun anvil-org--format-read-by-id-result (body children max-depth truncated)
+  "Render BODY plus CHILDREN listing as the MCP tool's return text.
+MAX-DEPTH and TRUNCATED annotate the footer so the caller knows
+whether subtrees were cut off."
+  (let ((body-trimmed (or body ""))
+        (n (length children)))
+    (concat
+     body-trimmed
+     (unless (string-suffix-p "\n" body-trimmed) "\n")
+     "\n"
+     (format
+      "------ Child headlines (%d)%s ------\n"
+      n
+      (cond ((null max-depth) "")
+            (truncated (format ", max_depth=%d (subtrees truncated)" max-depth))
+            (t (format ", max_depth=%d" max-depth))))
+     (if (zerop n)
+         "(none)\n"
+       (mapconcat (lambda (title) (concat "- " title)) children "\n"))
+     (when (> n 0) "\n"))))
+
+
+(defun anvil-org--tool-read-by-id (uuid &optional max_depth)
   "Tool wrapper for Layer-3 Org ID reads.
-UUID is the UUID from a headline's ID property.  Accepts either the
-raw UUID or an `org://UUID' citation URI emitted by the
+UUID is the UUID from a headline's ID property.  Accepts either the raw
+UUID or an `org://UUID' citation URI emitted by the
 progressive-disclosure Layer-1 / Layer-2 tools.  The `org-id://UUID'
 form is the MCP resource URI and is not accepted here.
 
+MAX_DEPTH is an optional integer string capping the depth of headings
+included in the returned text, relative to the target heading.  \"1\"
+(the default) returns just the target heading and its body — no child
+subtrees.  \"2\" includes immediate children; \"3\" adds grandchildren;
+and so on.  Pass \"0\" or a negative number to request the full subtree.
+
+Regardless of MAX_DEPTH, the response always ends with a \"Child
+headlines\" listing that names the immediate children of the target
+heading so the caller knows which subtrees it could descend into next.
+
 MCP Parameters:
-  uuid - UUID (or org://UUID citation URI) from headline's ID property"
+  uuid - UUID (or org://UUID citation URI) from headline's ID property
+  max_depth - Optional integer string capping the included heading
+              depth, default \"1\".  Use \"0\" or a negative value for
+              the full subtree."
   (when-let* ((id-resource
                (and (stringp uuid)
                     (anvil-org--extract-uri-suffix
@@ -1822,12 +1914,26 @@ MCP Parameters:
     (anvil-org--tool-validation-error
      "Parameter uuid does not accept org-id:// resource URIs.  Use the raw UUID \"%s\" or the org:// citation URI \"org://%s\" instead"
      id-resource id-resource))
-  (let ((id (if (and (stringp uuid)
-                     (string-prefix-p "org://" uuid))
-                (substring uuid (length "org://"))
-              uuid)))
-    (or (anvil-org--try-index-read-by-id id)
-        (anvil-org--handle-id-resource `(("uuid" . ,id))))))
+  (let* ((id (if (and (stringp uuid)
+                      (string-prefix-p "org://" uuid))
+                 (substring uuid (length "org://"))
+               uuid))
+         (depth (anvil-org--parse-max-depth max_depth 1)))
+    (or
+     (when-let* ((plist (anvil-org--try-index-read-by-id-with-children
+                         id depth)))
+       (anvil-org--format-read-by-id-result
+        (plist-get plist :body)
+        (plist-get plist :children)
+        depth
+        (plist-get plist :truncated)))
+     (let* ((full (anvil-org--handle-id-resource `(("uuid" . ,id))))
+            (bc (anvil-org--bounded-subtree-from-text full depth))
+            (bounded (car bc))
+            (children (cdr bc))
+            (truncated (and depth (not (string= bounded full)))))
+       (anvil-org--format-read-by-id-result
+        bounded children depth truncated)))))
 
 (defun anvil-org-enable ()
   "Enable the anvil-org module."
@@ -2235,8 +2341,15 @@ be in anvil-org-allowed-files.
 Parameters:
   uuid - UUID (or org://UUID citation URI) from headline's ID
          property (string, required)
+  max_depth - Optional integer string capping the included heading
+              depth relative to the target heading.  \"1\" (default)
+              returns the heading and its body only; \"2\" adds
+              immediate children; \"0\" or negative returns the full
+              subtree.
 
-Returns: Plain text content of the headline and its subtree"
+Returns: Plain text content of the bounded subtree followed by a
+\"------ Child headlines (N) ------\" footer naming the immediate
+children, so the caller knows which subtrees to descend into next"
    :read-only t
    :server-id anvil-org--server-id)
 

--- a/tests/anvil-org-read-by-id-depth-test.el
+++ b/tests/anvil-org-read-by-id-depth-test.el
@@ -1,0 +1,175 @@
+;;; anvil-org-read-by-id-depth-test.el --- ERT for bounded read-by-id -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `org-read-by-id' used to dump the entire subtree, which wastes
+;; context on large headings.  The bounded variant caps the response
+;; at `max_depth' heading levels and always appends a "Child
+;; headlines" footer naming the immediate children, so callers know
+;; which subtrees they could descend into next.
+;;
+;; Two backing paths must agree on output shape: the SQL-indexed fast
+;; path (`anvil-org-index-read-by-id-with-children') and the
+;; regex-truncating fallback over the full-subtree text
+;; (`anvil-org--bounded-subtree-from-text').  Both are pinned here.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'anvil)
+(require 'anvil-org)
+(require 'anvil-org-index)
+
+(defconst anvil-org-read-by-id-depth-test--uuid
+  "aaaaaaaa-1111-2222-3333-444444444444")
+
+(defconst anvil-org-read-by-id-depth-test--content
+  (concat "* Root\n"
+          ":PROPERTIES:\n"
+          ":ID: " anvil-org-read-by-id-depth-test--uuid "\n"
+          ":END:\n"
+          "Root body.\n"
+          "** Child One :tagged:\n"
+          "Child one body.\n"
+          "*** Grandchild\n"
+          "Deep body.\n"
+          "** Child Two\n"
+          "* Sibling\n"))
+
+;;;; Unit: max_depth parsing
+
+(ert-deftest anvil-org-read-by-id-depth-test-parse-max-depth ()
+  "String depths parse; zero/negative mean full subtree (nil)."
+  (should (= 1 (anvil-org--parse-max-depth nil 1)))
+  (should (= 1 (anvil-org--parse-max-depth "" 1)))
+  (should (= 2 (anvil-org--parse-max-depth "2" 1)))
+  (should (= 3 (anvil-org--parse-max-depth 3 1)))
+  (should-not (anvil-org--parse-max-depth "0" 1))
+  (should-not (anvil-org--parse-max-depth "-1" 1)))
+
+;;;; Unit: text fallback truncation
+
+(ert-deftest anvil-org-read-by-id-depth-test-bounded-text-depth-1 ()
+  "Depth 1 keeps the heading and body only; children listed, tags stripped."
+  (let* ((bc (anvil-org--bounded-subtree-from-text
+              anvil-org-read-by-id-depth-test--content 1))
+         (bounded (car bc))
+         (children (cdr bc)))
+    (should (string-match-p "Root body" bounded))
+    (should-not (string-match-p "Child one body" bounded))
+    (should-not (string-match-p "Grandchild" bounded))
+    (should (equal '("Child One" "Child Two") children))))
+
+(ert-deftest anvil-org-read-by-id-depth-test-bounded-text-depth-2 ()
+  "Depth 2 includes children but not grandchildren."
+  (let* ((bc (anvil-org--bounded-subtree-from-text
+              anvil-org-read-by-id-depth-test--content 2))
+         (bounded (car bc)))
+    (should (string-match-p "Child one body" bounded))
+    (should-not (string-match-p "Grandchild" bounded))))
+
+(ert-deftest anvil-org-read-by-id-depth-test-bounded-text-full ()
+  "nil depth returns the input untouched."
+  (let ((bc (anvil-org--bounded-subtree-from-text
+             anvil-org-read-by-id-depth-test--content nil)))
+    (should (equal (car bc) anvil-org-read-by-id-depth-test--content))))
+
+;;;; Unit: footer rendering
+
+(ert-deftest anvil-org-read-by-id-depth-test-footer ()
+  "Footer names count, depth, and truncation; (none) for leaves."
+  (should (string-match-p
+           "------ Child headlines (2), max_depth=1 (subtrees truncated) ------"
+           (anvil-org--format-read-by-id-result "body" '("A" "B") 1 t)))
+  (should (string-match-p
+           "------ Child headlines (0) ------\n(none)"
+           (anvil-org--format-read-by-id-result "body" nil nil nil))))
+
+;;;; Index fast path
+
+(defun anvil-org-read-by-id-depth-test--have-sqlite ()
+  (and (fboundp 'sqlite-available-p) (sqlite-available-p)))
+
+(defmacro anvil-org-read-by-id-depth-test--with-index (&rest body)
+  "Run BODY with a fresh index over the test content."
+  (declare (indent 0))
+  `(let* ((tmpdir (make-temp-file "anvil-rbid-test-" t))
+          (orgfile (expand-file-name "sample.org" tmpdir))
+          (dbfile (expand-file-name "test-index.db" tmpdir))
+          (anvil-org-index-db-path dbfile)
+          (anvil-org-index-paths (list tmpdir))
+          (anvil-org-index--backend nil)
+          (anvil-org-index--db nil))
+     (unwind-protect
+         (progn
+           (let ((coding-system-for-write 'utf-8-unix))
+             (write-region anvil-org-read-by-id-depth-test--content
+                           nil orgfile nil 'silent))
+           (anvil-org-index-enable)
+           (anvil-org-index-rebuild)
+           ,@body)
+       (ignore-errors (anvil-org-index-disable))
+       (ignore-errors (delete-directory tmpdir t)))))
+
+(ert-deftest anvil-org-read-by-id-depth-test-index-with-children ()
+  "Index path: bounded body, ordered children, truncated flag."
+  (skip-unless (anvil-org-read-by-id-depth-test--have-sqlite))
+  (anvil-org-read-by-id-depth-test--with-index
+    (let ((p1 (anvil-org-index-read-by-id-with-children
+               anvil-org-read-by-id-depth-test--uuid 1)))
+      (should (string-match-p "Root body" (plist-get p1 :body)))
+      (should-not (string-match-p "Child one body" (plist-get p1 :body)))
+      (should (equal '("Child One" "Child Two") (plist-get p1 :children)))
+      (should (plist-get p1 :truncated)))
+    (let ((p2 (anvil-org-index-read-by-id-with-children
+               anvil-org-read-by-id-depth-test--uuid 2)))
+      (should (string-match-p "Child one body" (plist-get p2 :body)))
+      (should-not (string-match-p "Deep body" (plist-get p2 :body)))
+      (should (plist-get p2 :truncated)))
+    (let ((pf (anvil-org-index-read-by-id-with-children
+               anvil-org-read-by-id-depth-test--uuid nil)))
+      (should (string-match-p "Deep body" (plist-get pf :body)))
+      (should-not (plist-get pf :truncated)))))
+
+(ert-deftest anvil-org-read-by-id-depth-test-index-read-by-id-depth ()
+  "anvil-org-index-read-by-id honours its new max-depth argument."
+  (skip-unless (anvil-org-read-by-id-depth-test--have-sqlite))
+  (anvil-org-read-by-id-depth-test--with-index
+    (let ((bounded (anvil-org-index-read-by-id
+                    anvil-org-read-by-id-depth-test--uuid 1))
+          (full (anvil-org-index-read-by-id
+                 anvil-org-read-by-id-depth-test--uuid)))
+      (should-not (string-match-p "Child one body" bounded))
+      (should (string-match-p "Deep body" full)))))
+
+;;;; Tool integration via the text fallback
+
+(ert-deftest anvil-org-read-by-id-depth-test-tool-fallback ()
+  "Without an index, the tool truncates via text and appends the footer."
+  (let* ((path (make-temp-file "anvil-rbid-tool-" nil ".org"
+                               anvil-org-read-by-id-depth-test--content))
+         (anvil-org-allowed-files (list path))
+         (anvil-org-allowed-files-enabled t))
+    (unwind-protect
+        (cl-letf (((symbol-function 'anvil-org--index-available-p)
+                   (lambda () nil)))
+          (let ((default-result (anvil-org--tool-read-by-id
+                                 anvil-org-read-by-id-depth-test--uuid)))
+            ;; default depth 1: body only + footer with both children
+            (should (string-match-p "Root body" default-result))
+            (should-not (string-match-p "Child one body" default-result))
+            (should (string-match-p
+                     "------ Child headlines (2), max_depth=1 (subtrees truncated) ------"
+                     default-result))
+            (should (string-match-p "^- Child One$" default-result))
+            (should (string-match-p "^- Child Two$" default-result)))
+          (let ((full-result (anvil-org--tool-read-by-id
+                              anvil-org-read-by-id-depth-test--uuid "0")))
+            (should (string-match-p "Deep body" full-result))
+            (should (string-match-p "------ Child headlines (2) ------"
+                                    full-result)))))
+      (delete-file path)))
+
+(provide 'anvil-org-read-by-id-depth-test)
+;;; anvil-org-read-by-id-depth-test.el ends here


### PR DESCRIPTION
## Problem

`org-read-by-id` returns the entire subtree. For Layer-3 progressive disclosure that's backwards on large headings: an agent asking about one project heading gets every child task, logbook and sub-subtree — often thousands of tokens — when it only needed the heading body plus a hint of what's underneath.

## Change

New optional `max_depth` parameter (integer string, default `"1"`):

- `"1"` — target heading + its body, no child subtrees
- `"2"` — adds immediate children; `"3"` grandchildren; etc.
- `"0"` / negative — full subtree (old behaviour)

Regardless of depth, the response ends with a footer that keeps disclosure progressive:

```
------ Child headlines (2), max_depth=1 (subtrees truncated) ------
- Child One
- Child Two
```

so the caller always knows which subtrees it could descend into next, and whether anything was cut off.

## Implementation

Two backing paths agree on output shape:

- **Index fast path** — `anvil-org-index-read-by-id-with-children`: one bounded SELECT (`anvil-org-index--lookup-id-bounded` caps the line range at the first heading deeper than the depth limit) plus an ordered children-titles query. `anvil-org-index-read-by-id` itself gains the same optional `max-depth` (nil = unchanged behaviour, so existing callers are unaffected).
- **Text fallback** — `anvil-org--bounded-subtree-from-text` truncates the full-subtree text by heading level and extracts child titles (trailing tags stripped), used when the index is unavailable.

Tool registration description updated to document the parameter and footer.

## Tests

`tests/anvil-org-read-by-id-depth-test.el` — 8 ERTs: `max_depth` parsing, text-fallback truncation at depths 1/2/full, footer rendering, index path (bounded body + ordered children + truncated flag at three depths, sqlite-gated), `anvil-org-index-read-by-id` depth argument, and tool-level integration through the fallback.

```
Ran 8 tests, 8 results as expected, 0 unexpected
Ran 48 tests, 48 results as expected, 0 unexpected   (anvil-org-test + anvil-org-index-test)
```