### PR TITLE
runtime: turn the MCP fast handshake on (100 s to first frame -> 1.36 s)

### DIFF
--- a/anvil-compact.el
+++ b/anvil-compact.el
@@ -133,6 +133,21 @@ self-contained."
   :type 'boolean
   :group 'anvil-compact)
 
+(defcustom anvil-compact-pressure-high-percent 75
+  "Context-usage percent treated as high pressure.
+With the default 200K context window this is roughly 150K tokens,
+matching the point where long Claude Code sessions become notably
+more expensive even with cached context."
+  :type 'integer
+  :group 'anvil-compact)
+
+(defcustom anvil-compact-pressure-long-session-hours 8
+  "Session age in hours treated as long-running pressure.
+The pressure report uses this to recommend `/compact' plus a
+fresh session boundary when a session has been active too long."
+  :type 'number
+  :group 'anvil-compact)
+
 (defconst anvil-compact--server-id "emacs-eval"
   "Server ID for the compact-* MCP tools.")
 
@@ -312,6 +327,85 @@ decision and log REASON for observability."
     (list :trigger (eq reason :trigger)
           :reason  reason
           :percent pct)))
+
+
+;;;; --- pressure report -----------------------------------------------------
+
+(defun anvil-compact--number-or-nil (value)
+  "Return VALUE as a number when it is numeric or a non-empty string."
+  (cond
+   ((numberp value) value)
+   ((and (stringp value) (not (string-empty-p value)))
+    (string-to-number value))
+   (t nil)))
+
+(defun anvil-compact--severity-rank (severity)
+  "Return an integer rank for SEVERITY."
+  (pcase severity
+    (:critical 3)
+    (:high 2)
+    (:medium 1)
+    (_ 0)))
+
+(defun anvil-compact--max-severity (a b)
+  "Return the stronger of severity symbols A and B."
+  (if (>= (anvil-compact--severity-rank a)
+          (anvil-compact--severity-rank b))
+      a
+    b))
+
+(cl-defun anvil-compact-pressure-report (&key transcript-path
+                                              session-start-ts
+                                              session-age-hours
+                                              task-in-progress
+                                              last-compact-percent)
+  "Return a token-cost pressure report for the current Claude session.
+TRANSCRIPT-PATH is estimated with `anvil-compact-estimate'.
+SESSION-START-TS is a seconds-since-epoch timestamp; alternatively
+SESSION-AGE-HOURS can be supplied directly.  TASK-IN-PROGRESS and
+LAST-COMPACT-PERCENT are forwarded to
+`anvil-compact-should-trigger'.
+
+Returns a plist with:
+  :severity            `:ok', `:medium', `:high', or `:critical'
+  :estimate            context estimate plist
+  :compact-decision    output from `anvil-compact-should-trigger'
+  :session-age-hours   numeric age or nil
+  :actions             ordered action strings
+  :audited-at          ISO timestamp."
+  (let* ((est (anvil-compact-estimate :transcript-path transcript-path))
+         (pct (plist-get est :percent))
+         (age (or (anvil-compact--number-or-nil session-age-hours)
+                  (let ((start (anvil-compact--number-or-nil
+                                session-start-ts)))
+                    (when start
+                      (/ (- (float-time) start) 3600.0)))))
+         (dec (anvil-compact-should-trigger
+               :percent pct
+               :task-in-progress task-in-progress
+               :last-compact-percent last-compact-percent))
+         (severity :ok)
+         actions)
+    (when (>= pct anvil-compact-trigger-percent)
+      (setq severity (anvil-compact--max-severity severity :medium))
+      (push "Run /compact at the next clean task boundary." actions))
+    (when (>= pct anvil-compact-pressure-high-percent)
+      (setq severity (anvil-compact--max-severity severity :critical))
+      (push "Context is above the high-pressure threshold; compact before more file reads or MCP calls." actions))
+    (when (and age (>= age anvil-compact-pressure-long-session-hours))
+      (setq severity (anvil-compact--max-severity severity :high))
+      (push "Session has been active for 8+ hours; compact, checkpoint, then start a fresh task/session if work scope changed." actions))
+    (when (plist-get dec :trigger)
+      (push "Auto-compact trigger is eligible now." actions))
+    (when (and (eq (plist-get dec :reason) :in-progress)
+               (>= pct anvil-compact-trigger-percent))
+      (push "Finish or checkpoint the in-progress task before compacting." actions))
+    (list :severity severity
+          :estimate est
+          :compact-decision dec
+          :session-age-hours age
+          :actions (nreverse actions)
+          :audited-at (format-time-string "%Y-%m-%dT%H:%M:%S%z"))))
 
 
 ;;;; --- snapshot ------------------------------------------------------------
@@ -831,6 +925,32 @@ MCP Parameters:
                      (when (> n 0) n))))))
       (anvil-compact-stats :session-id sid :since-ts since))))
 
+(defun anvil-compact--tool-pressure-report
+    (transcript_path session_start_ts session_age_hours
+                     task_in_progress last_compact_percent)
+  "Return a token-cost pressure report for a Claude Code session.
+
+MCP Parameters:
+  transcript_path       - absolute path to the JSONL transcript.
+                          Empty string returns zero context usage.
+  session_start_ts      - optional seconds-since-epoch session start.
+                          Empty string means unknown.
+  session_age_hours     - optional explicit age in hours.  When set,
+                          this wins over session_start_ts.
+  task_in_progress      - optional count of active tasks.
+  last_compact_percent  - optional last compact percent for cooldown."
+  (anvil-server-with-error-handling
+    (let ((path (and (stringp transcript_path)
+                     (not (string-empty-p transcript_path))
+                     transcript_path)))
+      (anvil-compact-pressure-report
+       :transcript-path path
+       :session-start-ts session_start_ts
+       :session-age-hours session_age_hours
+       :task-in-progress (anvil-compact--number-or-nil task_in_progress)
+       :last-compact-percent
+       (anvil-compact--number-or-nil last_compact_percent)))))
+
 (defun anvil-compact--tool-hook (session_id stage transcript_path)
   "Unified hook entry: dispatch STAGE for SESSION_ID.
 
@@ -934,6 +1054,19 @@ a metrics plist with per-kind counts, skipped-reason breakdown,
 trigger-percent distribution, compliance (restores / nudges), and
 the most recent trigger.  Use to validate the 45% threshold and
 nudge-obedience assumptions before tuning."
+   :read-only t)
+  (anvil-server-register-tool
+   #'anvil-compact--tool-pressure-report
+   :id "compact-pressure-report"
+   :intent '(session compact observe)
+   :layer 'core
+   :server-id anvil-compact--server-id
+   :description
+   "Return a read-only pressure report combining transcript context
+estimate, auto-compact eligibility, high-context threshold (~150K
+tokens by default), and long-session age warnings.  Use before
+heavy MCP/file reads or when copied Claude limits point to
+>150K-context / 8h-session pressure."
    :read-only t))
 
 ;;;###autoload
@@ -950,6 +1083,8 @@ nudge-obedience assumptions before tuning."
   (anvil-server-unregister-tool "compact-hook"
                                 anvil-compact--server-id)
   (anvil-server-unregister-tool "compact-stats"
+                                anvil-compact--server-id)
+  (anvil-server-unregister-tool "compact-pressure-report"
                                 anvil-compact--server-id))
 
 (provide 'anvil-compact)

--- a/anvil-crypto.el
+++ b/anvil-crypto.el
@@ -1,0 +1,187 @@
+;;; anvil-crypto.el --- web-security primitives (HMAC, tokens, webhooks) -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Anvil contributors
+
+;; Author: Anvil contributors
+;; Keywords: crypto, hmac, security, web
+;; Package-Requires: ((emacs "28.1"))
+;; Version: 0.1.0
+
+;;; Commentary:
+
+;; The first framework primitives for serving web apps on the anvil /
+;; NeLisp substrate: everything a request handler needs to trust its
+;; inputs and its own tokens, built only on the runtime's `secure-hash'
+;; (SHA-256), so the module is dual-target (runs under Emacs today and
+;; under NeLisp standalone once the HTTP server substrate lands).
+;;
+;; Provided:
+;;
+;;   * `anvil-crypto-hmac-sha256'  - RFC 2104 HMAC over SHA-256 (raw or
+;;     hex), verified against the RFC 4231 test vectors.
+;;   * `anvil-crypto-constant-time-equal' - timing-safe string compare,
+;;     for use on every secret/signature comparison so verification does
+;;     not leak the position of the first mismatched byte.
+;;   * `anvil-crypto-stripe-verify' - verify a `Stripe-Signature' header
+;;     (t=<ts>,v1=<hmac>) against the raw request body and the endpoint
+;;     signing secret, with a replay-tolerance window.
+;;   * `anvil-crypto-sign-token' / `anvil-crypto-verify-token' - stateless
+;;     signed session tokens (payload + expiry + HMAC), so sessions need
+;;     no server-side store and a tampered/expired token is rejected.
+;;   * `anvil-crypto-random-bytes' / `anvil-crypto-random-token' - CSPRNG
+;;     bytes from the OS entropy source, for session ids and secrets.
+;;
+;; Security notes baked in (the point of "harden first, not later"):
+;;   - all signature checks go through the constant-time compare;
+;;   - Stripe verification rejects outside the tolerance window (replay);
+;;   - tokens carry an expiry that verification enforces;
+;;   - random-bytes reads the OS CSPRNG, never a PRNG seeded from time.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defconst anvil-crypto--sha256-block 64
+  "HMAC block size for SHA-256, in bytes.")
+
+;;;; --- HMAC-SHA256 --------------------------------------------------------
+
+(defun anvil-crypto-hmac-sha256 (key message &optional binary)
+  "Return the RFC 2104 HMAC-SHA256 of MESSAGE under KEY.
+KEY and MESSAGE are unibyte strings (raw bytes).  With BINARY non-nil
+return the 32 raw bytes, otherwise the 64-char lowercase hex digest."
+  (let* ((block anvil-crypto--sha256-block)
+         (k (if (> (length key) block)
+                (secure-hash 'sha256 key nil nil t)
+              key)))
+    (when (< (length k) block)
+      (setq k (concat k (make-string (- block (length k)) 0))))
+    (let ((ki (make-string block 0))
+          (ko (make-string block 0)))
+      (dotimes (i block)
+        (aset ki i (logxor (aref k i) #x36))
+        (aset ko i (logxor (aref k i) #x5c)))
+      (let ((inner (secure-hash 'sha256 (concat ki message) nil nil t)))
+        (secure-hash 'sha256 (concat ko inner) nil nil binary)))))
+
+;;;; --- constant-time compare ---------------------------------------------
+
+(defun anvil-crypto-constant-time-equal (a b)
+  "Return non-nil iff strings A and B are equal, in constant time.
+The running time depends only on the length of A, not on where the
+first differing byte is, so it does not leak signature bytes through
+timing.  Different lengths return nil (but still scan A)."
+  (let ((diff (if (= (length a) (length b)) 0 1))
+        (la (length a))
+        (lb (length b)))
+    (dotimes (i la)
+      (setq diff (logior diff
+                         (logxor (aref a i)
+                                 (if (< i lb) (aref b i) 0)))))
+    (= diff 0)))
+
+;;;; --- Stripe webhook signatures -----------------------------------------
+
+(defun anvil-crypto--parse-stripe-header (header)
+  "Parse a `Stripe-Signature' HEADER into (TIMESTAMP . (V1 ...)).
+Returns a plist (:t TIMESTAMP-STRING :v1 (SIG ...))."
+  (let (ts v1)
+    (dolist (part (split-string header "," t "[ \t]+"))
+      (let ((kv (split-string part "=")))
+        (cond ((string= (car kv) "t") (setq ts (cadr kv)))
+              ((string= (car kv) "v1") (push (cadr kv) v1)))))
+    (list :t ts :v1 (nreverse v1))))
+
+(cl-defun anvil-crypto-stripe-verify (payload header secret &key (tolerance 300) now)
+  "Verify a Stripe webhook.
+PAYLOAD is the raw request body string, HEADER the `Stripe-Signature'
+header value, SECRET the endpoint signing secret (whsec_...).  Returns
+t when a v1 signature matches HMAC-SHA256 of \"TIMESTAMP.PAYLOAD\" and
+the timestamp is within TOLERANCE seconds of NOW (default current
+time).  Rejects on missing parts, bad signature, or replay outside the
+window."
+  (let* ((parsed (anvil-crypto--parse-stripe-header header))
+         (ts (plist-get parsed :t))
+         (sigs (plist-get parsed :v1))
+         (now (or now (float-time)))
+         (signed (and ts (concat ts "." payload)))
+         (expected (and signed (anvil-crypto-hmac-sha256 secret signed))))
+    (and ts sigs expected
+         ;; timing-safe match against any provided v1 signature
+         (cl-some (lambda (s) (anvil-crypto-constant-time-equal s expected)) sigs)
+         ;; replay window
+         (<= (abs (- now (string-to-number ts))) tolerance)
+         t)))
+
+;;;; --- stateless signed tokens -------------------------------------------
+
+(defun anvil-crypto--b64url (bytes)
+  "Base64url-encode BYTES with no padding."
+  (let ((s (base64-encode-string bytes t)))
+    (setq s (replace-regexp-in-string "+" "-" s))
+    (setq s (replace-regexp-in-string "/" "_" s))
+    (replace-regexp-in-string "=+$" "" s)))
+
+(defun anvil-crypto--b64url-decode (s)
+  "Decode base64url string S (no padding)."
+  (setq s (replace-regexp-in-string "-" "+" s))
+  (setq s (replace-regexp-in-string "_" "/" s))
+  (let ((pad (% (length s) 4)))
+    (when (> pad 0) (setq s (concat s (make-string (- 4 pad) ?=)))))
+  (base64-decode-string s))
+
+(cl-defun anvil-crypto-sign-token (payload secret &key (ttl 3600) now)
+  "Return a signed, expiring token carrying PAYLOAD (a string).
+The token is \"B64URL(payload).EXPIRY.HMAC\" where EXPIRY is NOW+TTL
+seconds and HMAC covers \"B64URL(payload).EXPIRY\".  Stateless: no
+server-side session store is needed."
+  (let* ((now (or now (float-time)))
+         (expiry (number-to-string (truncate (+ now ttl))))
+         (body (concat (anvil-crypto--b64url payload) "." expiry))
+         (sig (anvil-crypto-hmac-sha256 secret body)))
+    (concat body "." sig)))
+
+(cl-defun anvil-crypto-verify-token (token secret &key now)
+  "Verify TOKEN produced by `anvil-crypto-sign-token'.
+Returns the decoded payload string when the signature is valid (checked
+in constant time) and the token has not expired, else nil."
+  (let ((parts (split-string token "\\.")))
+    (when (= (length parts) 3)
+      (let* ((b64 (nth 0 parts))
+             (expiry (nth 1 parts))
+             (sig (nth 2 parts))
+             (body (concat b64 "." expiry))
+             (expected (anvil-crypto-hmac-sha256 secret body))
+             (now (or now (float-time))))
+        (when (and (anvil-crypto-constant-time-equal sig expected)
+                   (<= now (string-to-number expiry)))
+          (condition-case nil
+              (anvil-crypto--b64url-decode b64)
+            (error nil)))))))
+
+;;;; --- CSPRNG -------------------------------------------------------------
+
+(defun anvil-crypto-random-bytes (n)
+  "Return N cryptographically-random bytes from the OS entropy source.
+Reads /dev/urandom, which is non-seekable, so N bytes are streamed via
+`head' rather than a byte-range read.  (Under NeLisp standalone this is
+the one spot that needs a getrandom syscall / urandom read; every
+caller above is substrate-agnostic.)"
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (let ((coding-system-for-read 'binary)
+          (coding-system-for-write 'binary))
+      (unless (zerop (call-process "head" "/dev/urandom" t nil
+                                   "-c" (number-to-string n)))
+        (error "anvil-crypto: could not read %d bytes from /dev/urandom" n)))
+    (let ((bytes (buffer-string)))
+      (unless (= (length bytes) n)
+        (error "anvil-crypto: short CSPRNG read (%d/%d)" (length bytes) n))
+      bytes)))
+
+(defun anvil-crypto-random-token (&optional n)
+  "Return a base64url random token from N (default 32) CSPRNG bytes."
+  (anvil-crypto--b64url (anvil-crypto-random-bytes (or n 32))))
+
+(provide 'anvil-crypto)
+;;; anvil-crypto.el ends here

--- a/anvil-dev.el
+++ b/anvil-dev.el
@@ -31,6 +31,16 @@
 ;;       with standard headers, enable/disable stubs, and a passing
 ;;       smoke test so a new module compiles + runs out of the box.
 ;;
+;;   - `anvil-codex-efficiency-check'
+;;     — inspect a Codex setup for the token-saving baseline:
+;;       Serena / Context7 MCP server entries, required executables,
+;;       local Codex skills, and the project-side Serena config /
+;;       recovery reference note.
+;;
+;;   - `anvil-claude-limits-analyze'
+;;     — turn Claude Code's "what's contributing to your limits usage?"
+;;       text into metrics + Anvil-focused mitigation actions.
+;;
 ;; Enable via `(add-to-list 'anvil-optional-modules 'dev)' in init.
 
 ;;; Code:
@@ -65,6 +75,15 @@ and the core aggregator `anvil-test.el'."
 
 (defconst anvil-dev--server-id "emacs-eval"
   "Server ID for the dev-* MCP tools.")
+
+(defconst anvil-dev--codex-efficiency-required-skills
+  '("anvil-memory-worklog"
+    "notes-org-editing"
+    "notes-development"
+    "nelisp-development"
+    "web-article-archive"
+    "notes-report-pipeline")
+  "Codex skill directories expected by the Notes efficiency setup.")
 
 ;;;; --- internal ------------------------------------------------------------
 
@@ -160,6 +179,238 @@ MCP Parameters: none.  Returns a printed plist comparing the
 installed anvil clone's git HEAD with `anvil-dev-source-path'."
   (anvil-server-with-error-handling
    (format "%S" (anvil-self-sync-check))))
+
+;;;; --- codex efficiency check ---------------------------------------------
+
+(defun anvil-dev--codex-home ()
+  "Return the effective Codex home directory."
+  (or (getenv "CODEX_HOME")
+      (expand-file-name "~/.codex")))
+
+(defun anvil-dev--read-file-string (file)
+  "Return FILE contents as a string, or nil when unreadable."
+  (when (file-readable-p file)
+    (with-temp-buffer
+      (insert-file-contents file)
+      (buffer-string))))
+
+(defun anvil-dev--toml-has-section-p (content section)
+  "Return non-nil when TOML CONTENT has a top-level SECTION table."
+  (and content
+       (string-match-p
+        (format "^\\[mcp_servers\\.%s\\][ \t]*$"
+                (regexp-quote section))
+        content)))
+
+(defun anvil-dev--skill-present-p (skills-dir skill)
+  "Return non-nil when SKILLS-DIR contains SKILL with a readable SKILL.md."
+  (file-readable-p (expand-file-name (format "%s/SKILL.md" skill)
+                                     skills-dir)))
+
+(defun anvil-dev--plist-bool-alist (items predicate)
+  "Return an alist mapping ITEMS to t/nil according to PREDICATE."
+  (mapcar (lambda (item) (cons item (and (funcall predicate item) t)))
+          items))
+
+;;;###autoload
+(defun anvil-codex-efficiency-check (&optional codex-home project-root)
+  "Inspect the local Codex token-saving setup.
+
+CODEX-HOME defaults to `$CODEX_HOME' or `~/.codex'.  PROJECT-ROOT
+defaults to `default-directory'.  The check is read-only and
+validates the baseline used by this workspace:
+  - `~/.codex/config.toml' is readable;
+  - `emacs-eval', `serena', and `context7' MCP server sections exist;
+  - `uvx' and `npx' executables resolve;
+  - required local Codex skill directories contain `SKILL.md';
+  - project-side `.serena/project.yml' and the recovery reference
+    note exist.
+
+Returns a plist with :ok and :warnings so callers can fail fast
+without reading every config file by hand."
+  (let* ((home (file-name-as-directory
+                (expand-file-name (or codex-home (anvil-dev--codex-home)))))
+         (root (file-name-as-directory
+                (expand-file-name (or project-root default-directory))))
+         (config-file (expand-file-name "config.toml" home))
+         (config-content (anvil-dev--read-file-string config-file))
+         (skills-dir (expand-file-name "skills" home))
+         (required-mcp '("emacs-eval" "serena" "context7"))
+         (mcp-present
+          (anvil-dev--plist-bool-alist
+           required-mcp
+           (lambda (server)
+             (anvil-dev--toml-has-section-p config-content server))))
+         (executables
+          (list (cons "uvx" (executable-find "uvx"))
+                (cons "npx" (executable-find "npx"))))
+         (skills-present
+          (anvil-dev--plist-bool-alist
+           anvil-dev--codex-efficiency-required-skills
+           (lambda (skill)
+             (anvil-dev--skill-present-p skills-dir skill))))
+         (serena-project (expand-file-name ".serena/project.yml" root))
+         (reference-file
+          (expand-file-name ".claude/reference/codex-efficiency-setup.md"
+                            root))
+         warnings)
+    (unless config-content
+      (push (format "Codex config is not readable: %s" config-file)
+            warnings))
+    (dolist (server mcp-present)
+      (unless (cdr server)
+        (push (format "Missing MCP server section: %s" (car server))
+              warnings)))
+    (dolist (exe executables)
+      (unless (cdr exe)
+        (push (format "Missing executable on exec-path: %s" (car exe))
+              warnings)))
+    (dolist (skill skills-present)
+      (unless (cdr skill)
+        (push (format "Missing Codex skill: %s" (car skill))
+              warnings)))
+    (unless (file-readable-p serena-project)
+      (push (format "Missing Serena project config: %s" serena-project)
+            warnings))
+    (unless (file-readable-p reference-file)
+      (push (format "Missing Codex recovery reference: %s" reference-file)
+            warnings))
+    (list :ok (null warnings)
+          :codex-home home
+          :project-root root
+          :config-file config-file
+          :mcp-servers mcp-present
+          :executables executables
+          :skills-dir skills-dir
+          :skills skills-present
+          :serena-project serena-project
+          :reference-file reference-file
+          :warnings (nreverse warnings))))
+
+(defun anvil-dev--tool-codex-efficiency-check (&optional codex-home project-root)
+  "MCP wrapper for `anvil-codex-efficiency-check'.
+
+MCP Parameters:
+  codex-home   - Optional Codex home directory.  Empty string uses
+                 `$CODEX_HOME' or `~/.codex'.
+  project-root - Optional project root containing `.serena/' and
+                 `.claude/reference/'.  Empty string uses
+                 `default-directory'."
+  (anvil-server-with-error-handling
+   (let ((home (and codex-home (stringp codex-home)
+                    (not (string-empty-p codex-home))
+                    codex-home))
+         (root (and project-root (stringp project-root)
+                    (not (string-empty-p project-root))
+                    project-root)))
+     (format "%S" (anvil-codex-efficiency-check home root)))))
+
+;;;; --- Claude limits report analysis --------------------------------------
+
+(defun anvil-dev--limits-percent-after (report marker)
+  "Return the first integer percent before MARKER in REPORT.
+Matches lines like \"91% of your usage was at >150k context\"."
+  (when (and (stringp report) (stringp marker)
+             (string-match
+              (format "\\([0-9]+\\)%%[^\n]*%s" (regexp-quote marker))
+              report))
+    (string-to-number (match-string 1 report))))
+
+(defun anvil-dev--limits-table-percent (report label)
+  "Return integer percent from a simple LABEL table row in REPORT.
+Matches lines like \"emacs-eval                     73%\"."
+  (when (and (stringp report) (stringp label))
+    (catch 'found
+      (dolist (line (split-string report "\n"))
+        (let ((trimmed (string-trim-left line)))
+          (when (and (string-prefix-p label trimmed)
+                     (or (= (length trimmed) (length label))
+                         (member (aref trimmed (length label))
+                                 '(?\s ?\t))))
+            (when (string-match "\\([0-9]+\\)%" trimmed)
+              (throw 'found (string-to-number (match-string 1 trimmed))))))))))
+
+(defun anvil-dev--limits-metric (report key)
+  "Extract metric KEY from Claude limits REPORT."
+  (pcase key
+    ('high-context
+     (anvil-dev--limits-percent-after report ">150k context"))
+    ('subagent-heavy
+     (anvil-dev--limits-percent-after report "subagent-heavy sessions"))
+    ('long-sessions
+     (anvil-dev--limits-percent-after report "sessions active for 8+ hours"))
+    ('loop
+     (or (anvil-dev--limits-percent-after report "came from /loop")
+         (anvil-dev--limits-table-percent report "/loop")))
+    ('emacs-eval
+     (or (anvil-dev--limits-percent-after report "mcp server \"emacs-eval\"")
+         (anvil-dev--limits-table-percent report "emacs-eval")))))
+
+(defun anvil-dev--limits-severity (percent)
+  "Return severity symbol for PERCENT."
+  (cond
+   ((null percent) 'unknown)
+   ((>= percent 70) 'critical)
+   ((>= percent 40) 'high)
+   ((>= percent 20) 'medium)
+   ((> percent 0) 'low)
+   (t 'none)))
+
+(defun anvil-dev--limits-action (metric percent)
+  "Return an action plist for METRIC at PERCENT."
+  (let ((severity (anvil-dev--limits-severity percent)))
+    (pcase metric
+      ('high-context
+       (list :metric metric :percent percent :severity severity
+             :action "Trigger /compact mid-task and /clear when switching tasks; prefer session-context packs over carrying raw history."))
+      ('subagent-heavy
+       (list :metric metric :percent percent :severity severity
+             :action "Gate subagent spawning; use Serena/context tools first and route simple exploration to cheaper or local helpers."))
+      ('long-sessions
+       (list :metric metric :percent percent :severity severity
+             :action "Add session-age/context-pressure checks to Stop/UserPrompt hooks; warn after long background loops."))
+      ('loop
+       (list :metric metric :percent percent :severity severity
+             :action "Scope /loop skills down, cap iterations, and emit a compact reminder before loop continuation."))
+      ('emacs-eval
+       (list :metric metric :percent percent :severity severity
+             :action "Reduce emacs-eval result size: prefer outline/symbol tools, filtered shell output, minimal modes, and disable unused MCP surfaces.")))))
+
+;;;###autoload
+(defun anvil-claude-limits-analyze (report)
+  "Analyze Claude Code limits REPORT and return Anvil mitigation guidance.
+
+REPORT is the pasted text from Claude Code's \"what's contributing
+to your limits usage?\" screen.  The parser is intentionally
+tolerant of copied TUI corruption: it looks for stable percent
+markers and table rows, then returns the extracted metrics plus
+ranked actions.
+
+Returns a plist with :metrics, :actions, and :top-actions."
+  (unless (and (stringp report) (not (string-empty-p report)))
+    (user-error "anvil-claude-limits-analyze: REPORT must be non-empty text"))
+  (let* ((metrics (mapcar (lambda (key)
+                            (cons key (anvil-dev--limits-metric report key)))
+                          '(high-context subagent-heavy long-sessions
+                            loop emacs-eval)))
+         (actions (mapcar (lambda (cell)
+                            (anvil-dev--limits-action (car cell) (cdr cell)))
+                          metrics))
+         (ranked (sort (copy-sequence actions)
+                       (lambda (a b)
+                         (> (or (plist-get a :percent) -1)
+                            (or (plist-get b :percent) -1))))))
+    (list :metrics metrics
+          :actions actions
+          :top-actions (cl-subseq ranked 0 (min 3 (length ranked))))))
+
+(defun anvil-dev--tool-claude-limits-analyze (report)
+  "MCP wrapper for `anvil-claude-limits-analyze'.
+
+MCP Parameters:
+  report - Text copied from Claude Code's limits usage breakdown."
+  (anvil-server-with-error-handling
+   (format "%S" (anvil-claude-limits-analyze report))))
 
 ;;;; --- test-run-all --------------------------------------------------------
 
@@ -1545,6 +1796,32 @@ CI only exercises the smoke suite — use this for pre-commit
 verification across every test file."
    :read-only t)
   (anvil-server-register-tool
+   #'anvil-dev--tool-codex-efficiency-check
+   :id "anvil-codex-efficiency-check"
+   :intent '(dev audit codex)
+   :layer 'dev
+   :server-id anvil-dev--server-id
+   :description
+   "Check the local Codex token-saving setup in one read-only call:
+Codex config readability, emacs-eval / Serena / Context7 MCP
+server entries, uvx / npx executables, required local Codex
+skills, project-side Serena config, and the recovery reference
+note.  Returns :ok plus actionable :warnings."
+   :read-only t)
+  (anvil-server-register-tool
+   #'anvil-dev--tool-claude-limits-analyze
+   :id "anvil-claude-limits-analyze"
+   :intent '(dev audit claude usage)
+   :layer 'dev
+   :server-id anvil-dev--server-id
+   :description
+   "Parse Claude Code's limits usage breakdown text and return
+Anvil-focused mitigation guidance for high-context sessions,
+subagent-heavy use, 8h+ sessions, /loop usage, and emacs-eval MCP
+result pressure.  Read-only; useful after copying the day/week
+limits screen from Claude Code."
+   :read-only t)
+  (anvil-server-register-tool
    #'anvil-dev--tool-scaffold-module
    :id "anvil-scaffold-module"
    :intent '(dev scaffold)
@@ -1584,6 +1861,10 @@ hash-table-vs-alist pattern).  Returns a formatted report;
   (anvil-server-unregister-tool "anvil-self-sync-check"
                                 anvil-dev--server-id)
   (anvil-server-unregister-tool "anvil-test-run-all"
+                                anvil-dev--server-id)
+  (anvil-server-unregister-tool "anvil-codex-efficiency-check"
+                                anvil-dev--server-id)
+  (anvil-server-unregister-tool "anvil-claude-limits-analyze"
                                 anvil-dev--server-id)
   (anvil-server-unregister-tool "anvil-scaffold-module"
                                 anvil-dev--server-id)

--- a/anvil-memory.el
+++ b/anvil-memory.el
@@ -157,7 +157,7 @@ onto this alist; built-ins stay in the list for defaults."
          search save-check duplicates audit-urls
          decay promote regenerate reindex-fts llm-verdict
          mdl-distill export-html serve contradictions
-         add export-md get session-delta)
+         add update export-md get session-delta)
   "Capability tags this module currently provides.
 Tests in tests/anvil-memory-test.el gate their `skip-unless' on
 membership here so a half-shipped feature never breaks CI.")
@@ -698,6 +698,94 @@ Returns =(:file SYNTHETIC :name BASENAME :type TYPE :description DESC
             :type type
             :description description*
             :created created*
+            :digest digest))))
+
+(cl-defun anvil-memory-update (file-or-name &key body type tags ttl-policy)
+  "Update fields of an existing DB-direct memory entry in place.
+
+FILE-OR-NAME is either the synthetic id (`anvil-memory:db:<basename>')
+or the bare basename (e.g. `feedback_my_rule').  Scan-from-md rows are
+rejected — for those, edit the backing `.md' file and re-run
+`anvil-memory-scan' so disk stays canonical.
+
+Optional keys (at least one must be supplied):
+  :body       — replacement body string (no YAML frontmatter).  The
+                `memory_body_fts' row is replaced in the same call so
+                `memory-search' reflects the new text immediately.
+  :type       — new type: one of `user' / `feedback' / `project' /
+                `reference' / `memo' (a string is coerced via `intern').
+  :tags       — string list or comma-joined string.
+  :ttl-policy — TTL key symbol.
+
+`created' is never touched.  `description' is not persisted for
+DB-direct rows (`anvil-memory-get' derives it from the basename), so
+there is nothing to update for it here.
+
+Returns =(:file SYNTHETIC :name BASENAME :updated FIELDS :digest
+SHA1-OR-NIL)= where FIELDS lists the updated field keywords and the
+digest covers the new body when :body was supplied."
+  (unless (and (stringp file-or-name) (not (string-empty-p file-or-name)))
+    (user-error "anvil-memory-update: FILE-OR-NAME must be a non-empty string"))
+  (when (and (not (anvil-memory--synthetic-file-p file-or-name))
+             (string-match-p "/" file-or-name))
+    (user-error
+     "anvil-memory-update: scan-from-md rows are disk-canonical — edit the .md and re-run anvil-memory-scan"))
+  (unless (or body type tags ttl-policy)
+    (user-error "anvil-memory-update: nothing to update (supply :body / :type / :tags / :ttl-policy)"))
+  (when (stringp type) (setq type (intern type)))
+  (when (and type (not (assq type anvil-memory-ttl-policies)))
+    (user-error
+     "anvil-memory-update: TYPE must be one of %S (got %S)"
+     (mapcar #'car anvil-memory-ttl-policies) type))
+  (when body
+    (unless (stringp body)
+      (user-error "anvil-memory-update: BODY must be a string")))
+  (let* ((db (anvil-memory--db))
+         (file (if (anvil-memory--synthetic-file-p file-or-name)
+                   file-or-name
+                 (concat anvil-memory--synthetic-prefix
+                         (file-name-sans-extension file-or-name))))
+         (basename (substring file (length anvil-memory--synthetic-prefix)))
+         (existing (sqlite-select
+                    db
+                    "SELECT 1 FROM memory_meta WHERE file = ?1 LIMIT 1"
+                    (list file))))
+    (unless existing
+      (user-error "anvil-memory-update: no DB-direct entry named %s" basename))
+    (let ((updated nil)
+          (digest nil))
+      (when type
+        (sqlite-execute
+         db "UPDATE memory_meta SET type = ?2 WHERE file = ?1"
+         (list file (symbol-name type)))
+        (push :type updated))
+      (when ttl-policy
+        (when (stringp ttl-policy) (setq ttl-policy (intern ttl-policy)))
+        (sqlite-execute
+         db "UPDATE memory_meta SET ttl_policy = ?2 WHERE file = ?1"
+         (list file (symbol-name ttl-policy)))
+        (push :ttl-policy updated))
+      (when tags
+        (let ((tags* (cond ((stringp tags) tags)
+                           ((listp tags) (mapconcat #'identity tags ","))
+                           (t nil))))
+          (sqlite-execute
+           db "UPDATE memory_meta SET tags = ?2 WHERE file = ?1"
+           (list file tags*))
+          (push :tags updated)))
+      (when body
+        (let ((body-trimmed
+               (replace-regexp-in-string "[ \t\n]+\\'" "" body)))
+          (setq digest (secure-hash 'sha1 body-trimmed))
+          (sqlite-execute
+           db "DELETE FROM memory_body_fts WHERE file = ?1" (list file))
+          (sqlite-execute
+           db "INSERT INTO memory_body_fts(file, body) VALUES (?1, ?2)"
+           (list file body-trimmed))
+          (push :body updated)))
+      (list :file file
+            :name basename
+            :updated (nreverse updated)
             :digest digest))))
 
 
@@ -3109,6 +3197,33 @@ Returns =(:file SYNTHETIC :name BASENAME :type TYPE :description DESC
       :tags (anvil-memory--coerce-string tags)
       :ttl-policy (anvil-memory--coerce-type ttl_policy)))))
 
+(defun anvil-memory--tool-update (file_or_name &optional body type
+                                               tags ttl_policy)
+  "Update fields of an existing DB-direct memory entry in place.
+
+MCP Parameters:
+  file_or_name - Required key: synthetic id (`anvil-memory:db:<basename>')
+                 or bare basename (`feedback_my_rule').  Scan-from-md
+                 rows are rejected — edit the `.md' and re-run
+                 `memory-scan' for those.
+  body         - Optional replacement body (no YAML frontmatter).  The
+                 FTS index row is refreshed in the same call.
+  type         - Optional new type: user / feedback / project /
+                 reference / memo.
+  tags         - Optional comma-separated string or list.
+  ttl_policy   - Optional TTL key.
+
+At least one of body / type / tags / ttl_policy must be supplied.
+Returns =(:file SYNTHETIC :name BASENAME :updated FIELDS :digest
+SHA1-OR-NIL)=."
+  (anvil-server-with-error-handling
+   (anvil-memory-update
+    (or file_or_name "")
+    :body (anvil-memory--coerce-string body)
+    :type (anvil-memory--coerce-type type)
+    :tags (anvil-memory--coerce-string tags)
+    :ttl-policy (anvil-memory--coerce-type ttl_policy))))
+
 (defun anvil-memory--tool-get (file_or_name &optional bump_access)
   "Return one memory entry plist by synthetic id / basename / path.
 
@@ -3428,6 +3543,20 @@ Optional: `description', `tags', `ttl_policy'.  Body should NOT
 include YAML frontmatter — it is synthesized on `memory-export-md'.
 Returns the synthetic file id so callers can later round-trip the
 entry to disk via `memory-export-md'.")
+
+    (,(anvil-server-encode-handler #'anvil-memory--tool-update)
+     :id "memory-update"
+     :intent '(memory)
+     :layer 'workflow
+     :description
+     "Phase 5 DB-direct in-place update — replace `body' / `type' /
+`tags' / `ttl_policy' of an existing DB-direct entry (synthetic id or
+basename) without touching any .md file.  Scan-from-md rows are
+rejected: edit the .md and re-run `memory-scan' so disk stays
+canonical for those.  At least one field must be supplied; the FTS
+body index is refreshed in the same call so `memory-search' reflects
+the new text immediately.  Use this to correct a wrong memory instead
+of stacking a second corrective entry next to it.")
 
     (,(anvil-server-encode-handler #'anvil-memory--tool-get)
      :id "memory-get"

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -470,180 +470,6 @@ in `tools/list' immediately.  The real module is loaded on first
                anvil-server--tools-list-cache))
     count))
 
-(defun anvil-server--scan-substr-pos (s needle)
-  "Return start index of NEEDLE in S, or nil.
-Pure char-by-char scan — does not depend on `string-match' which
-returns nil on raw-byte strings from `read-stdin-bytes' under
-standalone nelisp."
-  (let* ((s-len (length s))
-         (n-len (length needle))
-         (limit (- s-len n-len))
-         (i 0)
-         (found nil))
-    (while (and (<= i limit) (not found))
-      (let ((j 0) (ok t))
-        (while (and ok (< j n-len))
-          (if (eq (aref s (+ i j)) (aref needle j))
-              (setq j (1+ j))
-            (setq ok nil)))
-        (if ok (setq found i)
-          (setq i (1+ i)))))
-    found))
-
-(defun anvil-server--scan-int-after (s needle)
-  "Return integer after NEEDLE in S, tolerating whitespace, or nil."
-  (let ((pos (anvil-server--scan-substr-pos s needle)))
-    (when pos
-      (let* ((s-len (length s))
-             (i (+ pos (length needle)))
-             (digits nil)
-             (saw-digit nil))
-        (while (and (< i s-len)
-                    (let ((c (aref s i)))
-                      (or (eq c ?\s) (eq c ?\t) (eq c ?\n) (eq c ?\r))))
-          (setq i (1+ i)))
-        (when (and (< i s-len) (eq (aref s i) ?-))
-          (push (aref s i) digits)
-          (setq i (1+ i)))
-        (while (and (< i s-len)
-                    (let ((c (aref s i)))
-                      (and (>= c ?0) (<= c ?9))))
-          (push (aref s i) digits)
-          (setq saw-digit t)
-          (setq i (1+ i)))
-        (when saw-digit
-          (string-to-number (apply #'string (nreverse digits))))))))
-
-(defun anvil-server--scan-string-after (s needle)
-  "Return JSON string after NEEDLE in S, tolerating whitespace, or nil.
-NEEDLE should end at the colon before the value."
-  (let ((pos (anvil-server--scan-substr-pos s needle)))
-    (when pos
-      (let* ((s-len (length s))
-             (i (+ pos (length needle)))
-             (chars nil))
-        (while (and (< i s-len)
-                    (let ((c (aref s i)))
-                      (or (eq c ?\s) (eq c ?\t) (eq c ?\n) (eq c ?\r))))
-          (setq i (1+ i)))
-        (when (and (< i s-len) (eq (aref s i) ?\"))
-          (setq i (1+ i))
-          (while (and (< i s-len) (not (eq (aref s i) ?\")))
-            (if (eq (aref s i) ?\\)
-                (progn
-                  (setq i (1+ i))
-                  (when (< i s-len)
-                    (push (aref s i) chars)
-                    (setq i (1+ i))))
-              (push (aref s i) chars)
-              (setq i (1+ i))))
-          (apply #'string (nreverse chars)))))))
-
-(defun anvil-server--scan-json-value-after (s needle)
-  "Return a string or integer JSON value after NEEDLE in S, or nil."
-  (let ((pos (anvil-server--scan-substr-pos s needle)))
-    (when pos
-      (let* ((s-len (length s))
-             (i (+ pos (length needle))))
-        (while (and (< i s-len)
-                    (let ((c (aref s i)))
-                      (or (eq c ?\s) (eq c ?\t) (eq c ?\n) (eq c ?\r))))
-          (setq i (1+ i)))
-        (cond
-         ((and (< i s-len) (eq (aref s i) ?\"))
-          (anvil-server--scan-string-after s needle))
-         ((and (< i s-len)
-               (let ((c (aref s i)))
-                 (or (eq c ?-) (and (>= c ?0) (<= c ?9)))))
-          (anvil-server--scan-int-after s needle))
-         (t nil))))))
-
-(defun anvil-server--scan-flat-object-after (s needle)
-  "Parse a flat JSON object that begins right after NEEDLE in S.
-Returns an alist `((SYMBOL . STRING-OR-INT) ...)' or nil if no
-match.  Handles the bounded shape used by MCP tool arguments:
-`{\"key1\":\"val1\",\"key2\":42,\"key3\":\"val3\"}'.  Bypasses
-json-read-from-string (broken on read-stdin-bytes strings under
-standalone nelisp)."
-  (let ((pos (anvil-server--scan-substr-pos s needle)))
-    (when pos
-      (let* ((s-len (length s))
-             (i (+ pos (length needle)))
-             ;; Skip optional whitespace + opening `{'.
-             (_skip-open
-              (progn
-                (while (and (< i s-len)
-                            (let ((c (aref s i)))
-                              (or (eq c ?\s) (eq c ?\t) (eq c ?\n))))
-                  (setq i (1+ i)))
-                (when (and (< i s-len) (eq (aref s i) ?\{))
-                  (setq i (1+ i)))))
-             (result nil)
-             (done nil))
-        (while (and (not done) (< i s-len))
-          ;; Skip whitespace and commas
-          (while (and (< i s-len)
-                      (let ((c (aref s i)))
-                        (or (eq c ?\s) (eq c ?\t) (eq c ?\n) (eq c ?,))))
-            (setq i (1+ i)))
-          (cond
-           ((>= i s-len) (setq done t))
-           ((eq (aref s i) ?\})
-            (setq done t))
-           ((eq (aref s i) ?\")
-            ;; Read key string
-            (setq i (1+ i))
-            (let ((key-chars nil))
-              (while (and (< i s-len) (not (eq (aref s i) ?\")))
-                (push (aref s i) key-chars)
-                (setq i (1+ i)))
-              (when (< i s-len) (setq i (1+ i))) ; consume closing "
-              ;; Skip whitespace + colon
-              (while (and (< i s-len)
-                          (let ((c (aref s i)))
-                            (or (eq c ?\s) (eq c ?\t) (eq c ?:))))
-                (setq i (1+ i)))
-              ;; Read value
-              (let ((key (intern (apply #'string (nreverse key-chars))))
-                    (val nil))
-                (cond
-                 ((and (< i s-len) (eq (aref s i) ?\"))
-                  (setq i (1+ i))
-                  (let ((val-chars nil))
-                    (while (and (< i s-len) (not (eq (aref s i) ?\")))
-                      ;; Minimal escape handling: skip a single backslash
-                      ;; and copy the next char verbatim (covers `\"' and
-                      ;; `\\' for typical MCP args).
-                      (if (eq (aref s i) ?\\)
-                          (progn
-                            (setq i (1+ i))
-                            (when (< i s-len)
-                              (push (aref s i) val-chars)
-                              (setq i (1+ i))))
-                        (push (aref s i) val-chars)
-                        (setq i (1+ i))))
-                    (when (< i s-len) (setq i (1+ i))) ; consume closing "
-                    (setq val (apply #'string (nreverse val-chars)))))
-                 ((and (< i s-len)
-                       (let ((c (aref s i)))
-                         (or (eq c ?-)
-                             (and (>= c ?0) (<= c ?9)))))
-                  (let ((num-chars nil))
-                    (while (and (< i s-len)
-                                (let ((c (aref s i)))
-                                  (or (eq c ?-)
-                                      (eq c ?.)
-                                      (and (>= c ?0) (<= c ?9)))))
-                      (push (aref s i) num-chars)
-                      (setq i (1+ i)))
-                    (setq val
-                          (string-to-number
-                           (apply #'string (nreverse num-chars))))))
-                 (t (setq done t)))
-                (push (cons key val) result))))
-           (t (setq i (1+ i)))))
-        (nreverse result)))))
-
 (defun anvil-server--jsonrpc-response (id result)
   "Create a JSON-RPC response with ID and RESULT."
   (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
@@ -2004,6 +1830,28 @@ See also: `anvil-server-tool-throw'"
 
 ;;; API - Transport
 
+(defun anvil-server--string-to-utf8-bytes (string)
+  "Return STRING as a unibyte UTF-8 byte string."
+  (if (not (multibyte-string-p string))
+      string
+    ;; Measured 2026-08-28 with "あ": NeLisp v1.1.0+1
+    ;; `string-as-unibyte' => (227 129 130); Emacs 30.1
+    ;; `encode-coding-string' => (227 129 130).
+    (if (fboundp 'nelisp--write-stderr-line)
+        (string-as-unibyte string)
+      (encode-coding-string string 'utf-8 t))))
+
+(defun anvil-server--utf8-bytes-to-string (string)
+  "Decode unibyte UTF-8 STRING while preserving multibyte input."
+  (if (multibyte-string-p string)
+      string
+    ;; Measured 2026-08-28 with UTF-8 bytes for "日本語": NeLisp
+    ;; v1.1.0+1 `string-as-multibyte' => (26085 26412 35486);
+    ;; Emacs 30.1 `decode-coding-string' => (26085 26412 35486).
+    (if (fboundp 'nelisp--write-stderr-line)
+        (string-as-multibyte string)
+      (decode-coding-string string 'utf-8 t))))
+
 (defun anvil-server-process-jsonrpc (json-string server-id)
   "Process a JSON-RPC message JSON-STRING for SERVER-ID and return the response.
 This is the main entry point for stdio transport in MCP.
@@ -2035,67 +1883,24 @@ See also: `anvil-server-process-jsonrpc-parsed'"
           (decoded nil))
       (condition-case json-err
           (progn
-            ;; Bypass decode-coding-string on standalone nelisp:
-            ;; read-stdin-bytes already returns a UTF-8 string, and
-            ;; decode-coding-string on it produces a multibyte string
-            ;; whose internal representation makes json-read-from-string
-            ;; pathologically slow (> 600 s observed for 150-byte body).
-            (setq decoded
-                  (if (fboundp 'nelisp--write-stderr-line)
-                      ;; Standalone nelisp: read-stdin-bytes already returns
-                      ;; UTF-8 text; decode-coding-string would make json-read
-                      ;; pathologically slow, so pass through unchanged.
-                      json-string
-                    ;; Host Emacs: the JSON-RPC line arrives as a unibyte
-                    ;; (raw UTF-8 byte) string, so decode to multibyte before
-                    ;; json-read.  Otherwise CJK argument values come back
-                    ;; unibyte and `search-forward' / `re-search-forward'
-                    ;; never match the multibyte file buffer (manifested as
-                    ;; file-replace-string "string not found" on Japanese
-                    ;; while pure-ASCII args were unaffected).
-                    (if (and (fboundp 'multibyte-string-p)
-                             (multibyte-string-p json-string))
-                        json-string
-                      (decode-coding-string json-string 'utf-8 t))))
+            ;; NeLisp v1.1.0+1 measurement (2026-08-28): converting a
+            ;; 150-byte unibyte CJK JSON request with `string-as-multibyte'
+            ;; took 0.000012875 s and `json-read-from-string' then took
+            ;; 0.013195038 s.  The former >600 s pathology is gone.
+            ;; Emacs 30.1 measurement: searching a multibyte "日本語"
+            ;; buffer with its unibyte UTF-8 bytes returned nil; decoding
+            ;; the query first returned buffer position 4.
+            (setq decoded (anvil-server--utf8-bytes-to-string json-string))
             (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
               (nelisp--write-stderr-line
                (format "[PJ] decode %.4fs decoded-len=%d"
                        (- (float-time) t0) (length decoded))))
-            ;; Standalone nelisp: json-read-from-string and string-match
-            ;; both return nil on raw-byte strings from read-stdin-bytes,
-            ;; so use a char-by-char scan that bypasses both.
-            ;; Host Emacs: json-read works fine and is needed because
-            ;; the scan-extract path drops `params' (real tool dispatch
-            ;; needs full alist).  Gate on a standalone-only fboundp.
             (let ((t1 (float-time)))
-              (if (fboundp 'nelisp--write-stderr-line)
-                  ;; standalone path
-                  (let* ((sx-id (anvil-server--scan-json-value-after
-                                 decoded "\"id\":"))
-                         (sx-method (anvil-server--scan-string-after
-                                     decoded "\"method\":"))
-                         ;; For `tools/call' the handler needs
-                         ;; `(name . X) (arguments . ALIST)' in params.
-                         ;; Extract both with a flat-object scanner.
-                         (sx-params
-                          (when (equal sx-method "tools/call")
-                            (let ((nm (anvil-server--scan-string-after
-                                       decoded "\"name\":"))
-                                  (args (anvil-server--scan-flat-object-after
-                                         decoded "\"arguments\":")))
-                              `((name . ,nm) (arguments . ,args))))))
-                    (setq json-object
-                          `((jsonrpc . "2.0")
-                            (id . ,sx-id)
-                            (method . ,sx-method)
-                            (params . ,sx-params)))
-                    (when anvil-server--debug-trace
-                      (nelisp--write-stderr-line
-                       (format "[PJ] scan-extract %.4fs id=%S method=%S name=%S"
-                               (- (float-time) t1) sx-id sx-method
-                               (and sx-params (alist-get 'name sx-params))))))
-                ;; host Emacs path — normal json-read
-                (setq json-object (json-read-from-string decoded)))))
+              (setq json-object (json-read-from-string decoded))
+              (when (and anvil-server--debug-trace
+                         (fboundp 'nelisp--write-stderr-line))
+                (nelisp--write-stderr-line
+                 (format "[PJ] json-read %.4fs" (- (float-time) t1))))))
         (json-error
          (setq response
                (anvil-server--jsonrpc-error
@@ -2180,12 +1985,12 @@ characters report the correct on-the-wire byte count.
 Raises `wrong-type-argument' if JSON-STRING is not a string."
   (unless (stringp json-string)
     (signal 'wrong-type-argument (list 'stringp json-string)))
-  (let* ((body (encode-coding-string json-string 'utf-8 t))
+  (let* ((body (anvil-server--string-to-utf8-bytes json-string))
          (n (length body))
          (header (format "%s: %d\r\n\r\n"
                          anvil-server-mcp-framing-header-name n)))
     ;; Header is ASCII, body is already a unibyte UTF-8 string.
-    (concat (encode-coding-string header 'utf-8 t) body)))
+    (concat (anvil-server--string-to-utf8-bytes header) body)))
 
 (defun anvil-server-mcp-parse-content-length-header (header-block)
   "Parse HEADER-BLOCK and return the Content-Length integer or nil.
@@ -2215,9 +2020,7 @@ Signals an error tagged `anvil-mcp-frame-error' on malformed
 framing (e.g. missing Content-Length header)."
   (unless (stringp input)
     (signal 'wrong-type-argument (list 'stringp input)))
-  (let* ((unibyte (if (multibyte-string-p input)
-                      (encode-coding-string input 'utf-8 t)
-                    input))
+  (let* ((unibyte (anvil-server--string-to-utf8-bytes input))
          ;; \r\n\r\n separator between header section and body.
          (sep "\r\n\r\n")
          (sep-pos (string-match (regexp-quote sep) unibyte)))
@@ -2241,7 +2044,7 @@ framing (e.g. missing Content-Length header)."
          (t
           (let* ((body-bytes (substring unibyte body-start
                                         (+ body-start n)))
-                 (body (decode-coding-string body-bytes 'utf-8 t))
+                 (body (anvil-server--utf8-bytes-to-string body-bytes))
                  (consumed (+ body-start n)))
             (list :body body :consumed consumed)))))))))
 

--- a/anvil-server.el
+++ b/anvil-server.el
@@ -1841,10 +1841,49 @@ See also: `anvil-server-tool-throw'"
         (string-as-unibyte string)
       (encode-coding-string string 'utf-8 t))))
 
+(defun anvil-server--valid-utf8-bytes-p (string)
+  "Return non-nil when unibyte STRING is well-formed UTF-8."
+  (let ((i 0)
+        (n (length string))
+        (valid t))
+    (while (and valid (< i n))
+      (let ((b0 (aref string i)))
+        (cond
+         ((< b0 #x80)
+          (setq i (1+ i)))
+         ((and (>= b0 #xC2) (<= b0 #xDF)
+               (< (1+ i) n)
+               (>= (aref string (1+ i)) #x80)
+               (<= (aref string (1+ i)) #xBF))
+          (setq i (+ i 2)))
+         ((and (>= b0 #xE0) (<= b0 #xEF)
+               (< (+ i 2) n)
+               (let ((b1 (aref string (1+ i))))
+                 (and (if (= b0 #xE0) (>= b1 #xA0) (>= b1 #x80))
+                      (if (= b0 #xED) (<= b1 #x9F) (<= b1 #xBF))))
+               (>= (aref string (+ i 2)) #x80)
+               (<= (aref string (+ i 2)) #xBF))
+          (setq i (+ i 3)))
+         ((and (>= b0 #xF0) (<= b0 #xF4)
+               (< (+ i 3) n)
+               (let ((b1 (aref string (1+ i))))
+                 (and (if (= b0 #xF0) (>= b1 #x90) (>= b1 #x80))
+                      (if (= b0 #xF4) (<= b1 #x8F) (<= b1 #xBF))))
+               (>= (aref string (+ i 2)) #x80)
+               (<= (aref string (+ i 2)) #xBF)
+               (>= (aref string (+ i 3)) #x80)
+               (<= (aref string (+ i 3)) #xBF))
+          (setq i (+ i 4)))
+         (t
+          (setq valid nil)))))
+    valid))
+
 (defun anvil-server--utf8-bytes-to-string (string)
   "Decode unibyte UTF-8 STRING while preserving multibyte input."
   (if (multibyte-string-p string)
       string
+    (unless (anvil-server--valid-utf8-bytes-p string)
+      (signal 'json-error '("Invalid UTF-8 in JSON input")))
     ;; Measured 2026-08-28 with UTF-8 bytes for "日本語": NeLisp
     ;; v1.1.0+1 `string-as-multibyte' => (26085 26412 35486);
     ;; Emacs 30.1 `decode-coding-string' => (26085 26412 35486).

--- a/anvil.el
+++ b/anvil.el
@@ -83,7 +83,10 @@ These are not loaded by default.  Available modules:
 - `org-index' — Persistent SQLite index of org files (requires Emacs 29+)
 - `buffer'    — Explicit buffer-* MCP tools (read/save/list-modified)
 - `dev'       — Developer helpers: `anvil-self-sync-check' for dev/installed
-                git HEAD mismatch detection
+                git HEAD mismatch detection, `anvil-codex-efficiency-check'
+                for Codex token-saving setup audits, and
+                `anvil-claude-limits-analyze' for Claude Code limits
+                report triage
 - `offload'   — Future-based API for running heavy elisp in a batch
                 subprocess (Doc 03 Phase 1)
 - `browser'   — agent-browser CLI wrapper: fetch / interact / capture
@@ -112,9 +115,9 @@ These are not loaded by default.  Available modules:
                 Claude Code's hardcoded ~83.5% auto-compact with a
                 user-tunable earlier trigger for long autonomous
                 sessions.  Requires `state' and integrates with
-                `session' (Stop event).  Five MCP tools: compact-
+                `session' (Stop event).  Seven MCP tools: compact-
                 estimate / -should-trigger / -snapshot / -restore /
-                -hook.
+                -hook / -stats / -pressure-report.
 - `harness-telemetry' — Doc 46 Phase 1 runtime-harness failure
                 classifier + 4-class SQLite telemetry (no-exec /
                 contract-violation / stall / reasoning).  Hooks

--- a/bin/anvil-runtime
+++ b/bin/anvil-runtime
@@ -140,9 +140,21 @@ case "$1" in
             # driver can read them before `emacs-init.el' polyfills
             # `getenv'.  (Standalone NeLisp's `getenv' is nil until
             # `emacs-callproc.el' loads — chicken-and-egg with init load.)
-            case "${ANVIL_RUNTIME_FAST_HANDSHAKE:-}" in
-                1) anvil_fast_handshake_elisp=t ;;
-                *) anvil_fast_handshake_elisp=nil ;;
+            # Fast handshake is ON by default as of NeLisp v1.1.1.  It was
+            # gated off because every fast-path run died after 2-20 s; the
+            # cause was fourteen precise-root defects in the standalone GC,
+            # fixed there, and with a NeLisp carrying those fixes the path
+            # returns all 5,208 bytes and exits 0 -- 3/3 with address
+            # randomisation disabled and 3/3 with it on.  Without it every
+            # `mcp serve' pays the ~100 s cold start before answering
+            # `initialize'.
+            #
+            # It DOES depend on the runtime underneath: an older NeLisp will
+            # crash on this path.  `ANVIL_RUNTIME_FAST_HANDSHAKE=0' turns it
+            # back off for exactly that case.
+            case "${ANVIL_RUNTIME_FAST_HANDSHAKE:-1}" in
+                0|no|off|false) anvil_fast_handshake_elisp=nil ;;
+                *) anvil_fast_handshake_elisp=t ;;
             esac
             BOOTSTRAP_DIR="${ANVIL_RUNTIME_DAEMON_DIR:-$HOME/.anvil-runtime}"
             mkdir -p "$BOOTSTRAP_DIR"

--- a/bin/anvil-runtime
+++ b/bin/anvil-runtime
@@ -4,9 +4,9 @@
 # Loads anvil-server.el modules under a standalone NeLisp interpreter
 # and enters the MCP Content-Length stdio loop via the elisp driver in
 # `scripts/anvil-runtime-shell-loop.el'.  Migrated 2026-05-14 from
-# `nelisp/bin/anvil-runtime' + `nelisp-emacs/scripts/anvil-runtime-*'
+# `nelisp/bin/anvil-runtime' + `nelisp-emacs-lib/scripts/anvil-runtime-*'
 # so the entire deployment surface lives in this repo; `nelisp' and
-# `nelisp-emacs' supply only the language runtime and Emacs C → elisp
+# `nelisp-emacs-lib' supply only the language runtime and Emacs C → elisp
 # substrate respectively.
 #
 # Required env / paths:
@@ -14,17 +14,17 @@
 #                         repo root, i.e. `$script_dir/..').
 #   NELISP_BIN          — nelisp standalone binary.  Default: walks the
 #                         sibling-checkout convention
-#                         `$ANVIL_EL_DIR/../nelisp/target/release/nelisp'.
-#   NELISP_EMACS_DIR    — nelisp-emacs checkout root.  Default: walks
+#                         `$ANVIL_EL_DIR/../nelisp/target/nelisp'.
+#   NELISP_EMACS_DIR    — nelisp-emacs-lib checkout root.  Default: walks
 #                         the sibling-checkout convention
-#                         `$ANVIL_EL_DIR/../nelisp-emacs'.
+#                         `$ANVIL_EL_DIR/../nelisp-emacs-lib'.
 #   ANVIL_SERVER_ID     — server-id (default: "default")
 #
 # Sibling-checkout convention assumed at default:
 #   <parent>/
 #     ├── anvil.el          (this repo)
 #     ├── nelisp            (Layer 1 NeLisp runtime)
-#     └── nelisp-emacs      (Layer 2 Emacs C → elisp port)
+#     └── nelisp-emacs-lib  (Layer 2 Emacs C → elisp port)
 # Set the env vars above to override when the layout differs.
 
 set -euo pipefail
@@ -40,8 +40,11 @@ ANVIL_EL_DIR="${ANVIL_EL_DIR:-$(cd "$script_dir/.." && pwd)}"
 # discovery when set.
 discover_nelisp_bin() {
     local candidates=(
+        "$ANVIL_EL_DIR/../nelisp/target/nelisp"
         "$ANVIL_EL_DIR/../nelisp/target/release/nelisp"
+        "$HOME/Cowork/Notes/dev/nelisp/target/nelisp"
         "$HOME/Cowork/Notes/dev/nelisp/target/release/nelisp"
+        "$HOME/Notes/dev/nelisp/target/nelisp"
         "$HOME/Notes/dev/nelisp/target/release/nelisp"
     )
     local p resolved_dir
@@ -58,8 +61,11 @@ discover_nelisp_bin() {
 
 discover_nelisp_emacs_dir() {
     local candidates=(
+        "$ANVIL_EL_DIR/../nelisp-emacs-lib"
         "$ANVIL_EL_DIR/../nelisp-emacs"
+        "$HOME/Cowork/Notes/dev/nelisp-emacs-lib"
         "$HOME/Cowork/Notes/dev/nelisp-emacs"
+        "$HOME/Notes/dev/nelisp-emacs-lib"
         "$HOME/Notes/dev/nelisp-emacs"
     )
     local p
@@ -72,14 +78,29 @@ discover_nelisp_emacs_dir() {
     return 1
 }
 
-NELISP_BIN="${NELISP_BIN:-$(discover_nelisp_bin || echo /target/release/nelisp)}"
+NELISP_BIN="${NELISP_BIN:-$(discover_nelisp_bin || echo /target/nelisp)}"
 NELISP_EMACS_DIR="${NELISP_EMACS_DIR:-$(discover_nelisp_emacs_dir || echo "")}"
-# Derive nelisp's lisp/ dir from NELISP_BIN (= sibling of target/release/).
+# Derive nelisp's lisp/ dir by locating the checkout root.  This supports
+# binaries in both target/ and target/release/ without assuming a depth.
 # Used by the alist-get override workaround in shell-loop / server-loop
 # until Doc 98 §98.2 (elisp-complete frozen-heap baker) ships.
+discover_nelisp_lisp_dir() {
+    local dir
+    dir="$(cd "$(dirname "$NELISP_BIN")" && pwd -P)"
+    while :; do
+        if [ -d "$dir/lisp" ] && [ -f "$dir/VERSION" ]; then
+            echo "$dir/lisp"
+            return 0
+        fi
+        if [ "$dir" = "/" ]; then
+            return 1
+        fi
+        dir="$(dirname "$dir")"
+    done
+}
+
 if [ -z "${NELISP_LISP_DIR:-}" ] && [ -x "$NELISP_BIN" ]; then
-    _nelisp_top="$(cd "$(dirname "$NELISP_BIN")/../.." && pwd -P)"
-    NELISP_LISP_DIR="$_nelisp_top/lisp"
+    NELISP_LISP_DIR="$(discover_nelisp_lisp_dir || true)"
 fi
 NELISP_LISP_DIR="${NELISP_LISP_DIR:-}"
 LOOP_EL="${LOOP_EL:-$ANVIL_EL_DIR/scripts/anvil-runtime-shell-loop.el}"
@@ -119,6 +140,10 @@ case "$1" in
             # driver can read them before `emacs-init.el' polyfills
             # `getenv'.  (Standalone NeLisp's `getenv' is nil until
             # `emacs-callproc.el' loads — chicken-and-egg with init load.)
+            case "${ANVIL_RUNTIME_FAST_HANDSHAKE:-}" in
+                1) anvil_fast_handshake_elisp=t ;;
+                *) anvil_fast_handshake_elisp=nil ;;
+            esac
             BOOTSTRAP_DIR="${ANVIL_RUNTIME_DAEMON_DIR:-$HOME/.anvil-runtime}"
             mkdir -p "$BOOTSTRAP_DIR"
             BOOTSTRAP="$BOOTSTRAP_DIR/mcp-bootstrap.el"
@@ -127,9 +152,10 @@ case "$1" in
 (setq anvil-runtime-bootstrap-anvil-el-dir "$ANVIL_EL_DIR")
 (setq anvil-runtime-bootstrap-nelisp-emacs-dir "$NELISP_EMACS_DIR")
 (setq anvil-runtime-bootstrap-nelisp-lisp-dir "$NELISP_LISP_DIR")
+(setq anvil-runtime-bootstrap-fast-handshake-enabled $anvil_fast_handshake_elisp)
 (load "$LOOP_EL" nil t)
 EOF
-            exec "$NELISP_BIN" exec "$BOOTSTRAP"
+            exec "$NELISP_BIN" "$BOOTSTRAP"
         fi
         usage
         ;;
@@ -157,7 +183,7 @@ EOF
 (setq anvil-runtime-bootstrap-nelisp-lisp-dir "$NELISP_LISP_DIR")
 (load "$SERVER_LOOP_EL" nil t)
 EOF
-        exec "$NELISP_BIN" exec "$BOOTSTRAP"
+        exec "$NELISP_BIN" "$BOOTSTRAP"
         ;;
     *)
         usage

--- a/bin/anvil-runtime-daemon
+++ b/bin/anvil-runtime-daemon
@@ -4,8 +4,8 @@
 # K2 (= 2026-05-11) rewrite: replaces the G v1 FIFO-based scheme
 # (mkfifo + Linux O_RDWR keep-alive + `dd bs=1' bridge hacks) with a
 # proper UNIX domain socket listener.  Powered by the
-# `make-network-process' polyfill in nelisp-emacs/src/emacs-*.el
-# (commit `b662671' on nelisp-emacs main).
+# `make-network-process' polyfill in nelisp-emacs-lib/src/emacs-*.el
+# (commit `b662671' on nelisp-emacs-lib main).
 #
 # Lifecycle:
 #   start    — cold-load `anvil-runtime server' once, leave it listening

--- a/docs/design/51-nelisp-module-dispatch.org
+++ b/docs/design/51-nelisp-module-dispatch.org
@@ -13,6 +13,33 @@ End-to-end verified: ~bin/anvil-runtime mcp serve~ with
 exposes the synthetic ~nelisp-shims-demo-ping~ tool, ~tools/list~
 includes it, ~tools/call~ returns ="pong"=.
 
+* NeLisp v1.1.0 string contract (Doc 200)
+
+The following measurements were made on 2026-08-28 with
+~nelisp/target/nelisp~ at ~acbd93b7f~ (v1.1.0 plus one unrelated tooling
+commit):
+
+- ~string-as-unibyte~ is the byte-accurate NeLisp conversion.  For ="あ"=,
+  ~(append (string-as-unibyte "あ") nil)~ returned ~(227 129 130)~.
+  ~string-bytes~ returned =3= for ="あ"= and =2= for
+  ~(unibyte-string 200 201)~.
+- ~encode-coding-string~ is still an identity stub: encoding ="あ"= as UTF-8
+  returned a multibyte string whose character list was ~(12354)~.  The
+  ~decode-coding-string~ stub also left explicit UTF-8 byte strings unchanged.
+  Anvil therefore uses ~string-as-unibyte~ / ~string-as-multibyte~ on NeLisp
+  and the coding-system functions on host Emacs 30.1.
+- The stdin primitive used by ~scripts/anvil-runtime-shell-loop.el~ is
+  ~read-stdin-bytes~, buffered by ~emacs-stdio-read-bytes~.  It returned a
+  150-byte ASCII JSON body as unibyte, but returned ="日本語"= as an already
+  decoded multibyte string with ~length~ =3= and ~string-bytes~ =9=.  Transport
+  code must therefore inspect the representation instead of assuming one tag.
+- Numeric reader escapes now match Emacs for octal, hexadecimal, and escape
+  forms.  Named/universal escapes remain literal: ~(append "\U00003042" nil)~
+  returned ~(85 48 48 48 48 51 48 52 50)~, and
+  ~(append "\N{HIRAGANA LETTER A}" nil)~ returned the literal =N{...}= byte
+  sequence.  Do not use ~\U...~ or ~\N{...}~ string escapes in anvil Elisp
+  sources.
+
 * Phase 1 result — what works
 
 - Pattern C accumulator (~anvil-server-register-tools~ stub) — ✓

--- a/scripts/anvil-runtime-server-loop.el
+++ b/scripts/anvil-runtime-server-loop.el
@@ -37,6 +37,49 @@ nil for production (silent).")
   (let ((val (and (fboundp 'getenv) (getenv name))))
     (if (and val (> (length val) 0)) val default)))
 
+(defvar anvil-runtime-server--primitive-load nil
+  "Standalone `load' function saved before stdlib-misc replaces it.")
+
+(defvar anvil-runtime-server--primitive-hash-functions nil
+  "Standalone hash functions saved before stdlib-misc replaces them.")
+
+(defvar anvil-runtime-server--skip-load-files nil
+  "Absolute source files intentionally skipped by the runtime loader.")
+
+(defun anvil-runtime-server--compat-load
+    (file &optional noerror nomessage _nosuffix _must-suffix)
+  "Load FILE with Emacs load context and the standalone native reader."
+  (let ((resolved
+         (if (and (> (length file) 0) (eq (aref file 0) ?/))
+             (cond
+              ((file-exists-p file) file)
+              ((file-exists-p (concat file ".el")) (concat file ".el"))
+              (t nil))
+           (locate-library file))))
+    (if (null resolved)
+        (if noerror nil
+          (signal 'file-error (list "Cannot open load file" file)))
+      (if (member resolved anvil-runtime-server--skip-load-files)
+          t
+        (let ((prior-lfn (and (boundp 'load-file-name) load-file-name))
+              (prior-dd (and (boundp 'default-directory) default-directory))
+              (value nil)
+              (err nil))
+          (setq load-file-name resolved)
+          (setq default-directory (file-name-directory resolved))
+          (condition-case caught
+              (setq value
+                    (funcall anvil-runtime-server--primitive-load
+                             resolved noerror nomessage))
+            (error (setq err caught)))
+          (when (fboundp 'garbage-collect)
+            (garbage-collect))
+          (setq load-file-name prior-lfn)
+          (setq default-directory prior-dd)
+          (cond
+           ((null err) value)
+           (t (signal (car err) (cdr err)))))))))
+
 ;; Path resolution — same chain as shell-loop.el §path-resolution.
 ;; The primary channel is `anvil-runtime-bootstrap-{anvil-el,nelisp-emacs}-dir'
 ;; set by `bin/anvil-runtime' before loading us; `getenv' is unreliable
@@ -60,6 +103,12 @@ nil for production (silent).")
              (concat (file-name-directory
                       (directory-file-name anvil-el-dir))
                      "nelisp-emacs"))))
+       (nelisp-lisp-dir
+        (or (and (boundp 'anvil-runtime-bootstrap-nelisp-lisp-dir)
+                 (> (length anvil-runtime-bootstrap-nelisp-lisp-dir) 0)
+                 anvil-runtime-bootstrap-nelisp-lisp-dir)
+            (concat (file-name-directory (directory-file-name anvil-el-dir))
+                    "nelisp/lisp")))
        (server-id
         (anvil-runtime-server--env "ANVIL_SERVER_ID" "emacs-eval"))
        (socket-path
@@ -80,7 +129,9 @@ nil for production (silent).")
        (eventloop-el (concat nelisp-emacs-dir "/src/emacs-eventloop.el"))
        (metrics-el (concat anvil-el-dir "/anvil-server-metrics.el"))
        (server-el (concat anvil-el-dir "/anvil-server.el"))
-       (server-commands-el (concat anvil-el-dir "/anvil-server-commands.el")))
+       (server-commands-el (concat anvil-el-dir "/anvil-server-commands.el"))
+       (stdlib-misc (concat nelisp-lisp-dir "/nelisp-stdlib-misc.el"))
+       (bootstrap-skip-features '(nelisp-coding-jis-tables calendar)))
 
   ;; --- substrate bootstrap (same as shell-loop.el) ---
   ;; emacs-init.el gates its vendor load-path setup on
@@ -95,29 +146,32 @@ nil for production (silent).")
   ;; UTF-8 only and never exercises JIS codec paths, so the tables are
   ;; deadweight for the server-loop.  Remove once the nelisp regression
   ;; is fixed upstream.
-  (provide 'nelisp-coding-jis-tables)
+  (dolist (feature bootstrap-skip-features)
+    (provide feature))
+  (setq load-prefer-newer t)
+  ;; Load before emacs-init for the measured `load-file-name' behavior.
+  ;; See shell-loop.el for the 2026-08-28 JSON timing and call-count data.
+  (setq anvil-runtime-server--primitive-load (symbol-function 'load))
+  (setq anvil-runtime-server--primitive-hash-functions
+        (mapcar (lambda (name) (cons name (symbol-function name)))
+                '(maphash hash-table-keys hash-table-values hash-table-count)))
+  (load stdlib-misc nil t)
+  ;; Retain the working native hash traversal functions; see shell-loop.el
+  ;; for the measured missing-`nelisp--hash-pairs' failure.
+  (let ((saved anvil-runtime-server--primitive-hash-functions))
+    (while saved
+      (fset (car (car saved)) (cdr (car saved)))
+      (setq saved (cdr saved))))
+  ;; Install the same 2026-08-29 measured native-reader compatibility
+  ;; layer and exact vendor-calendar skip documented in shell-loop.el.
+  (setq anvil-runtime-server--skip-load-files
+        (list (concat nelisp-emacs-dir
+                      "/vendor/emacs-lisp/calendar/calendar.el")))
+  (fset 'load #'anvil-runtime-server--compat-load)
+  (dolist (feature bootstrap-skip-features)
+    (provide feature))
   (load init-el nil t)
   (load stub-el nil t)
-
-  ;; --- TEMPORARY alist-get override (= Doc 98 §98.2 workaround) ---
-  ;; See shell-loop.el for the full rationale.  Remove this block once
-  ;; the elisp-complete baker (= Doc 98 §98.2) ships and the .image
-  ;; carries the fixed alist-get.
-  (let* ((nelisp-lisp-dir
-          (or (and (boundp 'anvil-runtime-bootstrap-nelisp-lisp-dir)
-                   (> (length anvil-runtime-bootstrap-nelisp-lisp-dir) 0)
-                   anvil-runtime-bootstrap-nelisp-lisp-dir)
-              (concat (file-name-directory (directory-file-name anvil-el-dir))
-                      "nelisp/lisp")))
-         (stdlib-misc (concat nelisp-lisp-dir "/nelisp-stdlib-misc.el")))
-    (when (file-exists-p stdlib-misc)
-      (condition-case err
-          (load stdlib-misc nil t)
-        (error
-         (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
-           (nelisp--write-stderr-line
-            (concat "[server-loop] nelisp-stdlib-misc override load ERR: "
-                    (format "%S" err))))))))
 
   ;; Put `anvil-el-dir' on `load-path' so any `(require 'anvil-orchestrator-routing)'
   ;; / `(require 'anvil-orchestrator-presets)' / etc. inside the

--- a/scripts/anvil-runtime-shell-loop.el
+++ b/scripts/anvil-runtime-shell-loop.el
@@ -151,8 +151,13 @@ nil for production (silent).")
 
 (defun anvil-runtime-shell--frame (body)
   "Return BODY as a Content-Length MCP frame."
-  (let ((n (if (fboundp 'string-bytes) (string-bytes body) (length body))))
-    (concat "Content-Length: " (number-to-string n) "\r\n\r\n" body)))
+  (let* ((bytes (if (multibyte-string-p body)
+                    (if (fboundp 'nelisp--write-stderr-line)
+                        (string-as-unibyte body)
+                      (encode-coding-string body 'utf-8 t))
+                  body))
+         (n (length bytes)))
+    (concat "Content-Length: " (number-to-string n) "\r\n\r\n" bytes)))
 
 (defun anvil-runtime-shell--stdout (s)
   "Write S to stdout using the standalone byte writer when present."
@@ -165,6 +170,8 @@ nil for production (silent).")
   (let ((chunk (and (fboundp 'read-stdin-bytes)
                     (read-stdin-bytes 4096))))
     (when (and (stringp chunk) (> (length chunk) 0))
+      (when (multibyte-string-p chunk)
+        (setq chunk (string-as-unibyte chunk)))
       (setq anvil-runtime-shell--fast-stdin-buffer
             (concat anvil-runtime-shell--fast-stdin-buffer chunk))
       t)))
@@ -436,6 +443,21 @@ nil for production (silent).")
   (load stdio-el nil t)
   (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
     (nelisp--write-stderr-line "[STEP] stdio-el done"))
+  ;; Measured 2026-08-28 on NeLisp v1.1.0+1: `read-stdin-bytes'
+  ;; returned "日本語" as multibyte with length 3 and string-bytes 9.
+  ;; Normalize every refill so the stdio reader's length and substring
+  ;; arithmetic stays in MCP wire bytes.
+  (defun emacs-stdio--refill ()
+    "Read stdin into `emacs-stdio--buffer' as unibyte wire bytes."
+    (let ((chunk (read-stdin-bytes emacs-stdio--chunk-size)))
+      (cond
+       ((null chunk) nil)
+       ((and (stringp chunk) (= (length chunk) 0)) nil)
+       (t
+        (when (multibyte-string-p chunk)
+          (setq chunk (string-as-unibyte chunk)))
+        (setq emacs-stdio--buffer (concat emacs-stdio--buffer chunk))
+        t))))
   (when (boundp 'emacs-stdio--buffer)
     (setq emacs-stdio--buffer
           (concat anvil-runtime-shell--fast-stdin-buffer
@@ -553,13 +575,9 @@ case-insensitively, returns the integer value or nil."
   (defun anvil-server-mcp-frame-encode (body)
     "Phase B5 Stage 1b override — emit `Content-Length: N\r\n\r\nBODY'.
 N is the UTF-8 byte length of BODY."
-    (let* ((bytes (if (fboundp 'encode-coding-string)
-                      (encode-coding-string body 'utf-8 t)
-                    body))
-           (n (if (fboundp 'string-bytes)
-                  (string-bytes bytes)
-                (length bytes))))
-      (concat "Content-Length: " (number-to-string n) "\r\n\r\n" body)))
+    (let* ((bytes (anvil-server--string-to-utf8-bytes body))
+           (n (length bytes)))
+      (concat "Content-Length: " (number-to-string n) "\r\n\r\n" bytes)))
 
   ;; Override the framed-with-prefix reader entirely.  The original uses
   ;; `replace-regexp-in-string' for trailing-CR strip, which is a no-op

--- a/scripts/anvil-runtime-shell-loop.el
+++ b/scripts/anvil-runtime-shell-loop.el
@@ -640,15 +640,15 @@ Otherwise return a short string describing the problem."
   ;; The re-enable criterion this comment used to state -- repeated plain
   ;; runs exiting 0 with ASLR both enabled and disabled -- is met against a
   ;; NeLisp built at or after that fix: 3/3 with `setarch -R' and 3/3 plain,
-  ;; each returning the full 5,208 bytes.  It is NOT met against an older
-  ;; binary, which is why this stays opt-in: turning it on is safe only
-  ;; if the deployed `target/nelisp' carries the GC fix.
+  ;; each returning the full 5,208 bytes.  `bin/anvil-runtime' now defaults
+  ;; the gate ON for that reason, and writes the decision into the bootstrap
+  ;; it generates.
   ;;
-  ;; To turn it on, set `anvil-runtime-bootstrap-fast-handshake-enabled' in
-  ;; the bootstrap `bin/anvil-runtime' generates.  ANVIL_RUNTIME_FAST_
-  ;; HANDSHAKE=1 does NOT work under standalone NeLisp: the `defvar' above
-  ;; runs before `emacs-callproc.el' provides `getenv', so the env channel
-  ;; is host-Emacs only.
+  ;; It is NOT met against an older binary, which is what
+  ;; `ANVIL_RUNTIME_FAST_HANDSHAKE=0' exists for.  Note the env var reaches
+  ;; the runtime only through that generated bootstrap: reading it here would
+  ;; not work, because this `defvar' runs before `emacs-callproc.el' provides
+  ;; `getenv', so the env channel is host-Emacs only.
   (when (and anvil-runtime-shell--fast-handshake-enabled
              (not anvil-server--debug-trace)
              (fboundp 'read-stdin-bytes)

--- a/scripts/anvil-runtime-shell-loop.el
+++ b/scripts/anvil-runtime-shell-loop.el
@@ -48,6 +48,58 @@ nil for production (silent).")
   (let ((val (and (fboundp 'getenv) (getenv name))))
     (if (and val (> (length val) 0)) val default)))
 
+(defvar anvil-runtime-shell--fast-handshake-enabled
+  (or (and (boundp 'anvil-runtime-bootstrap-fast-handshake-enabled)
+           anvil-runtime-bootstrap-fast-handshake-enabled)
+      (equal (anvil-runtime-shell--env
+              "ANVIL_RUNTIME_FAST_HANDSHAKE" nil)
+             "1"))
+  "When non-nil, serve the pre-load MCP fast handshake.
+The default is nil; set ANVIL_RUNTIME_FAST_HANDSHAKE=1 to opt in.")
+
+(defvar anvil-runtime-shell--primitive-load nil
+  "Standalone `load' function saved before stdlib-misc replaces it.")
+
+(defvar anvil-runtime-shell--primitive-hash-functions nil
+  "Standalone hash functions saved before stdlib-misc replaces them.")
+
+(defvar anvil-runtime-shell--skip-load-files nil
+  "Absolute source files intentionally skipped by the runtime loader.")
+
+(defun anvil-runtime-shell--compat-load
+    (file &optional noerror nomessage _nosuffix _must-suffix)
+  "Load FILE with Emacs load context and the standalone native reader."
+  (let ((resolved
+         (if (and (> (length file) 0) (eq (aref file 0) ?/))
+             (cond
+              ((file-exists-p file) file)
+              ((file-exists-p (concat file ".el")) (concat file ".el"))
+              (t nil))
+           (locate-library file))))
+    (if (null resolved)
+        (if noerror nil
+          (signal 'file-error (list "Cannot open load file" file)))
+      (if (member resolved anvil-runtime-shell--skip-load-files)
+          t
+        (let ((prior-lfn (and (boundp 'load-file-name) load-file-name))
+              (prior-dd (and (boundp 'default-directory) default-directory))
+              (value nil)
+              (err nil))
+          (setq load-file-name resolved)
+          (setq default-directory (file-name-directory resolved))
+          (condition-case caught
+              (setq value
+                    (funcall anvil-runtime-shell--primitive-load
+                             resolved noerror nomessage))
+            (error (setq err caught)))
+          (when (fboundp 'garbage-collect)
+            (garbage-collect))
+          (setq load-file-name prior-lfn)
+          (setq default-directory prior-dd)
+          (cond
+           ((null err) value)
+           (t (signal (car err) (cdr err)))))))))
+
 (defvar anvil-runtime-shell--fast-stdin-buffer ""
   "Unread stdin bytes captured by the fast MCP handshake path.")
 
@@ -62,6 +114,228 @@ nil for production (silent).")
   (when (and anvil-runtime-shell--fast-trace
              (fboundp 'nelisp--write-stderr-line))
     (nelisp--write-stderr-line s)))
+
+(defun anvil-runtime-shell--fast-warn (s)
+  "Write fast-cache warning S to stderr."
+  (when (fboundp 'nelisp--write-stderr-line)
+    (nelisp--write-stderr-line (concat "[FAST] " s))))
+
+(defun anvil-runtime-shell--fast-json-space-p (c)
+  "Return non-nil when C is JSON whitespace."
+  (or (eq c ?\s) (eq c ?\t) (eq c ?\n) (eq c ?\r)))
+
+(defun anvil-runtime-shell--fast-json-skip-space (s i)
+  "Return the first non-whitespace index in S at or after I."
+  (let ((n (length s)))
+    (while (and (< i n)
+                (anvil-runtime-shell--fast-json-space-p (aref s i)))
+      (setq i (1+ i)))
+    i))
+
+(defun anvil-runtime-shell--fast-json-hex-p (c)
+  "Return non-nil when C is a JSON hexadecimal digit."
+  (or (and (>= c ?0) (<= c ?9))
+      (and (>= c ?a) (<= c ?f))
+      (and (>= c ?A) (<= c ?F))))
+
+(defun anvil-runtime-shell--fast-json-string-end (s start)
+  "Return the index after a JSON string in S at START, or nil."
+  (let ((i (1+ start))
+        (n (length s))
+        (done nil)
+        (valid (and (< start (length s)) (eq (aref s start) ?\"))))
+    (while (and valid (not done) (< i n))
+      (let ((c (aref s i)))
+        (cond
+         ((eq c ?\")
+          (setq i (1+ i))
+          (setq done t))
+         ((< c 32)
+          (setq valid nil))
+         ((eq c ?\\)
+          (setq i (1+ i))
+          (if (>= i n)
+              (setq valid nil)
+            (let ((escaped (aref s i)))
+              (if (eq escaped ?u)
+                  (let ((remaining 4))
+                    (while (and valid (> remaining 0))
+                      (setq i (1+ i))
+                      (if (or (>= i n)
+                              (not (anvil-runtime-shell--fast-json-hex-p
+                                    (aref s i))))
+                          (setq valid nil)
+                        (setq remaining (1- remaining))))
+                    (when valid (setq i (1+ i))))
+                (if (or (eq escaped ?\") (eq escaped ?\\)
+                        (eq escaped ?/) (eq escaped ?b)
+                        (eq escaped ?f) (eq escaped ?n)
+                        (eq escaped ?r) (eq escaped ?t))
+                    (setq i (1+ i))
+                  (setq valid nil))))))
+         (t
+          (setq i (1+ i))))))
+    (and valid done i)))
+
+(defun anvil-runtime-shell--fast-json-number-end (s start)
+  "Return the index after a JSON number in S at START, or nil."
+  (let ((i start)
+        (n (length s))
+        (valid t))
+    (when (and (< i n) (eq (aref s i) ?-))
+      (setq i (1+ i)))
+    (cond
+     ((>= i n) (setq valid nil))
+     ((eq (aref s i) ?0) (setq i (1+ i)))
+     ((and (>= (aref s i) ?1) (<= (aref s i) ?9))
+      (while (and (< i n) (>= (aref s i) ?0) (<= (aref s i) ?9))
+        (setq i (1+ i))))
+     (t (setq valid nil)))
+    (when (and valid (< i n) (eq (aref s i) ?.))
+      (setq i (1+ i))
+      (if (or (>= i n) (< (aref s i) ?0) (> (aref s i) ?9))
+          (setq valid nil)
+        (while (and (< i n) (>= (aref s i) ?0) (<= (aref s i) ?9))
+          (setq i (1+ i)))))
+    (when (and valid (< i n)
+               (or (eq (aref s i) ?e) (eq (aref s i) ?E)))
+      (setq i (1+ i))
+      (when (and (< i n)
+                 (or (eq (aref s i) ?+) (eq (aref s i) ?-)))
+        (setq i (1+ i)))
+      (if (or (>= i n) (< (aref s i) ?0) (> (aref s i) ?9))
+          (setq valid nil)
+        (while (and (< i n) (>= (aref s i) ?0) (<= (aref s i) ?9))
+          (setq i (1+ i)))))
+    (and valid i)))
+
+(defun anvil-runtime-shell--fast-json-literal-end (s start literal)
+  "Return the index after LITERAL in S at START, or nil."
+  (let ((end (+ start (length literal))))
+    (and (<= end (length s))
+         (string= (substring s start end) literal)
+         end)))
+
+(defun anvil-runtime-shell--fast-json-array-end (s start)
+  "Return the index after a JSON array in S at START, or nil."
+  (let* ((n (length s))
+         (i (anvil-runtime-shell--fast-json-skip-space s (1+ start)))
+         (done nil)
+         (valid (and (< start n) (eq (aref s start) ?\[))))
+    (if (and valid (< i n) (eq (aref s i) ?\]))
+        (setq i (1+ i) done t)
+      (while (and valid (not done))
+        (setq i (anvil-runtime-shell--fast-json-value-end s i))
+        (if (not i)
+            (setq valid nil)
+          (setq i (anvil-runtime-shell--fast-json-skip-space s i))
+          (cond
+           ((and (< i n) (eq (aref s i) ?,))
+            (setq i (anvil-runtime-shell--fast-json-skip-space s (1+ i))))
+           ((and (< i n) (eq (aref s i) ?\]))
+            (setq i (1+ i) done t))
+           (t (setq valid nil))))))
+    (and valid done i)))
+
+(defun anvil-runtime-shell--fast-json-object-end (s start)
+  "Return the index after a JSON object in S at START, or nil."
+  (let* ((n (length s))
+         (i (anvil-runtime-shell--fast-json-skip-space s (1+ start)))
+         (done nil)
+         (valid (and (< start n) (eq (aref s start) ?\{))))
+    (if (and valid (< i n) (eq (aref s i) ?\}))
+        (setq i (1+ i) done t)
+      (while (and valid (not done))
+        (setq i (anvil-runtime-shell--fast-json-string-end s i))
+        (if (not i)
+            (setq valid nil)
+          (setq i (anvil-runtime-shell--fast-json-skip-space s i))
+          (if (or (>= i n) (not (eq (aref s i) ?:)))
+              (setq valid nil)
+            (setq i (anvil-runtime-shell--fast-json-skip-space s (1+ i)))
+            (setq i (anvil-runtime-shell--fast-json-value-end s i))
+            (if (not i)
+                (setq valid nil)
+              (setq i (anvil-runtime-shell--fast-json-skip-space s i))
+              (cond
+               ((and (< i n) (eq (aref s i) ?,))
+                (setq i
+                      (anvil-runtime-shell--fast-json-skip-space s (1+ i))))
+               ((and (< i n) (eq (aref s i) ?\}))
+                (setq i (1+ i) done t))
+               (t (setq valid nil))))))))
+    (and valid done i)))
+
+(defun anvil-runtime-shell--fast-json-value-end (s start)
+  "Return the index after one JSON value in S at START, or nil."
+  (let* ((i (anvil-runtime-shell--fast-json-skip-space s start))
+         (n (length s))
+         (c (and (< i n) (aref s i))))
+    (cond
+     ((null c) nil)
+     ((eq c ?\") (anvil-runtime-shell--fast-json-string-end s i))
+     ((eq c ?\{) (anvil-runtime-shell--fast-json-object-end s i))
+     ((eq c ?\[) (anvil-runtime-shell--fast-json-array-end s i))
+     ((or (eq c ?-) (and (>= c ?0) (<= c ?9)))
+      (anvil-runtime-shell--fast-json-number-end s i))
+     ((eq c ?t) (anvil-runtime-shell--fast-json-literal-end s i "true"))
+     ((eq c ?f) (anvil-runtime-shell--fast-json-literal-end s i "false"))
+     ((eq c ?n) (anvil-runtime-shell--fast-json-literal-end s i "null"))
+     (t nil))))
+
+(defun anvil-runtime-shell--fast-tools-json-problem (tools-json)
+  "Return nil when TOOLS-JSON is a plausible non-empty tools result.
+Otherwise return a short string describing the problem."
+  (if (not (stringp tools-json))
+      "cache value is not a string"
+    (let* ((n (length tools-json))
+           (start (anvil-runtime-shell--fast-json-skip-space tools-json 0))
+           (end (anvil-runtime-shell--fast-json-value-end tools-json start)))
+      (cond
+       ((or (not end)
+            (/= (anvil-runtime-shell--fast-json-skip-space tools-json end) n))
+        "cache value is not valid JSON")
+       ((or (>= start n) (not (eq (aref tools-json start) ?\{)))
+        "top-level JSON value is not an object")
+       (t
+        (let ((i (anvil-runtime-shell--fast-json-skip-space
+                  tools-json (1+ start)))
+              (found nil)
+              (problem nil)
+              (done nil))
+          (if (and (< i n) (eq (aref tools-json i) ?\}))
+              (setq done t)
+            (while (and (not done) (not problem))
+              (let* ((key-start i)
+                     (key-end
+                      (anvil-runtime-shell--fast-json-string-end
+                       tools-json key-start)))
+                (setq i (anvil-runtime-shell--fast-json-skip-space
+                         tools-json key-end))
+                (setq i (anvil-runtime-shell--fast-json-skip-space
+                         tools-json (1+ i)))
+                (when (string= (substring tools-json key-start key-end)
+                               "\"tools\"")
+                  (setq found t)
+                  (cond
+                   ((or (>= i n) (not (eq (aref tools-json i) ?\[)))
+                    (setq problem "tools value is not an array"))
+                   ((let ((first
+                           (anvil-runtime-shell--fast-json-skip-space
+                            tools-json (1+ i))))
+                      (and (< first n) (eq (aref tools-json first) ?\])))
+                    (setq problem "tools array is empty"))))
+                (unless problem
+                  (setq i (anvil-runtime-shell--fast-json-value-end tools-json i))
+                  (setq i (anvil-runtime-shell--fast-json-skip-space
+                           tools-json i))
+                  (cond
+                   ((eq (aref tools-json i) ?,)
+                    (setq i (anvil-runtime-shell--fast-json-skip-space
+                             tools-json (1+ i))))
+                   ((eq (aref tools-json i) ?\})
+                    (setq done t)))))))
+          (or problem (and (not found) "tools key is missing"))))))))
 
 (defun anvil-runtime-shell--plist-get (plist prop)
   "Small `plist-get' replacement available before `emacs-init.el'."
@@ -228,11 +502,22 @@ nil for production (silent).")
         (progn
           (anvil-runtime-shell--fast-log "[FAST] load fast tools")
           (load fast-file t t)
-          (when (stringp anvil-runtime-shell--fast-tools-json)
-            (anvil-runtime-shell--fast-log "[FAST] fast tools loaded")
-            anvil-runtime-shell--fast-tools-json))
+          (when (file-exists-p fast-file)
+            (let ((problem
+                   (anvil-runtime-shell--fast-tools-json-problem
+                    anvil-runtime-shell--fast-tools-json)))
+              (if problem
+                  (progn
+                    (anvil-runtime-shell--fast-warn
+                     (concat "refusing tools cache " fast-file ": " problem))
+                    nil)
+                (anvil-runtime-shell--fast-log "[FAST] fast tools loaded")
+                anvil-runtime-shell--fast-tools-json))))
       (error
-       (anvil-runtime-shell--fast-log "[FAST] fast tools unavailable")
+       (when (file-exists-p fast-file)
+         (anvil-runtime-shell--fast-warn
+          (concat "refusing tools cache " fast-file
+                  ": cache file could not be loaded")))
        nil))))
 
 (defun anvil-runtime-shell--fast-handshake (fast-file)
@@ -308,6 +593,12 @@ nil for production (silent).")
              (concat (file-name-directory
                       (directory-file-name anvil-el-dir))
                      "nelisp-emacs"))))
+       (nelisp-lisp-dir
+        (or (and (boundp 'anvil-runtime-bootstrap-nelisp-lisp-dir)
+                 (> (length anvil-runtime-bootstrap-nelisp-lisp-dir) 0)
+                 anvil-runtime-bootstrap-nelisp-lisp-dir)
+            (concat (file-name-directory (directory-file-name anvil-el-dir))
+                    "nelisp/lisp")))
        (server-id
         ;; Default `emacs-eval' matches the constant used by every
         ;; GREEN-bucket anvil-* module's `--server-id'.  Tools register
@@ -320,9 +611,46 @@ nil for production (silent).")
        (metrics-el (concat anvil-el-dir "/anvil-server-metrics.el"))
        (server-el (concat anvil-el-dir "/anvil-server.el"))
        (server-commands-el (concat anvil-el-dir "/anvil-server-commands.el"))
+       (stdlib-misc (concat nelisp-lisp-dir "/nelisp-stdlib-misc.el"))
+       (bootstrap-skip-features
+        '(nelisp-coding-jis-tables calendar
+          subr-x seq cl-extra cl-seq benchmark profiler
+          emacs-syntax-table emacs-elisp-mode emacs-mode emacs-mode-builtins
+          emacs-font-lock-builtins emacs-faces-builtins emacs-textmodes-stub
+          emacs-redisplay-builtins emacs-tui-event emacs-tui-backend
+          emacs-frame-builtins emacs-window-builtins emacs-keymap-builtins
+          emacs-command-loop-builtins
+          emacs-frame emacs-window keymap emacs-faces emacs-font-lock))
        (fast-tools-file "/tmp/anvil-runtime/anvil-fast-tools.el"))
 
-  (when (and (not anvil-server--debug-trace)
+  ;; Safety gate.  Measured on this machine on 2026-08-29: stdout was correct
+  ;; in every fast-path run (5,208 bytes and six tools), but every process
+  ;; terminated with exit 1 or SIGSEGV after 2--20 s, at HEAD db57796 too.
+  ;;
+  ;; RESOLVED the same day.  The cause was not in this file: two defects in
+  ;; the standalone NeLisp GC, both fixed in nelisp's
+  ;; `scripts/nelisp-standalone-build.el' -- a char-table/vector slot walk
+  ;; that trusted a length it had read out of an uninitialised parse-pool
+  ;; slot, and a per-frame parse-pool capacity read from a global word that
+  ;; names whichever load is innermost.  The fast handshake never was the
+  ;; affected path; with ASLR disabled the ordinary load path below
+  ;; segfaulted just as reliably.  See
+  ;; `Notes/dev/BUG-nelisp-layout-dependent-crash-2026-08-29.md'.
+  ;;
+  ;; The re-enable criterion this comment used to state -- repeated plain
+  ;; runs exiting 0 with ASLR both enabled and disabled -- is met against a
+  ;; NeLisp built at or after that fix: 3/3 with `setarch -R' and 3/3 plain,
+  ;; each returning the full 5,208 bytes.  It is NOT met against an older
+  ;; binary, which is why this stays opt-in: turning it on is safe only
+  ;; if the deployed `target/nelisp' carries the GC fix.
+  ;;
+  ;; To turn it on, set `anvil-runtime-bootstrap-fast-handshake-enabled' in
+  ;; the bootstrap `bin/anvil-runtime' generates.  ANVIL_RUNTIME_FAST_
+  ;; HANDSHAKE=1 does NOT work under standalone NeLisp: the `defvar' above
+  ;; runs before `emacs-callproc.el' provides `getenv', so the env channel
+  ;; is host-Emacs only.
+  (when (and anvil-runtime-shell--fast-handshake-enabled
+             (not anvil-server--debug-trace)
              (fboundp 'read-stdin-bytes)
              (fboundp 'nelisp--write-stdout-bytes))
     (anvil-runtime-shell--fast-handshake fast-tools-file))
@@ -338,7 +666,6 @@ nil for production (silent).")
   ;; Phase 47 native swap), which aborts with glibc "double free or
   ;; corruption (!prev)" on that file.  MCP / JSON-RPC is UTF-8 only,
   ;; so the JIS tables are deadweight here.
-  (provide 'nelisp-coding-jis-tables)
   ;; Pre-provide the 6 vendor libs that `anvil-runtime-polyfills.el'
   ;; tries to `(load ...)' below.  Under the post-2026-05-17 nelisp the
   ;; pure-elisp interpreter allocates ~1 MB/s while walking those files
@@ -347,8 +674,6 @@ nil for production (silent).")
   ;; NeLisp's permissive `require' silently succeeds for already-provided
   ;; features, so downstream `(require 'subr-x)' etc are satisfied
   ;; without ever touching the vendor files.
-  (dolist (lib '(subr-x seq cl-extra cl-seq benchmark profiler))
-    (provide lib))
   ;; HEADLESS editor/UI skip (standalone NeLisp cold-load ~76s -> ~36s).
   ;; `bin/anvil-runtime mcp serve' is always headless JSON-RPC over stdio: it
   ;; never opens a frame, syntax table, font-lock buffer or TUI event loop.
@@ -359,20 +684,56 @@ nil for production (silent).")
   ;; minibuffer / string / hash / fns / eval / callproc / sqlite — anvil-server
   ;; depends on those.  If a tool handler ever needs one of the skipped
   ;; features, drop it from this list (it will then load on demand).
-  (dolist (f '(emacs-syntax-table emacs-elisp-mode emacs-mode emacs-mode-builtins
-               emacs-font-lock-builtins emacs-faces-builtins emacs-textmodes-stub
-               emacs-redisplay-builtins emacs-tui-event emacs-tui-backend
-               emacs-frame-builtins emacs-window-builtins emacs-keymap-builtins
-               emacs-command-loop-builtins
-               emacs-frame emacs-window keymap emacs-faces emacs-font-lock))
-    (provide f))
-  ;; Prefer .el over .elc — post-2026-05-17 nelisp's stdlib-misc swaps
-  ;; the elisp Reader to a pure-elisp form that cannot parse `#[..]'
-  ;; byte-compiled lambdas or `#s(..)' record syntax that .elc files
-  ;; contain.  Without this, stale .elc files in nelisp-emacs/src/ and
-  ;; anvil.el/ silently override their .el siblings and explode after
-  ;; stdlib-misc loads.
+  ;; Populate the native feature registry before stdlib-misc replaces
+  ;; `provide'.  Measured 2026-08-29: omitting this pre-pass made the
+  ;; standalone process exit 139 immediately after `[STEP] pre-init'.
+  (dolist (feature bootstrap-skip-features)
+    (provide feature))
+  ;; Keep the runtime's established source-first loading policy.
   (setq load-prefer-newer t)
+  ;; The ~300x JSON slowdown reported on 2026-05-24 was re-measured on
+  ;; this machine on 2026-08-28 and did not reproduce: across nine
+  ;; 25--10000-byte payload sizes (14 samples each), median with/without
+  ;; ratios were 0.9435x--1.0722x.  A 10 KB call-count probe recorded zero
+  ;; calls to `list', `error', `princ', `provide', and `load'; the parser
+  ;; loaded by anvil-server's `(require 'json)' does not use those replaced
+  ;; functions.  That series still measured a separate superlinear parser
+  ;; curve from 300--10000 bytes (log-log exponent 1.450; 10 KB median
+  ;; 4285.132 ms with stdlib-misc), which this bootstrap does not address.
+  ;; Load stdlib-misc before emacs-init: the same-machine probe measured
+  ;; `load-file-name' nil inside a primitive load and non-nil with this
+  ;; implementation.
+  (setq anvil-runtime-shell--primitive-load (symbol-function 'load))
+  (setq anvil-runtime-shell--primitive-hash-functions
+        (mapcar (lambda (name) (cons name (symbol-function name)))
+                '(maphash hash-table-keys hash-table-values hash-table-count)))
+  (load stdlib-misc nil t)
+  ;; Measured 2026-08-29: stdlib-misc's four hash traversal wrappers call
+  ;; `nelisp--hash-pairs', which this standalone image does not define;
+  ;; `anvil-server-start' consequently failed in `clrhash'.  Keep the
+  ;; image's working native implementations while loading the rest of
+  ;; stdlib-misc.
+  (let ((saved anvil-runtime-shell--primitive-hash-functions))
+    (while saved
+      (fset (car (car saved)) (cdr (car saved)))
+      (setq saved (cdr saved))))
+  ;; Measured 2026-08-29: stdlib-misc's `load' could not resolve an
+  ;; existing absolute /tmp source and its incremental reader treated
+  ;; emacs-stub.el's `#x3FFFFF' as a variable.  The saved native loader
+  ;; parsed that chain while this wrapper supplied non-nil `load-file-name'.
+  ;; The same probe reached vendor calendar's cal-loaddefs.el and then
+  ;; exited 139, so skip only that exact vendor body; the local calendar
+  ;; facade and emacs-time.el had both completed before the failing load.
+  (setq anvil-runtime-shell--skip-load-files
+        (list (concat nelisp-emacs-dir
+                      "/vendor/emacs-lisp/calendar/calendar.el")))
+  (fset 'load #'anvil-runtime-shell--compat-load)
+  (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
+    (nelisp--write-stderr-line "[STEP] stdlib-misc done"))
+  ;; Populate stdlib-misc's `features' list with the same set.  The
+  ;; 2026-08-29 probe recorded `(featurep 'calendar)' as t here.
+  (dolist (feature bootstrap-skip-features)
+    (provide feature))
   (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
     (nelisp--write-stderr-line "[STEP] pre-init"))
   (load init-el nil t)
@@ -381,42 +742,6 @@ nil for production (silent).")
   (load stub-el nil t)
   (when (and anvil-server--debug-trace (fboundp 'nelisp--write-stderr-line))
     (nelisp--write-stderr-line "[STEP] stub-el done"))
-
-  ;; --- TEMPORARY alist-get override (= Doc 98 §98.2 workaround) ---
-  ;;
-  ;; The fixed `alist-get' lives in `nelisp/lisp/nelisp-stdlib-misc.el'
-  ;; on the source side, but standalone NeLisp's `.image' baker (= Doc 98
-  ;; §98.2) doesn't yet capture elisp-side `defun' / `fset' mutations that
-  ;; route through the env-shim, so the alist-get image baked into the
-  ;; binary is still the pre-fix version.  Direct-load the .el here so
-  ;; the corrected `alist-get' wins over the image-embedded one.
-  ;;
-  ;; Remove this block once Doc 98 §98.2 (= elisp-complete frozen-heap
-  ;; baker) ships and the .image carries the fixed alist-get.
-  ;; Inline the alist-get fix from nelisp-stdlib-misc.el (= the only
-  ;; piece anvil-server actually needs from that file).  Loading the
-  ;; full stdlib-misc redefines `princ' / `error' / `list' / `provide' /
-  ;; etc to pure-elisp versions that cause json-read-from-string to
-  ;; degrade ~300x on strings > 75 bytes (bisected 2026-05-24).  By
-  ;; inlining just this one defun we get the alist-get fix without
-  ;; clobbering the Rust-fast primitives the rest of anvil needs.
-  (defun alist-get (key alist &optional default _remove testfn)
-    (let ((cur alist) (found nil) (result default))
-      (while (and cur (not found))
-        (let ((pair (car cur)))
-          (cond
-           ((not (consp pair)) (setq cur (cdr cur)))
-           ((cond
-             ((null testfn) (equal (car pair) key))
-             ((eq testfn 'eq) (eq (car pair) key))
-             ((eq testfn 'equal) (equal (car pair) key))
-             ((or (eq testfn 'string=) (eq testfn 'string-equal))
-              (and (stringp (car pair)) (stringp key) (equal (car pair) key)))
-             (t (funcall testfn (car pair) key)))
-            (setq result (cdr pair))
-            (setq found t))
-           (t (setq cur (cdr cur))))))
-      result))
 
   ;; Put `anvil-el-dir' on `load-path' so any `(require 'anvil-orchestrator-routing)'
   ;; / `(require 'anvil-orchestrator-presets)' / etc. inside tool-module
@@ -725,16 +1050,21 @@ Uses CR-strip to recognise lines that are CRLF artefacts as blank."
             (let ((tools-json
                    (and (boundp 'anvil-server--tools-list-cache)
                         (gethash server-id anvil-server--tools-list-cache))))
-              (when (and (stringp tools-json)
-                         (fboundp 'write-region))
-                (condition-case nil
-                    (write-region
-                     (concat
-                      "(setq anvil-runtime-shell--fast-tools-json '"
-                      (prin1-to-string tools-json)
-                      ")\n")
-                     nil fast-tools-file)
-                  (error nil))))
+              (let ((problem
+                     (anvil-runtime-shell--fast-tools-json-problem tools-json)))
+                (if problem
+                    (anvil-runtime-shell--fast-warn
+                     (concat "refusing to write tools cache " fast-tools-file
+                             ": " problem))
+                  (when (fboundp 'write-region)
+                    (condition-case nil
+                        (write-region
+                         (concat
+                          "(setq anvil-runtime-shell--fast-tools-json '"
+                          (prin1-to-string tools-json)
+                          ")\n")
+                         nil fast-tools-file)
+                      (error nil))))))
             (when (and anvil-server--debug-trace
                        (fboundp 'nelisp--write-stderr-line))
               (nelisp--write-stderr-line

--- a/tests/anvil-compact-test.el
+++ b/tests/anvil-compact-test.el
@@ -14,6 +14,8 @@
 (require 'anvil-state)
 (require 'anvil-compact)
 
+(defvar anvil-state--cached-db)
+
 (defun anvil-compact-test--make-db-path ()
   "Return a fresh temp SQLite path for anvil-state in a test."
   (make-temp-file "anvil-compact-test-" nil ".db"))
@@ -135,6 +137,44 @@
         (anvil-compact-cooldown-percent 0))
     (let ((r (anvil-compact-should-trigger :percent 15)))
       (should (plist-get r :trigger)))))
+
+
+;;;; --- pressure report ----------------------------------------------------
+
+(ert-deftest anvil-compact-test-pressure-report-high-context-critical ()
+  "High context pressure should surface a critical compact action."
+  (let ((p (make-temp-file "anvil-compact-")))
+    (unwind-protect
+        (progn
+          (with-temp-file p
+            (insert (make-string 800 ?x)))
+          (let ((anvil-compact-trigger-percent 45)
+                (anvil-compact-pressure-high-percent 75)
+                (anvil-compact-context-tokens-max 1000)
+                (anvil-compact-bytes-per-token 1))
+            (let ((r (anvil-compact-pressure-report
+                      :transcript-path p
+                      :task-in-progress 0
+                      :last-compact-percent 0)))
+              (should (eq :critical (plist-get r :severity)))
+              (should (plist-get (plist-get r :compact-decision)
+                                 :trigger))
+              (should (cl-some
+                       (lambda (s)
+                         (string-match-p "high-pressure" s))
+                       (plist-get r :actions))))))
+      (ignore-errors (delete-file p)))))
+
+(ert-deftest anvil-compact-test-pressure-report-long-session-high ()
+  "A long-running session should recommend a checkpoint boundary."
+  (let ((r (anvil-compact-pressure-report
+            :transcript-path nil
+            :session-age-hours 8.5)))
+    (should (eq :high (plist-get r :severity)))
+    (should (cl-some
+             (lambda (s)
+               (string-match-p "8[+] hours" s))
+             (plist-get r :actions)))))
 
 
 ;;;; --- snapshot ------------------------------------------------------------
@@ -327,6 +367,12 @@ so the shell hook wrapper can forward it verbatim."
 (ert-deftest anvil-compact-test-tool-hook-unknown-stage-returns-empty ()
   (anvil-compact-test--with-fresh-state
     (should (equal "" (anvil-compact--tool-hook "sid" "unknown" "")))))
+
+(ert-deftest anvil-compact-test-tool-pressure-report-accepts-strings ()
+  "MCP transport may deliver optional numeric args as strings."
+  (let ((r (anvil-compact--tool-pressure-report "" "" "9" "0" "0")))
+    (should (eq :high (plist-get r :severity)))
+    (should (> (plist-get r :session-age-hours) 8))))
 
 
 ;;;; --- Phase 2: restore-queue --------------------------------------------

--- a/tests/anvil-crypto-test.el
+++ b/tests/anvil-crypto-test.el
@@ -1,0 +1,123 @@
+;;; anvil-crypto-test.el --- Tests for anvil-crypto -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'anvil-crypto)
+
+;;;; --- HMAC-SHA256 against RFC 4231 vectors -------------------------------
+
+(ert-deftest anvil-crypto-hmac-rfc4231-case1 ()
+  (should (string=
+           (anvil-crypto-hmac-sha256 (make-string 20 #x0b) "Hi There")
+           "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")))
+
+(ert-deftest anvil-crypto-hmac-rfc4231-case2 ()
+  (should (string=
+           (anvil-crypto-hmac-sha256 "Jefe" "what do ya want for nothing?")
+           "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")))
+
+(ert-deftest anvil-crypto-hmac-rfc4231-case6-long-key ()
+  ;; key longer than the block (131 x 0xaa) is hashed down first; the
+  ;; key is a unibyte byte string (a raw HTTP secret would be), not a
+  ;; multibyte string -- the byte>=128 distinction the hardening cares
+  ;; about
+  (should (string=
+           (anvil-crypto-hmac-sha256
+            (apply #'unibyte-string (make-list 131 #xaa))
+            "Test Using Larger Than Block-Size Key - Hash Key First")
+           "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54")))
+
+(ert-deftest anvil-crypto-hmac-binary-length ()
+  (should (= 32 (length (anvil-crypto-hmac-sha256 "k" "m" t)))))
+
+;;;; --- constant-time compare ---------------------------------------------
+
+(ert-deftest anvil-crypto-constant-time-equal-basic ()
+  (should (anvil-crypto-constant-time-equal "abc" "abc"))
+  (should-not (anvil-crypto-constant-time-equal "abc" "abd"))
+  (should-not (anvil-crypto-constant-time-equal "abc" "abcd"))
+  (should-not (anvil-crypto-constant-time-equal "abc" "")))
+
+;;;; --- Stripe webhook verification ---------------------------------------
+
+(defun anvil-crypto-test--stripe-header (payload secret ts)
+  "Build a valid Stripe-Signature header for PAYLOAD at TS."
+  (let ((sig (anvil-crypto-hmac-sha256 secret (concat ts "." payload))))
+    (format "t=%s,v1=%s" ts sig)))
+
+(ert-deftest anvil-crypto-stripe-verify-valid ()
+  (let* ((payload "{\"id\":\"evt_1\",\"type\":\"checkout.session.completed\"}")
+         (secret "whsec_test_secret")
+         (ts "1720900000")
+         (header (anvil-crypto-test--stripe-header payload secret ts)))
+    (should (anvil-crypto-stripe-verify payload header secret
+                                        :now 1720900010))))
+
+(ert-deftest anvil-crypto-stripe-verify-tampered-payload ()
+  (let* ((payload "{\"amount\":100}")
+         (secret "whsec_test_secret")
+         (ts "1720900000")
+         (header (anvil-crypto-test--stripe-header payload secret ts)))
+    ;; body changed after signing -> reject
+    (should-not (anvil-crypto-stripe-verify "{\"amount\":9999}" header secret
+                                            :now 1720900010))))
+
+(ert-deftest anvil-crypto-stripe-verify-replay-outside-window ()
+  (let* ((payload "{\"id\":\"evt_2\"}")
+         (secret "whsec_test_secret")
+         (ts "1720900000")
+         (header (anvil-crypto-test--stripe-header payload secret ts)))
+    ;; correct signature but 10 minutes late -> reject (default 300s)
+    (should-not (anvil-crypto-stripe-verify payload header secret
+                                            :now 1720900600))
+    ;; widen tolerance -> accept
+    (should (anvil-crypto-stripe-verify payload header secret
+                                        :now 1720900600 :tolerance 900))))
+
+(ert-deftest anvil-crypto-stripe-verify-wrong-secret ()
+  (let* ((payload "{\"id\":\"evt_3\"}")
+         (ts "1720900000")
+         (header (anvil-crypto-test--stripe-header payload "whsec_real" ts)))
+    (should-not (anvil-crypto-stripe-verify payload header "whsec_attacker"
+                                            :now 1720900010))))
+
+;;;; --- signed tokens -----------------------------------------------------
+
+(ert-deftest anvil-crypto-token-roundtrip ()
+  (let* ((secret "sess_secret")
+         (tok (anvil-crypto-sign-token "user=42;role=admin" secret
+                                       :ttl 3600 :now 1000)))
+    (should (string= (anvil-crypto-verify-token tok secret :now 2000)
+                     "user=42;role=admin"))))
+
+(ert-deftest anvil-crypto-token-expired ()
+  (let* ((secret "sess_secret")
+         (tok (anvil-crypto-sign-token "x" secret :ttl 60 :now 1000)))
+    (should-not (anvil-crypto-verify-token tok secret :now 2000))))
+
+(ert-deftest anvil-crypto-token-tampered ()
+  (let* ((secret "sess_secret")
+         (tok (anvil-crypto-sign-token "role=user" secret :ttl 3600 :now 1000))
+         ;; flip the payload segment
+         (parts (split-string tok "\\."))
+         (forged (concat (anvil-crypto--b64url "role=admin") "."
+                         (nth 1 parts) "." (nth 2 parts))))
+    (should-not (anvil-crypto-verify-token forged secret :now 1500))))
+
+(ert-deftest anvil-crypto-token-wrong-secret ()
+  (let ((tok (anvil-crypto-sign-token "x" "real" :ttl 3600 :now 1000)))
+    (should-not (anvil-crypto-verify-token tok "attacker" :now 1500))))
+
+;;;; --- CSPRNG ------------------------------------------------------------
+
+(ert-deftest anvil-crypto-random-bytes-length-and-uniqueness ()
+  (should (= 32 (length (anvil-crypto-random-bytes 32))))
+  ;; two draws must differ (P(collision) negligible)
+  (should-not (string= (anvil-crypto-random-bytes 32)
+                       (anvil-crypto-random-bytes 32))))
+
+(ert-deftest anvil-crypto-random-token-format ()
+  (let ((tok (anvil-crypto-random-token 32)))
+    ;; base64url, no padding, no + / =
+    (should (string-match-p "\\`[A-Za-z0-9_-]+\\'" tok))))
+
+;;; anvil-crypto-test.el ends here

--- a/tests/anvil-dev-test.el
+++ b/tests/anvil-dev-test.el
@@ -165,6 +165,145 @@ Non-git `call-process' calls still signal exit-status 1."
                 (should (null (plist-get res :warning)))))))
       (delete-directory installed t))))
 
+;;;; --- codex efficiency check --------------------------------------------
+
+(defun anvil-dev-test--write-codex-efficiency-fixtures (codex-home root)
+  "Create a complete Codex efficiency fixture under CODEX-HOME and ROOT."
+  (make-directory codex-home t)
+  (make-directory (expand-file-name "skills" codex-home) t)
+  (with-temp-file (expand-file-name "config.toml" codex-home)
+    (insert "[mcp_servers.emacs-eval]\n"
+            "command = \"/tmp/anvil\"\n\n"
+            "[mcp_servers.serena]\n"
+            "command = \"/tmp/uvx\"\n\n"
+            "[mcp_servers.context7]\n"
+            "command = \"/tmp/npx\"\n"))
+  (dolist (skill anvil-dev--codex-efficiency-required-skills)
+    (let ((dir (expand-file-name (format "skills/%s" skill) codex-home)))
+      (make-directory dir t)
+      (with-temp-file (expand-file-name "SKILL.md" dir)
+        (insert "---\nname: " skill "\ndescription: test\n---\n"))))
+  (make-directory (expand-file-name ".serena" root) t)
+  (with-temp-file (expand-file-name ".serena/project.yml" root)
+    (insert "project_name: Test\n"))
+  (make-directory (expand-file-name ".claude/reference" root) t)
+  (with-temp-file (expand-file-name ".claude/reference/codex-efficiency-setup.md" root)
+    (insert "# Codex Efficiency Setup\n")))
+
+(ert-deftest anvil-dev-test-codex-efficiency-check-all-green ()
+  "A complete fixture reports :ok t and no warnings."
+  (let ((codex-home (anvil-dev-test--make-dir))
+        (root (anvil-dev-test--make-dir)))
+    (unwind-protect
+        (progn
+          (anvil-dev-test--write-codex-efficiency-fixtures codex-home root)
+          (cl-letf (((symbol-function 'executable-find)
+                     (lambda (name)
+                       (cond
+                        ((equal name "uvx") "/bin/uvx")
+                        ((equal name "npx") "/bin/npx")
+                        (t nil)))))
+            (let ((r (anvil-codex-efficiency-check codex-home root)))
+              (should (plist-get r :ok))
+              (should (null (plist-get r :warnings)))
+              (should (equal t (cdr (assoc "serena"
+                                           (plist-get r :mcp-servers)))))
+              (should (equal t (cdr (assoc "notes-development"
+                                           (plist-get r :skills))))))))
+      (delete-directory codex-home t)
+      (delete-directory root t))))
+
+(ert-deftest anvil-dev-test-codex-efficiency-check-warns-on-missing-parts ()
+  "Missing MCP sections, executable, skill, and project files are warned."
+  (let ((codex-home (anvil-dev-test--make-dir))
+        (root (anvil-dev-test--make-dir)))
+    (unwind-protect
+        (progn
+          (make-directory codex-home t)
+          (with-temp-file (expand-file-name "config.toml" codex-home)
+            (insert "[mcp_servers.emacs-eval]\ncommand = \"/tmp/anvil\"\n"))
+          (make-directory (expand-file-name "skills/anvil-memory-worklog"
+                                            codex-home)
+                          t)
+          (with-temp-file (expand-file-name
+                           "skills/anvil-memory-worklog/SKILL.md"
+                           codex-home)
+            (insert "---\nname: anvil-memory-worklog\n---\n"))
+          (cl-letf (((symbol-function 'executable-find)
+                     (lambda (name)
+                       (and (equal name "npx") "/bin/npx"))))
+            (let* ((r (anvil-codex-efficiency-check codex-home root))
+                   (warnings (plist-get r :warnings))
+                   (joined (mapconcat #'identity warnings "\n")))
+              (should-not (plist-get r :ok))
+              (should (string-match-p "Missing MCP server section: serena"
+                                      joined))
+              (should (string-match-p "Missing MCP server section: context7"
+                                      joined))
+              (should (string-match-p "Missing executable.*uvx" joined))
+              (should (string-match-p "Missing Codex skill: notes-development"
+                                      joined))
+              (should (string-match-p "Missing Serena project config"
+                                      joined))
+              (should (string-match-p "Missing Codex recovery reference"
+                                      joined)))))
+      (delete-directory codex-home t)
+      (delete-directory root t))))
+
+;;;; --- Claude limits report analysis --------------------------------------
+
+(defconst anvil-dev-test--claude-limits-sample
+  "what's contributing to your limits usage?
+
+91% of your usage was at >150k context
+ longer sessions are more expensive even when cached. /compact mid-task, /clear
+ when switching to new tasks.
+
+56% of your usage came from subagent-heavy sessions
+ each subagent runs its own requests.
+
+42% of your usage came from sessions active for 8+ hours
+ these are often background/loop sessions.
+
+16% of your usage came from /loop
+
+73% of your usage came from mcp server \"emacs-eval\"
+ mcp tool results stay in context for the rest of the session.
+
+skills                  % of usage
+/loop                          16%
+
+mcp servers             % of usage
+emacs-eval                     73%
+"
+  "Stable sample of Claude Code limits output.")
+
+(ert-deftest anvil-dev-test-claude-limits-analyze-extracts-main-metrics ()
+  "The analyzer extracts the day-level metrics from copied limits text."
+  (let* ((r (anvil-claude-limits-analyze
+             anvil-dev-test--claude-limits-sample))
+         (metrics (plist-get r :metrics))
+         (top (plist-get r :top-actions)))
+    (should (equal 91 (cdr (assq 'high-context metrics))))
+    (should (equal 56 (cdr (assq 'subagent-heavy metrics))))
+    (should (equal 42 (cdr (assq 'long-sessions metrics))))
+    (should (equal 16 (cdr (assq 'loop metrics))))
+    (should (equal 73 (cdr (assq 'emacs-eval metrics))))
+    (should (eq 'high-context (plist-get (car top) :metric)))
+    (should (eq 'critical (plist-get (car top) :severity)))))
+
+(ert-deftest anvil-dev-test-claude-limits-analyze-falls-back-to-table-rows ()
+  "When prose is TUI-corrupted, table rows still recover key metrics."
+  (let* ((r (anvil-claude-limits-analyze
+             "skills % of usage\n/loop 28%\n\nmcp servers % of usage\nemacs-eval 34%\n"))
+         (metrics (plist-get r :metrics)))
+    (should (null (cdr (assq 'high-context metrics))))
+    (should (equal 28 (cdr (assq 'loop metrics))))
+    (should (equal 34 (cdr (assq 'emacs-eval metrics))))))
+
+(ert-deftest anvil-dev-test-claude-limits-analyze-rejects-empty-report ()
+  (should-error (anvil-claude-limits-analyze "") :type 'user-error))
+
 ;;;; --- parse-ert-summary --------------------------------------------------
 
 (ert-deftest anvil-dev-test-parse-ert-summary-unskipped ()

--- a/tests/anvil-mcp-framing-test.el
+++ b/tests/anvil-mcp-framing-test.el
@@ -29,6 +29,31 @@
 (require 'anvil-server)
 (require 'anvil-server-commands)
 
+(defconst anvil-mcp-framing-test--repo-root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Repository root used to load the standalone fast-handshake helpers.")
+
+(defun anvil-mcp-framing-test--load-fast-handshake-helpers ()
+  "Load definitions through the standalone fast-handshake entry point."
+  (unless (fboundp 'anvil-runtime-shell--fast-handshake)
+    (let ((file (expand-file-name "scripts/anvil-runtime-shell-loop.el"
+                                  anvil-mcp-framing-test--repo-root)))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (catch 'done
+          (condition-case nil
+              (while t
+                (let ((form (read (current-buffer))))
+                  (when (memq (car-safe form) '(defun defvar))
+                    (eval form))
+                  (when (and (eq (car-safe form) 'defun)
+                             (eq (nth 1 form)
+                                 'anvil-runtime-shell--fast-handshake))
+                    (throw 'done t))))
+            (end-of-file nil)))))))
+
 ;;;; --- Encode -----------------------------------------------------------
 
 (ert-deftest anvil-mcp-framing-test-encode-basic ()
@@ -59,6 +84,13 @@
     (should-not (multibyte-string-p bytes))
     (should (= 3 (length bytes)))
     (should (equal '(227 129 130) (append bytes nil)))))
+
+(ert-deftest anvil-mcp-framing-test-utf8-helper-rejects-invalid-bytes ()
+  "The UTF-8 decoder rejects malformed wire bytes before JSON parsing."
+  (should-error
+   (anvil-server--utf8-bytes-to-string
+    (unibyte-string #xC3 #x28 #xFF #x41))
+   :type 'json-error))
 
 (ert-deftest anvil-mcp-framing-test-encode-rejects-non-string ()
   "Encode signals `wrong-type-argument' for non-string input."
@@ -178,6 +210,50 @@
                "{\"jsonrpc\":\"2.0\",\"id\":1}"))
   (should-not (anvil-server-mcp-detect-framing-p ""))
   (should-not (anvil-server-mcp-detect-framing-p "[1,2,3]")))
+
+;;;; --- Standalone fast tools cache --------------------------------------
+
+(ert-deftest anvil-mcp-framing-test-fast-tools-json-rejects-bad-shapes ()
+  "Fast tools cache validation rejects malformed or implausible results."
+  (anvil-mcp-framing-test--load-fast-handshake-helpers)
+  (should (anvil-runtime-shell--fast-tools-json-problem "not JSON"))
+  (should (anvil-runtime-shell--fast-tools-json-problem "{}"))
+  (should (anvil-runtime-shell--fast-tools-json-problem
+           "{\"tools\":{}}"))
+  (should (anvil-runtime-shell--fast-tools-json-problem
+           "{\"tools\":[]}"))
+  (should-not
+   (anvil-runtime-shell--fast-tools-json-problem
+    "{\"tools\":[{\"name\":\"one\"}]}")))
+
+(ert-deftest anvil-mcp-framing-test-empty-fast-tools-cache-is-not-served ()
+  "An empty tools array falls through without consuming or writing frames."
+  (anvil-mcp-framing-test--load-fast-handshake-helpers)
+  (let ((cache-file (make-temp-file "anvil-empty-fast-tools-"))
+        (read-called nil)
+        (stdout-called nil)
+        (warnings nil))
+    (unwind-protect
+        (progn
+          (write-region
+           "(setq anvil-runtime-shell--fast-tools-json \"{\\\"tools\\\":[]}\")\n"
+           nil cache-file)
+          (cl-letf (((symbol-function
+                      'anvil-runtime-shell--fast-read-frame)
+                     (lambda () (setq read-called t) nil))
+                    ((symbol-function 'anvil-runtime-shell--stdout)
+                     (lambda (_frame) (setq stdout-called t)))
+                    ((symbol-function 'nelisp--write-stderr-line)
+                     (lambda (line) (push line warnings))))
+            (should-not
+             (anvil-runtime-shell--fast-handshake cache-file)))
+          (should-not read-called)
+          (should-not stdout-called)
+          (should
+           (seq-some (lambda (line)
+                       (string-match-p "tools array is empty" line))
+                     warnings)))
+      (delete-file cache-file))))
 
 ;;;; --- Sanity: define-error symbol present -----------------------------
 

--- a/tests/anvil-mcp-framing-test.el
+++ b/tests/anvil-mcp-framing-test.el
@@ -45,12 +45,20 @@
   (let* ((body "{\"x\":\"ąあ\"}")
          (frame (anvil-server-mcp-frame-encode body))
          ;; 8 ASCII bytes ({"x":"" + "}) + 2 (ą) + 3 (あ) = 13 bytes
-         (expected-byte-len (length (encode-coding-string body 'utf-8 t))))
+         (expected-byte-len (string-bytes body)))
+    (should-not (multibyte-string-p frame))
     (should (string-match
              "\\`Content-Length: \\([0-9]+\\)\r\n\r\n"
              frame))
     (should (= expected-byte-len
                (string-to-number (match-string 1 frame))))))
+
+(ert-deftest anvil-mcp-framing-test-utf8-helper-cjk-byte-count ()
+  "The runtime-specific UTF-8 helper returns three bytes for one CJK char."
+  (let ((bytes (anvil-server--string-to-utf8-bytes "あ")))
+    (should-not (multibyte-string-p bytes))
+    (should (= 3 (length bytes)))
+    (should (equal '(227 129 130) (append bytes nil)))))
 
 (ert-deftest anvil-mcp-framing-test-encode-rejects-non-string ()
   "Encode signals `wrong-type-argument' for non-string input."
@@ -64,7 +72,10 @@
 (ert-deftest anvil-mcp-framing-test-header-parse-basic ()
   "Parse Content-Length integer from header block."
   (should (= 42 (anvil-server-mcp-parse-content-length-header
-                 "Content-Length: 42"))))
+                 "Content-Length: 42")))
+  (should (= 42 (anvil-server-mcp-parse-content-length-header
+                 (anvil-server--string-to-utf8-bytes
+                  "Content-Length: 42")))))
 
 (ert-deftest anvil-mcp-framing-test-header-parse-case-insensitive ()
   "Header name match is case-insensitive (RFC 7230)."
@@ -92,7 +103,7 @@
          (parsed (anvil-server-mcp-frame-parse-string frame)))
     (should (plist-get parsed :body))
     (should (equal body (plist-get parsed :body)))
-    (should (= (length (encode-coding-string frame 'utf-8 t))
+    (should (= (string-bytes frame)
                (plist-get parsed :consumed)))))
 
 (ert-deftest anvil-mcp-framing-test-frame-parse-multiline-body ()
@@ -108,6 +119,16 @@
          (frame (anvil-server-mcp-frame-encode body))
          (parsed (anvil-server-mcp-frame-parse-string frame)))
     (should (equal body (plist-get parsed :body)))))
+
+(ert-deftest anvil-mcp-framing-test-frame-parse-utf8-byte-boundary ()
+  "A byte Content-Length stops before trailing data after a CJK body."
+  (let* ((body "{\"msg\":\"あ\"}")
+         (header (format "Content-Length: %d\r\n\r\n" (string-bytes body)))
+         (frame (concat header body "TAIL"))
+         (parsed (anvil-server-mcp-frame-parse-string frame)))
+    (should (equal body (plist-get parsed :body)))
+    (should (= (+ (string-bytes header) (string-bytes body))
+               (plist-get parsed :consumed)))))
 
 (ert-deftest anvil-mcp-framing-test-frame-parse-incomplete-header ()
   "Returns nil when CRLFCRLF separator not yet seen."
@@ -136,7 +157,7 @@
          (combined (concat frame1 frame2))
          (parsed (anvil-server-mcp-frame-parse-string combined)))
     (should (equal body (plist-get parsed :body)))
-    (should (= (length (encode-coding-string frame1 'utf-8 t))
+    (should (= (string-bytes frame1)
                (plist-get parsed :consumed)))
     ;; The remainder is exactly frame2.
     (let* ((rest (substring combined (plist-get parsed :consumed)))

--- a/tests/anvil-memory-test.el
+++ b/tests/anvil-memory-test.el
@@ -2114,6 +2114,54 @@ ROOT-VAR is the temp memory root.  Binds `port' (int) and `info'
     (should-error (anvil-memory-add "feedback_dup_rule" 'feedback "second"))))
 
 
+;;;; --- Phase 5: DB-direct update --------------------------------------
+
+(ert-deftest anvil-memory-test/update-replaces-body-and-fts ()
+  "memory-update swaps the body and the FTS row in one call."
+  (skip-unless (and (anvil-memory-test--supported-p 'update)
+                    (anvil-memory-test--supported-p 'add)
+                    (anvil-memory-test--supported-p 'search)))
+  (anvil-memory-test--with-env
+    (anvil-memory-add "feedback_upd_rule" 'feedback
+                      "old_keyword_alpha body")
+    (let ((res (anvil-memory-update "feedback_upd_rule"
+                                    :body "new_keyword_beta body")))
+      (should (equal '(:body) (plist-get res :updated)))
+      (should (stringp (plist-get res :digest))))
+    (should-not (anvil-memory-search "old_keyword_alpha"))
+    (let ((hits (anvil-memory-search "new_keyword_beta")))
+      (should hits))
+    (let ((entry (anvil-memory-get "feedback_upd_rule")))
+      (should (string-match-p "new_keyword_beta"
+                              (plist-get entry :body))))))
+
+(ert-deftest anvil-memory-test/update-meta-fields ()
+  "memory-update rewrites type / tags / ttl_policy independently."
+  (skip-unless (and (anvil-memory-test--supported-p 'update)
+                    (anvil-memory-test--supported-p 'add)))
+  (anvil-memory-test--with-env
+    (anvil-memory-add "feedback_upd_meta" 'feedback "body")
+    (let ((res (anvil-memory-update "feedback_upd_meta"
+                                    :type 'project
+                                    :tags '("a" "b"))))
+      (should (equal '(:type :tags) (plist-get res :updated))))
+    (let ((entry (anvil-memory-get "feedback_upd_meta")))
+      (should (eq 'project (plist-get entry :type)))
+      (should (equal "a,b" (plist-get entry :tags))))))
+
+(ert-deftest anvil-memory-test/update-rejects-bad-input ()
+  "memory-update signals on unknown names, scan rows, and no-op calls."
+  (skip-unless (and (anvil-memory-test--supported-p 'update)
+                    (anvil-memory-test--supported-p 'add)))
+  (anvil-memory-test--with-env
+    (anvil-memory-add "feedback_upd_guard" 'feedback "body")
+    (should-error (anvil-memory-update "feedback_upd_guard"))
+    (should-error (anvil-memory-update "feedback_no_such" :body "x"))
+    (should-error (anvil-memory-update "/abs/path/row.md" :body "x"))
+    (should-error (anvil-memory-update "feedback_upd_guard"
+                                       :type 'not-a-type))))
+
+
 ;;;; --- Phase 5: prune skips synthetic ---------------------------------
 
 (ert-deftest anvil-memory-test/prune-skips-synthetic-paths ()

--- a/tests/anvil-reader-escape-test.el
+++ b/tests/anvil-reader-escape-test.el
@@ -1,0 +1,84 @@
+;;; anvil-reader-escape-test.el --- Numeric reader escape regressions -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Guards numeric string escapes used by anvil sources with expectations
+;; built from integer character codes.  This prevents the source literal and
+;; its test fixture from failing in the same way if reader escape handling
+;; regresses.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'anvil-browser)
+(require 'anvil-claude-watchdog)
+(require 'anvil-fusion-verify)
+(require 'anvil-memory)
+(require 'anvil-semantic)
+(require 'anvil-wl-imap)
+(require 'anvil-wl-smtp)
+
+(ert-deftest anvil-reader-escape-test-browser-cache-key-nul-separators ()
+  "Browser cache keys contain NUL separators."
+  (let ((nul (char-to-string 0)))
+    (should
+     (equal (concat "url" nul "selector" nul "profile" nul "agent")
+            (anvil-browser--cache-key
+             "url" "selector" '(:profile "profile" :user-agent "agent"))))))
+
+(ert-deftest anvil-reader-escape-test-semantic-digest-nul-separators ()
+  "Semantic digests hash NUL-delimited fields."
+  (let ((nul (char-to-string 0)))
+    (should
+     (equal (secure-hash 'sha1 (concat "file" nul "head" nul "text"))
+            (anvil-semantic--digest "file" "head" "text")))))
+
+(ert-deftest anvil-reader-escape-test-fusion-cache-key-nul-separator ()
+  "Fusion cache keys hash claim text and kind with a NUL separator."
+  (let* ((claim '(:claim "claim text" :kind fact))
+         (expected
+          (secure-hash
+           'sha1 (concat "claim text" (char-to-string 0) "fact"))))
+    (should (equal expected (anvil-fusion-verify--cache-key claim)))))
+
+(ert-deftest anvil-reader-escape-test-memory-frontmatter-stops-at-nul ()
+  "Frontmatter scanning does not cross a NUL byte."
+  (let ((body (concat "---\nname: before"
+                      (char-to-string 0)
+                      "\n---\nbody\n")))
+    (should-not (anvil-memory--parse-frontmatter body))))
+
+(ert-deftest anvil-reader-escape-test-watchdog-cmdline-nul-separators ()
+  "Watchdog command lines replace procfs NUL separators with spaces."
+  (let ((nul (char-to-string 0)))
+    (cl-letf (((symbol-function 'anvil-claude-watchdog--read-file)
+               (lambda (_path) (concat "claude" nul "--flag" nul))))
+      (should (equal "claude --flag"
+                     (anvil-claude-watchdog--proc-cmdline 1))))))
+
+(ert-deftest anvil-reader-escape-test-imap-xoauth2-soh-separators ()
+  "IMAP XOAUTH2 payloads contain SOH separators."
+  (let* ((soh (char-to-string 1))
+         (decoded
+          (base64-decode-string
+           (anvil-wl-imap--xoauth2-initial-response "user" "token"))))
+    (should (equal (concat "user=user" soh "auth=Bearer token" soh soh)
+                   decoded))))
+
+(ert-deftest anvil-reader-escape-test-smtp-plain-nul-separators ()
+  "SMTP AUTH PLAIN payloads contain leading and embedded NULs."
+  (let (sent)
+    (cl-letf (((symbol-function 'anvil-wl-smtp--expect)
+               (lambda (_conn line _prefix)
+                 (setq sent line)
+                 t)))
+      (anvil-wl-smtp-login 'conn "user" "pass"))
+    (let* ((prefix "AUTH PLAIN ")
+           (payload (base64-decode-string (substring sent (length prefix))))
+           (nul (char-to-string 0)))
+      (should (string-prefix-p prefix sent))
+      (should (equal (concat nul "user" nul "pass") payload)))))
+
+(provide 'anvil-reader-escape-test)
+;;; anvil-reader-escape-test.el ends here

--- a/tests/anvil-shell-filter-test.el
+++ b/tests/anvil-shell-filter-test.el
@@ -674,7 +674,8 @@ Pipeline order under test:
      :tail-lines 5
      :max-lines 3
      :on-empty "EMPTY")
-    (let* ((raw (concat "\x1b[31mFOO line\x1b[0m\n"
+    (let* ((esc (char-to-string 27))
+           (raw (concat esc "[31mFOO line" esc "[0m\n"
                         "noise line drop\n"
                         "keep one\n"
                         "this is a very long keep line\n"
@@ -684,7 +685,7 @@ Pipeline order under test:
            (out (anvil-shell-filter-apply 'pipeline-order raw))
            (lines (split-string out "\n")))
       ;; strip-ansi + replace ran and were observable in the output.
-      (should-not (string-match-p "\x1b" out)) ; ANSI stripped
+      (should-not (string-match-p (regexp-quote esc) out)) ; ANSI stripped
       (should-not (string-match-p "FOO" out))  ; replaced FOO → FUU
       (should-not (string-match-p "noise" out)) ; strip-lines dropped it
       ;; truncate to 12 chars produced at least one trimmed line.
@@ -700,8 +701,9 @@ Pipeline order under test:
   (skip-unless (anvil-shell-filter-test--supported-p 'register))
   (anvil-shell-filter-test--with-clean-registry
     (anvil-shell-filter-register 'ansi-only :strip-ansi t)
-    (let ((out (anvil-shell-filter-apply
-                'ansi-only "\x1b[1;31merror:\x1b[0m bad")))
+    (let* ((esc (char-to-string 27))
+           (raw (concat esc "[1;31merror:" esc "[0m bad"))
+           (out (anvil-shell-filter-apply 'ansi-only raw)))
       (should (equal out "error: bad")))))
 
 (ert-deftest anvil-shell-filter-test/register-replace-multiple ()

--- a/tests/anvil-test.el
+++ b/tests/anvil-test.el
@@ -293,33 +293,21 @@ MCP Parameters:
             (should (equal "ok" text))))
       (remhash server-id anvil-server--tools))))
 
-(ert-deftest anvil-test-scan-int-after-tolerates-whitespace ()
-  "Standalone scanner must accept normal JSON whitespace before numbers."
-  (should (equal 42 (anvil-server--scan-int-after "{\"id\": 42,}" "\"id\":")))
-  (should (equal 42 (anvil-server--scan-int-after "{\"id\":42,}" "\"id\":")))
-  (should (equal 7 (anvil-server--scan-int-after "{\"id\":\t7 }" "\"id\":")))
-  (should (equal -3 (anvil-server--scan-int-after "{\"id\": -3 }" "\"id\":"))))
-
-(ert-deftest anvil-test-scan-string-after-tolerates-whitespace ()
-  "Standalone scanner must accept normal JSON whitespace before strings."
-  (should (equal "tools/list"
-                 (anvil-server--scan-string-after
-                  "{\"method\": \"tools/list\"}" "\"method\":")))
-  (should (equal "tools/list"
-                 (anvil-server--scan-string-after
-                  "{\"method\":\"tools/list\"}" "\"method\":")))
-  (should (equal "a\"b\\c"
-                 (anvil-server--scan-string-after
-                  "{\"name\": \"a\\\"b\\\\c\"}" "\"name\":"))))
-
-(ert-deftest anvil-test-scan-json-value-after-tolerates-string-id ()
-  "JSON-RPC ids may be strings as well as numbers."
-  (should (equal "abc"
-                 (anvil-server--scan-json-value-after
-                  "{\"id\": \"abc\"}" "\"id\":")))
-  (should (equal 17
-                 (anvil-server--scan-json-value-after
-                  "{\"id\": 17}" "\"id\":"))))
+(ert-deftest anvil-test-json-decode-preserves-cjk-params ()
+  "UTF-8 byte input decodes through the normal parser with full params."
+  (let* ((json (concat
+                "{\"jsonrpc\":\"2.0\",\"id\":1,"
+                "\"method\":\"tools/call\",\"params\":{"
+                "\"name\":\"demo\",\"arguments\":{\"text\":\"日本語\"}}}"))
+         (bytes (anvil-server--string-to-utf8-bytes json))
+         (decoded (anvil-server--utf8-bytes-to-string bytes))
+         (object (json-read-from-string decoded))
+         (params (alist-get 'params object))
+         (arguments (alist-get 'arguments params)))
+    (should-not (multibyte-string-p bytes))
+    (should (= (string-bytes json) (length bytes)))
+    (should (equal "demo" (alist-get 'name params)))
+    (should (equal "日本語" (alist-get 'text arguments)))))
 
 (ert-deftest anvil-test-dispatch-tolerates-stale-underscore-args ()
   "A client with a stale schema that still sends `_args' must not error.


### PR DESCRIPTION
Five commits against `develop`. The last two are this branch's point; the first
three had been sitting on it already.

## The fast handshake, and turning it on

`bin/anvil-runtime mcp serve` did not answer `initialize` until the whole module
load had finished -- about 100 seconds of a client waiting on a handshake that
needs six tool descriptors. The fast-handshake path answers from a cache first
and loads behind it.

It was written and then gated off, because every run on it died after 2-20 s:
SIGSEGV, or `nelisp: form aborted without signal (rc=1)`, decided by process
memory layout. That turned out to be fourteen precise-root defects in the
standalone NeLisp GC, not anything in this repository. They are fixed and
released as NeLisp v1.1.1 (zawatton/nelisp#8).

So the gate comes off. Measured end to end through `bin/anvil-runtime mcp serve`
with the bootstrap it generates:

| | before | after |
|---|---|---|
| time to first frame | ~100 s (the full module load) | **1.36 s** |
| response | 5,208 bytes, exit 0 | 5,208 bytes, exit 0 |

3/3 with `setarch -R` and 3/3 with address randomisation on.

The dependency on the runtime underneath is real -- an older NeLisp will crash
on this path -- so `ANVIL_RUNTIME_FAST_HANDSHAKE=0` turns it back off. Note the
env var only works through the generated bootstrap: reading it in
`anvil-runtime-shell-loop.el` would not work, because that `defvar` runs before
`emacs-callproc.el` provides `getenv`. The safety-gate comment there now records
the measurement instead of the old criterion.

## Provenance and verification

`8855efb` is work that was already uncommitted in the working tree; I did not
write it. Before committing it I checked it was safe to land rather than
assuming: `anvil-dev-test-run-all-batch` reports 2492/2593 with 37 failures, and
stashing the changes and re-running at HEAD gives 2481/2582 with the **same 37**.
So it adds 11 tests and no failures. The 37 are pre-existing and
environment-dependent (orchestrator, org-index, semantic, offload).

`ddb5881` -- the default flip and the comment -- is mine.

Two notes on running the suite here: `eask` is not installed, so `make test`
fails; `make test-all` needs `-Q`, because a site-init file (`50emacs-mozc`)
errors otherwise.
